### PR TITLE
S係数データおよびSEEデータの読み込みタイミングを改善し、計算処理を高速化する

### DIFF
--- a/FlexID.Calc/CalcOut.cs
+++ b/FlexID.Calc/CalcOut.cs
@@ -27,7 +27,7 @@ namespace FlexID.Calc
         }
 
         // 預託線量標的組織出力
-        public void CommitmentTarget(List<string> Target, DataClass data)
+        public void CommitmentTarget(string[] targets, DataClass data)
         {
             var nuclide = data.Nuclides[0];
 
@@ -41,10 +41,10 @@ namespace FlexID.Calc
             rCom.Write("     Time    ");
             rCom.Write("     WholeBody   ");
 
-            for (int i = 0; i < Target.Count; i++)
+            for (int i = 0; i < targets.Length; i++)
             {
-                dCom.Write("  {0,-12:n}", Target[i]);
-                rCom.Write("  {0,-12:n}", Target[i]);
+                dCom.Write("  {0,-12:n}", targets[i]);
+                rCom.Write("  {0,-12:n}", targets[i]);
             }
             dCom.WriteLine();
             dCom.Write("     [day]       ");
@@ -52,7 +52,7 @@ namespace FlexID.Calc
             rCom.WriteLine();
             rCom.Write("     [day]       ");
             rCom.Write("  [Sv/h]      ");
-            for (int i = 0; i < Target.Count; i++)
+            for (int i = 0; i < targets.Length; i++)
             {
                 dCom.Write("  [Sv/Bq]     ");
                 rCom.Write("  [Sv/h]      ");

--- a/FlexID.Calc/DataReader.cs
+++ b/FlexID.Calc/DataReader.cs
@@ -101,6 +101,16 @@ namespace FlexID.Calc
         /// 流入経路。
         /// </summary>
         public List<Inflow> Inflows;
+
+        /// <summary>
+        /// 線源領域の名称。
+        /// </summary>
+        public string SourceRegion;
+
+        /// <summary>
+        /// コンパートメントに対応付けられた線源領域から各標的組織へのS係数。
+        /// </summary>
+        public double[] S_Coefficients;
     }
 
     public class NuclideData
@@ -129,6 +139,16 @@ namespace FlexID.Calc
         /// 子孫核種の場合は<c>true</c>。
         /// </summary>
         public bool IsProgeny;
+
+        /// <summary>
+        /// S係数データにおける各線源領域の名称。
+        /// </summary>
+        public string[] SourceRegions;
+
+        /// <summary>
+        /// S係数データにおける各標的組織の名称。
+        /// </summary>
+        public string[] TargetTissues;
     }
 
     public class DataClass
@@ -137,6 +157,11 @@ namespace FlexID.Calc
         /// 全ての核種。
         /// </summary>
         public List<NuclideData> Nuclides = new List<NuclideData>();
+
+        /// <summary>
+        /// 核種毎のS係数データ表。
+        /// </summary>
+        public List<Dictionary<string, double[]>> SCoeffTables = new List<Dictionary<string, double[]>>();
 
         /// <summary>
         /// 全ての臓器。
@@ -200,7 +225,9 @@ namespace FlexID.Calc
                 };
                 data.Nuclides.Add(nuclide);
 
-                var sourceRegions = ReadSCoeff(nuclide);
+                // 核種に対応するS係数データを読み込む。
+                var tableSCoeff = ReadSCoeff(nuclide);
+                data.SCoeffTables.Add(tableSCoeff);
 
                 // 核種の体内動態モデル構成するコンパートメントの定義行を読み込む。
                 while (true)
@@ -252,11 +279,14 @@ namespace FlexID.Calc
                     if (sourceRegion != "-")
                     {
                         // コンパートメントに対応する線源領域がS係数データに存在することを確認する。
-                        if (!sourceRegions.Contains(sourceRegion))
+                        var indexS = Array.IndexOf(nuclide.SourceRegions, sourceRegion);
+                        if (indexS == -1)
                             throw Program.Error($"Line {num}: Unknown source region name: '{sourceRegion}'");
-                    }
 
