### PR TITLE
残留放射能の計算に関わる数値の持ち方を整理

### DIFF
--- a/FlexID.Calc/CalcOut.cs
+++ b/FlexID.Calc/CalcOut.cs
@@ -205,7 +205,7 @@ namespace FlexID.Calc
                 //var organId = organ.ID;
                 var end = Act.CalcNow[organ.Index].end * nucDecay;
                 //var total = Act.OutTotalNow[organ.Index] * nucDecay;
-                var cumulative = Act.IntakeQuantityNow[organ.Index] * nucDecay;
+                var cumulative = Act.OutTotalFromIntake[organ.Index] * nucDecay;
 
                 var wrRete = wsOrgansRete[organ.Index];
                 var wrCumu = wsOrgansCumu[organ.Index];

--- a/FlexID.Calc/CalcOut.cs
+++ b/FlexID.Calc/CalcOut.cs
@@ -202,14 +202,15 @@ namespace FlexID.Calc
             {
                 var nucDecay = organ.NuclideDecay;
 
-                //var organId = organ.ID;
-                var end = Act.CalcNow[organ.Index].end * nucDecay;
-                //var total = Act.OutTotalNow[organ.Index] * nucDecay;
+                var retention = organ.Func == OrganFunc.exc
+                    ? Act.OutNow[organ.Index].ave * nucDecay    // TODO: for ICRP OIR data compatibility?
+                    : Act.OutNow[organ.Index].end * nucDecay;
+
                 var cumulative = Act.OutTotalFromIntake[organ.Index] * nucDecay;
 
                 var wrRete = wsOrgansRete[organ.Index];
                 var wrCumu = wsOrgansCumu[organ.Index];
-                wrRete.Write("  {0:0.00000000E+00}", end);
+                wrRete.Write("  {0:0.00000000E+00}", retention);
                 wrCumu.Write("  {0:0.00000000E+00}", cumulative);
             }
 

--- a/FlexID.Calc/Common.cs
+++ b/FlexID.Calc/Common.cs
@@ -49,9 +49,9 @@ namespace FlexID.Calc
         public OrganActivity[] CalcNow;
 
         /// <summary>
-        /// 今回の出力時間メッシュにおける、コンパートメント毎の積算放射能。
+        /// 今回の出力時間メッシュにおける、コンパートメント毎の放射能。
         /// </summary>
-        public double[] OutTotalNow;
+        public OrganActivity[] OutNow;
 
         /// <summary>
         /// 摂取時からの、コンパートメント毎の積算放射能[Bq]。
@@ -98,9 +98,13 @@ namespace FlexID.Calc
         /// <param name="data"></param>
         public void NextOut(DataClass data)
         {
-            foreach (var organ in data.Organs)
+            foreach (var o in data.Organs)
             {
-                OutTotalNow[organ.Index] = 0;
+                // 前回の末期放射能を今回の初期放射能とする。
+                OutNow[o.Index].ini = OutNow[o.Index].end;
+                OutNow[o.Index].ave = 0;
+                OutNow[o.Index].end = 0;
+                OutNow[o.Index].total = 0;
             }
         }
 

--- a/FlexID.Calc/Common.cs
+++ b/FlexID.Calc/Common.cs
@@ -59,9 +59,6 @@ namespace FlexID.Calc
         // 1つ前の時間メッシュにおける、摂取時からの積算放射能
         public double[] IntakeQuantityNow;
 
-        public double[] Excreta;
-        public double[] PreExcreta;
-
         /// <summary>
         /// 次の計算時間メッシュのための準備を行う。
         /// </summary>
@@ -96,7 +93,6 @@ namespace FlexID.Calc
                 IterNow[o.Index].ave = 0;
                 IterNow[o.Index].end = 0;
                 IterNow[o.Index].total = 0;
-                PreExcreta[o.Index] = 0;
             }
         }
 
@@ -109,7 +105,6 @@ namespace FlexID.Calc
             foreach (var organ in data.Organs)
             {
                 OutTotalNow[organ.Index] = 0;
-                Excreta[organ.Index] = 0;
             }
         }
 

--- a/FlexID.Calc/Common.cs
+++ b/FlexID.Calc/Common.cs
@@ -53,11 +53,10 @@ namespace FlexID.Calc
         /// </summary>
         public double[] OutTotalNow;
 
