### PR TITLE
BioDecayとBioDecayCalcの差異を削除

### DIFF
--- a/FlexID.Calc/DataReader.cs
+++ b/FlexID.Calc/DataReader.cs
@@ -89,13 +89,9 @@ namespace FlexID.Calc
 
         /// <summary>
         /// 生物学的崩壊定数[/day]。
+        /// 蓄積コンパートメントのみで意味を持ち、それ以外では1.0となる。
         /// </summary>
         public double BioDecay;
-
-        /// <summary>
-        /// 生物学的崩壊定数[/day](計算用)。
-        /// </summary>
-        public double BioDecayCalc;
 
         /// <summary>
         /// 流入経路。
@@ -276,6 +272,9 @@ namespace FlexID.Calc
                         organFn == "exc" ? OrganFunc.exc :
                         throw Program.Error($"Line {num}: Unrecognized organ function '{organFn}'.");
 
+                    if (organFunc != OrganFunc.acc)
+                        bioDecay = 1.0;
+
                     var organ = new Organ
                     {
                         Nuclide = nuclide,
@@ -284,7 +283,6 @@ namespace FlexID.Calc
                         Name = organName,
                         Func = organFunc,
                         BioDecay = bioDecay,
-                        BioDecayCalc = bioDecay,
                         Inflows = new List<Inflow>(inflowNum),
                     };
 
@@ -555,6 +553,9 @@ namespace FlexID.Calc
                         organFn == "exc" ? OrganFunc.exc :
                         throw Program.Error($"Line {num}: Unrecognized organ function '{organFn}'.");
 
+                    if (organFunc != OrganFunc.acc)
+                        bioDecay = 1.0;
+
                     var organ = new Organ
                     {
                         Nuclide = nuclide,
@@ -563,7 +564,6 @@ namespace FlexID.Calc
                         Name = organName,
                         Func = organFunc,
                         BioDecay = bioDecay,
-                        BioDecayCalc = bioDecay,
                         Inflows = new List<Inflow>(inflowNum),
                     };
 

--- a/FlexID.Calc/SubRoutine.cs
+++ b/FlexID.Calc/SubRoutine.cs
@@ -92,7 +92,7 @@ namespace FlexID.Calc
                     continue;
 
                 // 流入元の生物学的崩壊定数[/day]
-                var beforeBio = inflow.Organ.BioDecayCalc;
+                var beforeBio = inflow.Organ.BioDecay;
 
                 // 放射能[Bq/day] = 流入元の放射能[Bq/day] * 流入元の生物学的崩壊定数[/day] * 流入割合[-]
                 ini += Act.IterNow[inflow.Organ.Index].ini * beforeBio * inflow.Rate;
@@ -103,8 +103,6 @@ namespace FlexID.Calc
             Act.IterNow[organ.Index].ave = ave;
             Act.IterNow[organ.Index].end = end;
             Act.IterNow[organ.Index].total = dT * ave;
-
-            organ.BioDecayCalc = 1;
         }
 
         /// <summary>
@@ -121,7 +119,7 @@ namespace FlexID.Calc
             foreach (var inflow in organ.Inflows)
             {
                 // 流入元の生物学的崩壊定数[/day]
-                var beforeBio = inflow.Organ.BioDecayCalc;
+                var beforeBio = inflow.Organ.BioDecay;
 
                 // 放射能[Bq/day] = 流入元の放射能[Bq/day] * 流入元の生物学的崩壊定数[/day] * 流入割合[-]
                 ini += Act.IterNow[inflow.Organ.Index].ini * beforeBio * inflow.Rate;
@@ -135,8 +133,6 @@ namespace FlexID.Calc
             // 混合コンパートメントでは、流入放射能は全て接続先へ流出するため、
             // 計算時間メッシュ期間における積算放射能をゼロと計算する。
             Act.IterNow[organ.Index].total = 0;
-
-            organ.BioDecayCalc = 1;
         }
 
         /// <summary>
@@ -178,7 +174,7 @@ namespace FlexID.Calc
                 var inflowOrgan = inflow.Organ;
 
                 // 流入元の生物学的崩壊定数[/day]
-                var beforeBio = inflowOrgan.BioDecayCalc;
+                var beforeBio = inflowOrgan.BioDecay;
 
                 // 親核種からの崩壊の場合、同じ臓器内で崩壊するので生物学的崩壊定数の影響を受けない
                 if (inflowOrgan.Nuclide != organ.Nuclide)


### PR DESCRIPTION
BioDecayについて、インプットファイルを読み込んだ段階でacc以外の機能コンパートメントに対する1.0設定を行うことでBioDecayCalc相当の値となるよう正規化し、そのうえでBioDecayCalcを削除する。

従来処理では、accコンパートメントの計算における計算開始直後の第1回目の収束計算でのみ、流入元コンパートメントのBioDecayがインプットから読み込んだそのままの値、これは現在TrialCalcで使用しているものでは全てゼロだったので、生物学的崩壊定数を1.0とした場合の正しい計算結果からずれていたと可能性が高い。ただしこれは、おそらく2回目以降の収束計算によって覆い隠されることで、計算結果のずれとしては表面化していなかったと推測される。