-                    data.CorrNum[(nuclide.Nuclide, organ.Name)] = sourceRegion;
+                        // コンパートメントの放射能を各標的組織に振り分けるためのS係数データを関連付ける。
+                        organ.SourceRegion = sourceRegion;
+                        organ.S_Coefficients = tableSCoeff[sourceRegion];
+                    }
 
                     // コンパートメントへの流入経路の記述を読み込む。
                     if (organ.Func == OrganFunc.inp)
@@ -314,24 +344,69 @@ namespace FlexID.Calc
             return data;
         }
 
-        private static string[] ReadSCoeff(NuclideData nuclide)
+        /// <summary>
+        /// S係数データを読み込む。
+        /// </summary>
+        /// <param name="nuclide">対象核種。線源領域と標的組織の名称が設定される。</param>
+        /// <returns>キーが線源領域の名称、値が各標的組織に対する成人男女平均のS係数、となる辞書。</returns>
+        private static Dictionary<string, double[]> ReadSCoeff(NuclideData nuclide)
         {
             var nuc = nuclide.Nuclide;
             var prg = nuclide.IsProgeny ? "prg_" : "";
 
-            string[] sourceRegions;
+            var fileAM = $"{nuc}_AM_{prg}S-Coefficient.txt";
+            var fileAF = $"{nuc}_AF_{prg}S-Coefficient.txt";
+            using (var readerAM = new StreamReader(Path.Combine("lib", "OIR", fileAM)))
+            using (var readerAF = new StreamReader(Path.Combine("lib", "OIR", fileAF)))
             {
-                var linesAM = File.ReadLines(Path.Combine("lib", "OIR", $"{nuc}_AM_{prg}S-Coefficient.txt"));
-                var linesAF = File.ReadLines(Path.Combine("lib", "OIR", $"{nuc}_AF_{prg}S-Coefficient.txt"));
+                // 1行目から線源領域の名称を配列で取得。
+                var sourcesAM = readerAM.ReadLine()?.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries).Skip(1).ToArray();
+                var sourcesAF = readerAF.ReadLine()?.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries).Skip(1).ToArray();
+                if (sourcesAM is null) throw Program.Error($"Incorrect S-Coefficient file format: {fileAM}");
+                if (sourcesAF is null) throw Program.Error($"Incorrect S-Coefficient file format: {fileAF}");
 
-                var sourceAM = linesAM.First().Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                var sourceAF = linesAF.First().Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                if (!Enumerable.SequenceEqual(sourceAM, sourceAF))
+                if (!Enumerable.SequenceEqual(sourcesAM, sourcesAF))
                     throw Program.Error($"Found mismatch of source region names in S-Coefficient data for nuclide {nuc}.");
-                sourceRegions = sourceAM;
-            }
+                var sources = sourcesAM;
+                var sourcesCount = sources.Length;
 
-            return sourceRegions;
+                var targets = new string[43];
+
+                var table = sources.ToDictionary(s => s, s => new double[43]);
+
+                for (int indexT = 0; indexT < 43; indexT++)
+                {
+                    var valuesAM = readerAM.ReadLine()?.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                    var valuesAF = readerAF.ReadLine()?.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                    if (valuesAM?.Length != 1 + sourcesCount) throw Program.Error($"Incorrect S-Coefficient file format: {fileAM}");
+                    if (valuesAF?.Length != 1 + sourcesCount) throw Program.Error($"Incorrect S-Coefficient file format: {fileAF}");
+
+                    // 各行の1列目から標的組織の名称を取得。
+                    var targetAM = valuesAM[0];
+                    var targetAF = valuesAF[0];
+                    if (targetAM != targetAF)
+                        throw Program.Error($"Found mismatch of target tissue names in S-Coefficient data for nuclide {nuc}.");
+                    targets[indexT] = targetAM;
+
+                    for (int indexS = 0; indexS < sourcesCount; indexS++)
+                    {
+                        var sourceRegion = sources[indexS];
+
+                        // ここでS係数の男女平均を取る。
+                        var scoeffAM = double.Parse(valuesAM[1 + indexS]);
+                        var scoeffAF = double.Parse(valuesAF[1 + indexS]);
+                        var scoeff = (scoeffAM + scoeffAF) / 2;
+
+                        table[sourceRegion][indexT] = scoeff;
+                    }
+                }
+
+                // 核種の線源領域と標的組織の名称を設定する。
+                nuclide.SourceRegions = sources;
+                nuclide.TargetTissues = targets;
+
+                return table;
+            }
         }
 
         /// <summary>