-        // 1つ前の時間メッシュにおける、摂取時からの積算放射能
-        public double[] IntakeQuantityPre;
-
-        // 1つ前の時間メッシュにおける、摂取時からの積算放射能
-        public double[] IntakeQuantityNow;
+        /// <summary>
+        /// 摂取時からの、コンパートメント毎の積算放射能[Bq]。
+        /// </summary>
+        public double[] OutTotalFromIntake;
 
         /// <summary>
         /// 次の計算時間メッシュのための準備を行う。
@@ -67,15 +66,12 @@ namespace FlexID.Calc
         {
             Swap(ref CalcPre, ref CalcNow);
 
-            Swap(ref IntakeQuantityPre, ref IntakeQuantityNow);
-
             foreach (var o in data.Organs)
             {
                 CalcNow[o.Index].ini = 0;
                 CalcNow[o.Index].ave = 0;
                 CalcNow[o.Index].end = 0;
                 CalcNow[o.Index].total = 0;
-                IntakeQuantityNow[o.Index] = 0;
             }
         }
 

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -326,10 +326,6 @@ namespace FlexID.Calc
                         Act.CalcNow[organLo.Index].end = Act.IterNow[organLo.Index].end;
 
                         Act.CalcNow[organLo.Index].total = Act.IterNow[organLo.Index].total;
-
-                        // 臓器毎の積算放射能算出
-                        Act.IntakeQuantityNow[organLo.Index] =
-                            Act.IntakeQuantityPre[organLo.Index] + Act.CalcNow[organLo.Index].total;
                     }
 
                     // 前回との差が収束するまで計算を繰り返す
@@ -372,6 +368,9 @@ namespace FlexID.Calc
                 {
                     // 今回の出力時間メッシュにおける積算放射能。
                     Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
+
+                    // 摂取時からの積算放射能。
+                    Act.OutTotalFromIntake[organ.Index] += Act.CalcNow[organ.Index].total;
                 }
 
                 // S係数の補間計算を実施する。
@@ -426,7 +425,7 @@ namespace FlexID.Calc
                         {
                             Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
 
-                            Act.IntakeQuantityNow[organ.Index] = 0; // TODO: for compatibility
+                            Act.OutTotalFromIntake[organ.Index] = 0; // TODO: for compatibility
                         }
                     }
 

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -370,8 +370,8 @@ namespace FlexID.Calc
                 // 時間メッシュ毎の放射能を足していく
                 foreach (var organ in dataLo.Organs)
                 {
+                    // 今回の出力時間メッシュにおける積算放射能。
                     Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
-                    Act.Excreta[organ.Index] += Act.PreExcreta[organ.Index];
                 }
 
                 // S係数の補間計算を実施する。
@@ -423,7 +423,11 @@ namespace FlexID.Calc
                     foreach (var organ in dataLo.Organs)
                     {
                         if (organ.Func == OrganFunc.exc)
-                            Act.CalcNow[organ.Index].end = Act.Excreta[organ.Index] / outDeltaDay;
+                        {
+                            Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
+
+                            Act.IntakeQuantityNow[organ.Index] = 0; // TODO: for compatibility
+                        }
                     }
 
                     // 放射能をファイルに出力する。

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -367,7 +367,7 @@ namespace FlexID.Calc
                 foreach (var organ in dataLo.Organs)
                 {
                     // 今回の出力時間メッシュにおける積算放射能。
-                    Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
+                    Act.OutNow[organ.Index].total += Act.CalcNow[organ.Index].total;
 
                     // 摂取時からの積算放射能。
                     Act.OutTotalFromIntake[organ.Index] += Act.CalcNow[organ.Index].total;
@@ -419,12 +419,15 @@ namespace FlexID.Calc
                     var outNowDay = TimeMesh.SecondsToDays(outNowT);
                     var outPreDay = TimeMesh.SecondsToDays(outPreT);
                     var outDeltaDay = TimeMesh.SecondsToDays(outDeltaT);
+
+                    // 出力時間メッシュにおける平均と末期の残留放射能を計算する。
                     foreach (var organ in dataLo.Organs)
                     {
+                        Act.OutNow[organ.Index].ave = Act.OutNow[organ.Index].total / outDeltaDay;
+                        Act.OutNow[organ.Index].end = Act.CalcNow[organ.Index].end;
+
                         if (organ.Func == OrganFunc.exc)
                         {
-                            Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
-
                             Act.OutTotalFromIntake[organ.Index] = 0; // TODO: for compatibility
                         }
                     }

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -145,10 +145,6 @@ namespace FlexID.Calc
                         Act.CalcNow[organ.Index].end = Act.IterNow[organ.Index].end;
 
                         Act.CalcNow[organ.Index].total = Act.IterNow[organ.Index].total;
-
-                        // 臓器毎の積算放射能算出
-                        Act.IntakeQuantityNow[organ.Index] =
-                            Act.IntakeQuantityPre[organ.Index] + Act.CalcNow[organ.Index].total;
                     }
 
                     // 前回との差が収束するまで計算を繰り返す
