### PR TITLE
計算処理が途中終了した場合の挙動を修正

### DIFF
--- a/FlexID.Calc/CalcOut.cs
+++ b/FlexID.Calc/CalcOut.cs
@@ -59,6 +59,12 @@ namespace FlexID.Calc
                 for (int n = 1; n < data.Nuclides.Count; n++)
                 {
                     var path = basePath + $".{n}";
+
+                    // 前回実行時の一時ファイルが残ってしまった場合を想定して、
+                    // 同名のファイルが存在する場合はこの隠し属性を外しておく。
+                    if (File.Exists(path))
+                        File.SetAttributes(path, File.GetAttributes(path) & ~FileAttributes.Hidden);
+
                     var writer = new StreamWriter(path, false, Encoding.UTF8);
 
                     // 隠しファイル属性を設定しておく。

--- a/FlexID.Calc/CalcOut.cs
+++ b/FlexID.Calc/CalcOut.cs
@@ -30,6 +30,16 @@ namespace FlexID.Calc
         private StreamWriter[] wsOrgansRete;
         private StreamWriter[] wsOrgansCumu;
 
+        /// <summary>
+        /// 計算処理が正常に終了した場合に<c>true</c>を設定する。
+        /// </summary>
+        private bool IsFinished = false;
+
+        /// <summary>
+        /// コンストラクタ。
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="outputPath"></param>
         public CalcOut(DataClass data, string outputPath)
         {
             this.data = data;
@@ -232,8 +242,28 @@ namespace FlexID.Calc
             wRate.WriteLine();
         }
 
+        /// <summary>
+        /// 計算完了時のメッセージを出力する。
+        /// </summary>
+        public void FinishOut()
+        {
+            // 現在はメッセージ出力は存在せず、終了フラグを設定するだけとなっている。
+            IsFinished = true;
+        }
+
         public void Dispose()
         {
+            if (!IsFinished)
+            {
+                // 計算が未完了の場合は、中断メッセージを出力する。
+                const string message = "[Abort Calculation]";
+
+                wDose.WriteLine(message);
+                wRate.WriteLine(message);
+                foreach (var w in wsRete) w.WriteLine(message);
+                foreach (var w in wsCumu) w.WriteLine(message);
+            }
+
             wDose.Dispose();
             wRate.Dispose();
             foreach (var w in wsRete) w.Dispose();

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -462,6 +462,9 @@ namespace FlexID.Calc
                     Array.Copy(Result, preResult, Result.Length);
                 }
             }
+
+            // 計算完了の出力を行う。
+            CalcOut.FinishOut();
         }
     }
 }

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -278,6 +278,9 @@ namespace FlexID.Calc
                     Array.Copy(Result, preResult, Result.Length);
                 }
             }
+
+            // 計算完了の出力を行う。
+            CalcOut.FinishOut();
         }
     }
 }


### PR DESCRIPTION
単体テストを途中で止めた際の挙動に問題があったため、これを修正した。