@@ -520,16 +595,22 @@ namespace FlexID.Calc
         private static string[] ReadSee(NuclideData nuclide)
         {
             var nuc = nuclide.Nuclide;
+            var file = $"{nuc}SEE.txt";
 
             string[] sourceRegions;
 
+            using (var reader = new StreamReader(Path.Combine("lib", "EIR", file)))
             {
-                var linesSEE = File.ReadLines(Path.Combine("lib", "EIR", $"{nuc}SEE.txt"));
+                reader.ReadLine();
 
-                var sourceSEE = linesSEE.Skip(1).First().Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                // 2行目から線源領域の名称を配列で取得。
+                var sources = reader.ReadLine()?.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries).Skip(1).ToArray();
+                if (sources is null) throw Program.Error($"Incorrect S-Coefficient file format: {file}");
 
-                sourceRegions = sourceSEE;
+                sourceRegions = sources;
             }
+
+            nuclide.SourceRegions = sourceRegions;
 
             return sourceRegions;
         }

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
-using TextIO;
 
 namespace FlexID.Calc
 {
@@ -80,7 +78,7 @@ namespace FlexID.Calc
             var CumulativePath = OutputPath + "_Cumulative.out";
             var DosePath = OutputPath + "_Dose.out";
             var DoseRatePath = OutputPath + "_DoseRate.out";
-            var IterPath = OutputPath + "_IterLog.out";
+            //var IterPath = OutputPath + "_IterLog.out";
 
             Directory.CreateDirectory(Path.GetDirectoryName(RetentionPath));
 
@@ -97,8 +95,10 @@ namespace FlexID.Calc
 
             // テンポラリファイルを並び替えて出力
             CalcOut.ActivityOut(RetentionPath, CumulativePath, TmpFile, dataList[0]);
+
             // Iter出力
             //CalcOut.IterOut(CalcTimeMesh, iterLog, IterPath);
+
             File.Delete(TmpFile);
         }
 
@@ -152,6 +152,117 @@ namespace FlexID.Calc
                 }
             }
 