@@ -191,6 +187,9 @@ namespace FlexID.Calc
                 {
                     // 今回の出力時間メッシュにおける積算放射能。
                     Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
+
+                    // 摂取時からの積算放射能。
+                    Act.OutTotalFromIntake[organ.Index] += Act.CalcNow[organ.Index].total;
                 }
 
                 foreach (var organ in data.Organs)
@@ -242,7 +241,7 @@ namespace FlexID.Calc
                         {
                             Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
 
-                            Act.IntakeQuantityNow[organ.Index] = 0; // TODO: for compatibility
+                            Act.OutTotalFromIntake[organ.Index] = 0; // TODO: for compatibility
                         }
                     }
 

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -189,8 +189,8 @@ namespace FlexID.Calc
                 // 時間メッシュ毎の放射能を足していく
                 foreach (var organ in data.Organs)
                 {
+                    // 今回の出力時間メッシュにおける積算放射能。
                     Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
-                    Act.Excreta[organ.Index] += Act.PreExcreta[organ.Index];
                 }
 
                 foreach (var organ in data.Organs)
@@ -239,7 +239,11 @@ namespace FlexID.Calc
                     foreach (var organ in data.Organs)
                     {
                         if (organ.Func == OrganFunc.exc)
-                            Act.CalcNow[organ.Index].end = Act.Excreta[organ.Index] / outDeltaDay;
+                        {
+                            Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
+
+                            Act.IntakeQuantityNow[organ.Index] = 0; // TODO: for compatibility
+                        }
                     }
 
                     // 放射能をファイルに出力する。

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -186,7 +186,7 @@ namespace FlexID.Calc
                 foreach (var organ in data.Organs)
                 {
                     // 今回の出力時間メッシュにおける積算放射能。
-                    Act.OutTotalNow[organ.Index] += Act.CalcNow[organ.Index].total;
+                    Act.OutNow[organ.Index].total += Act.CalcNow[organ.Index].total;
 
                     // 摂取時からの積算放射能。
                     Act.OutTotalFromIntake[organ.Index] += Act.CalcNow[organ.Index].total;
@@ -235,12 +235,15 @@ namespace FlexID.Calc
                     var outNowDay = TimeMesh.SecondsToDays(outNowT);
                     var outPreDay = TimeMesh.SecondsToDays(outPreT);
                     var outDeltaDay = TimeMesh.SecondsToDays(outDeltaT);
+
+                    // 出力時間メッシュにおける平均と末期の残留放射能を計算する。
                     foreach (var organ in data.Organs)
                     {
+                        Act.OutNow[organ.Index].ave = Act.OutNow[organ.Index].total / outDeltaDay;
+                        Act.OutNow[organ.Index].end = Act.CalcNow[organ.Index].end;
+
                         if (organ.Func == OrganFunc.exc)
                         {
-                            Act.CalcNow[organ.Index].end = Act.OutTotalNow[organ.Index] / outDeltaDay;
-
                             Act.OutTotalFromIntake[organ.Index] = 0; // TODO: for compatibility
                         }
                     }

--- a/FlexID.Calc/SubRoutine.cs
+++ b/FlexID.Calc/SubRoutine.cs
@@ -21,7 +21,7 @@ namespace FlexID.Calc
             Act.IterPre = new OrganActivity[data.Organs.Count];
             Act.IterNow = new OrganActivity[data.Organs.Count];
 
-            Act.OutTotalNow = new double[data.Organs.Count];
+            Act.OutNow = new OrganActivity[data.Organs.Count];
             Act.OutTotalFromIntake = new double[data.Organs.Count];
 
             // 全ての組織における計算結果を初期化する
@@ -37,7 +37,11 @@ namespace FlexID.Calc
                 Act.CalcNow[organ.Index].end = 0;
                 Act.CalcNow[organ.Index].total = 0;
 
-                Act.OutTotalNow[organ.Index] = 0;
+                Act.OutNow[organ.Index].ini = 0;
+                Act.OutNow[organ.Index].ave = 0;
+                Act.OutNow[organ.Index].end = 0;
+                Act.OutNow[organ.Index].total = 0;
+
                 Act.OutTotalFromIntake[organ.Index] = 0;
             }
 