+            DataClass dataLoInterp = null;  // 年齢区間の切り替わり検出用。
+            double[][] sourcesSee = null;
+            double[][] organsSee = null;
+
+            // S係数の補間のための領域を確保する。
+            void InterpolationAlloc()
+            {
+                if (dataLo == dataLoInterp)
+                    return;
+                dataLoInterp = dataLo;
+
+                // 実際の所、EIRでは全ての年齢区間で線源領域は同じのはずで、
+                // また体内動態モデルを定義するコンパートメント群も同じになるようだが
+                // 現状のデータの持ち方としてこれらが年齢区間毎に異なり得ると想定している。
+                Array.Resize(ref sourcesSee, dataLo.Nuclides.Select(n => n.SourceRegions.Length).Sum());
+                Array.Resize(ref organsSee, dataLo.Organs.Count);
+
+                int offsetS = 0;
+                foreach (var nuclide in dataLo.Nuclides)
+                {
+                    var sourcesCount = nuclide.SourceRegions.Length;
+
+                    for (int indexS = 0; indexS < sourcesCount; indexS++)
+                    {
+                        // ある核種における線源領域の1つ。
+                        var sourceRegion = nuclide.SourceRegions[indexS];
+
+                        // 各標的組織への補間されたS係数値が書き込まれる配列を確保(または再利用)する。
+                        var see = sourcesSee[offsetS + indexS];
+                        see = see ?? (sourcesSee[offsetS + indexS] = new double[31]);
+
+                        // 線源領域に対応する全てのコンパートメントに、
+                        // 補間されたS係数値が書き込まれる予定の配列を割り当てる。
+                        foreach (var organ in dataLo.Organs
+                            .Where(o => o.Nuclide == nuclide && o.SourceRegion == sourceRegion))
+                        {
+                            organsSee[organ.Index] = see;
+                        }
+                    }
+
+                    offsetS += sourcesCount;
+                }
+            }
+
+            // S係数の補間をやめて、コンパートメント毎に設定されたS係数を使用するよう切り替える。
+            void InterporationReset()
+            {
+                if (dataLo == dataLoInterp && sourcesSee is null)
+                    return;
+                dataLoInterp = dataLo;
+
+                sourcesSee = null;
+                Array.Resize(ref organsSee, dataLo.Organs.Count);
+
+                foreach (var organ in dataLo.Organs)
+                {
+                    organsSee[organ.Index] = organ.S_Coefficients;
+                }
+            }
+
+            // 指定の計算時間メッシュにおけるS係数の補間計算を実施する。
+            void InterpopationCalc(double nowT)
+            {
+                if (nowT < 6205)
+                {
+                    // 17歳未満の被ばく期間では、SEEデータを補間する。
+                    InterpolationAlloc();
+
+                    int offsetS = 0;
+                    foreach (var nuclide in dataLo.Nuclides)
+                    {
+                        var sourcesCount = nuclide.SourceRegions.Length;
+
+                        int indexN = dataLo.Nuclides.IndexOf(nuclide);
+                        var tableLo = dataLo.SCoeffTables[indexN];
+                        var tableHi = dataHi.SCoeffTables[indexN];
+
+                        for (int indexS = 0; indexS < sourcesCount; indexS++)
+                        {
+                            // ある核種における線源領域の1つ。
+                            var sourceRegion = nuclide.SourceRegions[indexS];
+
+                            // 各標的組織への補間されたS係数値を書き込むための配列を取得する。
+                            var see = sourcesSee[offsetS + indexS];
+
+                            var seeLo = tableLo[sourceRegion];
+                            var seeHi = tableHi[sourceRegion];
+                            for (int indexT = 0; indexT < 31; indexT++)
+                            {
+                                var scoeffLo = seeLo[indexT];
+                                var scoeffHi = seeHi[indexT];
+                                var scoeff = SubRoutine.Interpolation(nowT, scoeffLo, scoeffHi, dataLo.StartAge, dataHi.StartAge);
+                                see[indexT] = scoeff;
+                            }
+                        }
+                        offsetS += sourcesCount;
+                    }
+                }
+                else
+                {
+                    InterporationReset();
+                }
+            }
+
+            // 標的組織の名称リストを(親核種のS係数データから)取得。
+            var targetTissues = dataList[0].Nuclides[0].TargetTissues;
+            var targetWeights = targetTissues.Select(t => wT[t]).ToArray();
+
+            // 標的組織の名称をヘッダーとして出力。
+            CalcOut.CommitmentTarget(targetTissues.ToList(), dataList[0]);
+
             // 経過時間=0での計算結果を処理する
             int ctime = 0;  // 計算時間メッシュのインデックス
             int otime = 0;  // 出力時間メッシュのインデックス
@@ -198,11 +309,8 @@ namespace FlexID.Calc
             }
             ClearOutMeshTotal();    // 各臓器の積算放射能として0を設定する
 
-            var flgTarget = true;   // 預託線量ヘッダー出力用フラグ
-
             ctime = 1;
             otime = 1;
-
             for (; ctime < CalcTimeMesh.Count; ctime++)
             {
                 // 不要な前ステップのデータを削除
@@ -211,55 +319,43 @@ namespace FlexID.Calc
                 var calcPreT = CalcTimeMesh[ctime - 1];
                 var calcNowT = CalcTimeMesh[ctime - 0];
 
-                int daysLo;
-                int daysHi;
+                // 預託期間を超える計算は行わない
+                if (calcNowT > commitmentDays)
+                    break;
+
                 // 生まれてからの日数によってLoとHiを変える
                 if (calcNowT + ExposureDays <= year1)
                 {
                     dataLo = dataList[0];
                     dataHi = dataList[1];
-                    daysLo = month3;
-                    daysHi = year1;
                 }
                 else if (calcNowT + ExposureDays <= year5)
                 {
                     dataLo = dataList[1];
                     dataHi = dataList[2];
-                    daysLo = year1;
-                    daysHi = year5;
                 }
                 else if (calcNowT + ExposureDays <= year10)
                 {
                     dataLo = dataList[2];
                     dataHi = dataList[3];
-                    daysLo = year5;
-                    daysHi = year10;
                 }
                 else if (calcNowT + ExposureDays <= year15)
                 {
                     dataLo = dataList[3];
                     dataHi = dataList[4];
-                    daysLo = year10;
-                    daysHi = year15;
                 }
                 else if (calcNowT + ExposureDays <= adult)
                 {
                     dataLo = dataList[4];
                     dataHi = dataList[5];
-                    daysLo = year15;
-                    daysHi = adult;
                 }
                 else
                 {
                     dataLo = dataList[5];
                     dataHi = dataList[5];
-                    daysLo = adult;
-                    daysHi = adult;
                 }
-
-                // 預託期間を超える計算は行わない
-                if (calcNowT > commitmentDays)
-                    break;
+                int daysLo = dataLo.StartAge;
+                int daysHi = dataHi.StartAge;
 
                 #region 1つの計算時間メッシュ内で収束計算を繰り返す
                 for (int iter = 1; iter <= iterMax; iter++)
@@ -348,134 +444,46 @@ namespace FlexID.Calc
                 if (OutTimeMesh.Count <= otime)
                     break;
 
-                // S-Coefficient読込
-                var SEE = new Dictionary<string, string[]>();
-                for (int i = 0; i < dataLo.Nuclides.Count; i++)
-                {
-                    var nuc = dataLo.Nuclides[i].Nuclide;
-                    SEE[nuc] = File.ReadAllLines("lib\\EIR\\" + nuc + "SEE.txt");
-                }
+                // S係数の補間計算を実施する。
+                InterpopationCalc(calcNowT + ExposureDays);
 
                 // ΔT[sec]
                 var deltaT = (calcNowT - calcPreT) * 24 * 3600;
 
-                var TargetList = new List<string>();
-
-                var nucId = ""; // 現在対象としている核種
-                NuclideData nuclide = null;
-                var _see = new List<string>();
-                string line = "";
-                int oCount = 0;
-                List<string> SEElo = new List<string>();
-                List<string> SEEhi = new List<string>();
-                string[] S_lo;
-                string[] S_hi;
-                int S_count = 0;
-                string[] source = new string[0];
-
-                while (true)
+                foreach (var organ in dataLo.Organs)
                 {
-                    double total = 0;
-                    bool flgScoe = true;
+                    if (organ.Name.Contains("mix"))
+                        continue;
 
-                    foreach (var organ in dataLo.Organs)
+                    var nuclide = organ.Nuclide;
+                    var nucDecay = nuclide.Ramd;
+
+                    // タイムステップごとの放射能　
+                    var activity = Act.Now[organ.Index].end * deltaT * nucDecay;
+                    if (activity == 0)
+                        continue;
+
+                    if (organ.SourceRegion != null)
                     {
-                        if (organ.Name.Contains("mix"))
-                            continue;
-
-                        if (flgScoe)
+                        // コンパートメントから各標的組織への預託線量を計算する。
+                        for (int indexT = 0; indexT < 31; indexT++)
                         {
-                            nuclide = organ.Nuclide;
-                            nucId = nuclide.Nuclide;
-                            var lines = SEE[nucId].ToArray();
-                            source = lines[1].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                            // 標的組織の部分的な重量。
+                            var targetWeight = targetWeights[indexT];
 
-                            _see = new List<string>();
-                            (SEElo, SEEhi) = SEE_select(SEE[nucId], calcNowT, ExposureDays);
-                            S_lo = SEElo[S_count].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                            S_hi = SEEhi[S_count].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                            _see.Add(S_lo[0]);
-                            if (calcNowT + ExposureDays < 6205)
-                            {
-                                for (int i = 1; i < S_lo.Length; i++)
-                                {
-                                    _see.Add(Interpolation(calcNowT + ExposureDays, double.Parse(S_lo[i]), double.Parse(S_hi[i]), daysLo, daysHi).ToString());
-                                }
-                            }
-                            else
-                            {
-                                for (int i = 1; i < S_lo.Length; i++)
-                                {
-                                    _see.Add(S_lo[i]);
-                                }
-                            }
+                            // S係数(補間あり)。
+                            var scoeff = organsSee[organ.Index][indexT];
 
-                            if (line == null)
-                                break;
+                            // 等価線量 = 放射能 * S係数
+                            var equivalentDose = activity * scoeff;
 
-                            TargetList.Add(_see[0]);
-                            flgScoe = false;
+                            // 実効線量 = 等価線量 * wT
+                            var effectiveDose = equivalentDose * targetWeight;
+
+                            Result[indexT] += equivalentDose;
+                            WholeBody += effectiveDose;
                         }
-
-                        // 対象としてる核種が変わったら見るS係数ファイルを変える
-                        if (nuclide != organ.Nuclide)
-                        {
-                            nuclide = organ.Nuclide;
-                            nucId = nuclide.Nuclide;
-                            var lines = SEE[nucId].ToArray();
-                            source = lines[1].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-
-                            _see = new List<string>();
-                            (SEElo, SEEhi) = SEE_select(SEE[nucId], calcNowT, ExposureDays);
-                            S_lo = SEElo[S_count].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                            S_hi = SEEhi[S_count].Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                            _see.Add(S_lo[0]);
-                            if (calcNowT + ExposureDays < 6205)
-                            {
-                                for (int i = 1; i < S_lo.Length; i++)
-                                {
-                                    _see.Add(Interpolation(calcNowT + ExposureDays, double.Parse(S_lo[i]), double.Parse(S_hi[i]), daysLo, daysHi).ToString());
-                                }
-                            }
-                            else
-                            {
-                                for (int i = 1; i < S_lo.Length; i++)
-                                {
-                                    _see.Add(S_lo[i]);
-                                }
-                            }
-                        }
-
-                        var nucDecay = nuclide.Ramd;
-
-                        // タイムステップごとの放射能　
-                        var Act = this.Act.Now[organ.Index].end * deltaT * nucDecay;
-                        if (Act == 0)
-                            continue;
-
-                        // 放射能*S係数
-                        int index = Array.IndexOf(source, dataLo.CorrNum[(organ.Nuclide.Nuclide, organ.Name)]);
-                        if (index > 0) // indexが1より下は組織と対応するS係数無し
-                            total += Act * double.Parse(_see[index]);
                     }
-
-                    if (line == null)
-                        break;
-
-                    Result[oCount] += total;
-                    WholeBody += total * wT[_see[0]];  // 実効線量 = 男性等価線量*wT
-                    oCount++;
-                    S_count++;
-
-                    if (S_count >= SEElo.Count)
-                        break;
-                }
-
-                // 初回のみヘッダーの標的組織出力
-                if (flgTarget)
-                {
-                    CalcOut.CommitmentTarget(TargetList, dataLo);
-                    flgTarget = false;
                 }
 
                 if (calcNowT == OutTimeMesh[otime])
@@ -512,53 +520,6 @@ namespace FlexID.Calc
                     otime++;
                 }
             }