@@ -57,6 +61,9 @@ namespace FlexID.Calc
                     Act.CalcNow[organ.Index].ave = init;
                     Act.CalcNow[organ.Index].end = init;
                     Act.CalcNow[organ.Index].total = 0;
+
+                    // 初期配分結果の出力に使用される。
+                    Act.OutNow[organ.Index] = Act.CalcNow[organ.Index];
                 }
             }
         }

--- a/FlexID.Calc/SubRoutine.cs
+++ b/FlexID.Calc/SubRoutine.cs
@@ -26,9 +26,6 @@ namespace FlexID.Calc
             Act.IntakeQuantityPre = new double[data.Organs.Count];
             Act.IntakeQuantityNow = new double[data.Organs.Count];
 
-            Act.Excreta = new double[data.Organs.Count];
-            Act.PreExcreta = new double[data.Organs.Count];
-
             // 全ての組織における計算結果を初期化する
             foreach (var organ in data.Organs)
             {
@@ -45,8 +42,6 @@ namespace FlexID.Calc
                 Act.OutTotalNow[organ.Index] = 0;
 
                 Act.IntakeQuantityNow[organ.Index] = 0;
-
-                Act.Excreta[organ.Index] = 0;
             }
 
             foreach (var organ in data.Organs)
@@ -94,7 +89,7 @@ namespace FlexID.Calc
             }
             organ.BioDecayCalc = 1;
 
-            Act.PreExcreta[organ.Index] = dT * ave;
+            Act.IterNow[organ.Index].total = dT * ave;
         }
 
         /// <summary>
@@ -121,7 +116,11 @@ namespace FlexID.Calc
             Act.IterNow[organ.Index].ini = ini;
             Act.IterNow[organ.Index].ave = ave;
             Act.IterNow[organ.Index].end = end;
+
+            // 混合コンパートメントでは、流入放射能は全て接続先へ流出するため、
+            // 計算時間メッシュ期間における積算放射能をゼロと計算する。
             Act.IterNow[organ.Index].total = 0;
+
             organ.BioDecayCalc = 1;
         }
 
@@ -138,6 +137,9 @@ namespace FlexID.Calc
             Act.IterNow[organ.Index].ini = 0;
             Act.IterNow[organ.Index].ave = 0;
             Act.IterNow[organ.Index].end = 0;
+
+            // 入力コンパートメントでは、全ての放射能は初期配分によって接続先へ流出するため、
+            // 計算時間メッシュ期間における積算放射能をゼロと計算する。
             Act.IterNow[organ.Index].total = 0;
         }
 

--- a/FlexID.Calc/SubRoutine.cs
+++ b/FlexID.Calc/SubRoutine.cs
@@ -22,9 +22,7 @@ namespace FlexID.Calc
             Act.IterNow = new OrganActivity[data.Organs.Count];
 
             Act.OutTotalNow = new double[data.Organs.Count];
-
-            Act.IntakeQuantityPre = new double[data.Organs.Count];
-            Act.IntakeQuantityNow = new double[data.Organs.Count];
+            Act.OutTotalFromIntake = new double[data.Organs.Count];
 
             // 全ての組織における計算結果を初期化する
             foreach (var organ in data.Organs)
@@ -40,8 +38,7 @@ namespace FlexID.Calc
                 Act.CalcNow[organ.Index].total = 0;
 
                 Act.OutTotalNow[organ.Index] = 0;
-
-                Act.IntakeQuantityNow[organ.Index] = 0;
+                Act.OutTotalFromIntake[organ.Index] = 0;
             }
 
             foreach (var organ in data.Organs)
@@ -60,7 +57,6 @@ namespace FlexID.Calc
                     Act.CalcNow[organ.Index].ave = init;
                     Act.CalcNow[organ.Index].end = init;
                     Act.CalcNow[organ.Index].total = 0;
-                    Act.IntakeQuantityNow[organ.Index] = 0;
                 }
             }
         }


### PR DESCRIPTION
従来処理では余分なデータ構造を使用していた箇所を、コンパートメント機能に関わらず同じデータの持ち方となるよう整理した。

またこの作業の結果、既存処理における課題がいくつか見つかっている。詳細はコミットログを参照。