-        }
-
-        public static double Interpolation(double day, double valueLo, double valueHi, int daysLo, int daysHi)
-        {
-            double value;
-            value = valueLo + (day - daysLo) * (valueHi - valueLo) / (daysHi - daysLo);
-            return value;
-        }
-
-        private (List<string>, List<string>) SEE_select(string[] data, double calcNowT, int ExposureDays)
-        {
-            List<string> dataLo = new List<string>();
-            List<string> dataHi = new List<string>();
-
-            List<string> Data = new List<string>(data);
-
-            if (calcNowT + ExposureDays <= year1)
-            {
-                dataLo = DataClass.Read_See(Data, "Age:3month");
-                dataHi = DataClass.Read_See(Data, "Age:1year");
-            }
-            else if (calcNowT + ExposureDays <= year5)
-            {
-                dataLo = DataClass.Read_See(Data, "Age:1year");
-                dataHi = DataClass.Read_See(Data, "Age:5year");
-            }
-            else if (calcNowT + ExposureDays <= year10)
-            {
-                dataLo = DataClass.Read_See(Data, "Age:5year");
-                dataHi = DataClass.Read_See(Data, "Age:10year");
-            }
-            else if (calcNowT + ExposureDays <= year15)
-            {
-                dataLo = DataClass.Read_See(Data, "Age:10year");
-                dataHi = DataClass.Read_See(Data, "Age:15year");
-            }
-            else if (calcNowT + ExposureDays <= adult)
-            {
-                dataLo = DataClass.Read_See(Data, "Age:15year");
-                dataHi = DataClass.Read_See(Data, "Age:adult");
-            }
-            else
-            {
-                dataLo = DataClass.Read_See(Data, "Age:adult");
-                dataHi = DataClass.Read_See(Data, "Age:adult");
-            }
-            return (dataLo, dataHi);
         }
     }
 }

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -261,7 +261,7 @@ namespace FlexID.Calc
             var targetWeights = targetTissues.Select(t => wT[t]).ToArray();
 
             // 標的組織の名称をヘッダーとして出力。
-            CalcOut.CommitmentTarget(targetTissues.ToList(), dataList[0]);
+            CalcOut.CommitmentTarget(targetTissues, dataList[0]);
 
             // 経過時間=0での計算結果を処理する
             int ctime = 0;  // 計算時間メッシュのインデックス

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -117,7 +117,7 @@ namespace FlexID.Calc
             var targetWeights = targetTissues.Select(t => wT[t]).ToArray();
 
             // 標的組織の名称をヘッダーとして出力。
-            CalcOut.CommitmentTarget(targetTissues.ToList(), data);
+            CalcOut.CommitmentTarget(targetTissues, data);
 
             // 経過時間=0での計算結果を処理する
             int ctime = 0;  // 計算時間メッシュのインデックス

--- a/FlexID.Calc/SubRoutine.cs
+++ b/FlexID.Calc/SubRoutine.cs
@@ -226,34 +226,34 @@ namespace FlexID.Calc
         public static void Accumulation_EIR(double dT, Organ organLo, Organ organHi, Activity Act, double day, int daysLo, int daysHi)
         {
             // alpha = 核種の崩壊定数 + 当該臓器の生物学的崩壊定数
-            double alpha;
-            alpha = organLo.BioDecay;
+            double alpha = organLo.BioDecay;
+
             #region 流入臓器の数ループ
             double ave = 0.0;
             for (int i = 0; i < organLo.Inflows.Count; i++)
             {
                 // 丸め誤差が出るので、Roundするか否か
-                var InflowLo = Math.Round(organLo.Inflows[i].Organ.BioDecay * organLo.Inflows[i].Rate, 6);
-                var InflowHi = Math.Round(organHi.Inflows[i].Organ.BioDecay * organHi.Inflows[i].Rate, 6);
+                var inflowLo = Math.Round(organLo.Inflows[i].Organ.BioDecay * organLo.Inflows[i].Rate, 6);
+                var inflowHi = Math.Round(organHi.Inflows[i].Organ.BioDecay * organHi.Inflows[i].Rate, 6);
 
-                double beforeBio;
                 // 流入元生物学的崩壊定数
+                double beforeBio;
                 if (day <= MainRoutine_EIR.adult)
                 {
                     if (organLo.Name == "Plasma" && organLo.Inflows[i].Organ.Name == "SI")
                     {
                         beforeBio = organLo.Inflows[i].Organ.BioDecay * organLo.Inflows[i].Rate;
-                        alpha = MainRoutine_EIR.Interpolation(day, organLo.BioDecay, organHi.BioDecay, daysLo, daysHi);
+                        alpha = Interpolation(day, organLo.BioDecay, organHi.BioDecay, daysLo, daysHi);
                     }
                     else if (organLo.Name == "SI")
                     {
-                        beforeBio = MainRoutine_EIR.Interpolation(day, InflowLo, InflowHi, daysLo, daysHi);
+                        beforeBio = Interpolation(day, inflowLo, inflowHi, daysLo, daysHi);
                         alpha = organLo.BioDecay;
                     }
                     else
                     {
-                        beforeBio = MainRoutine_EIR.Interpolation(day, InflowLo, InflowHi, daysLo, daysHi);
-                        alpha = MainRoutine_EIR.Interpolation(day, organLo.BioDecay, organHi.BioDecay, daysLo, daysHi);
+                        beforeBio = Interpolation(day, inflowLo, inflowHi, daysLo, daysHi);
+                        alpha = Interpolation(day, organLo.BioDecay, organHi.BioDecay, daysLo, daysHi);
                     }
                 }
                 else
@@ -308,6 +308,13 @@ namespace FlexID.Calc
                 Act.rNow[organLo.Index].end = 0;
             if (Act.rNow[organLo.Index].total <= 1e-60)
                 Act.rNow[organLo.Index].total = 0;
+        }
+
+        public static double Interpolation(double day, double valueLo, double valueHi, int daysLo, int daysHi)
+        {
+            double value;
+            value = valueLo + (day - daysLo) * (valueHi - valueLo) / (daysHi - daysLo);
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
これまでは計算処理中に同じS係数データやSEEデータを何度も読み込んでおり、このファイルIO処理のため計算時間が増大していた。インプットの読み込み直後にこれらのデータを1度だけ読み込むことでこれを改善する。