### PR TITLE
移行係数[/d]がゼロの場合に計算結果がNaNになる問題を修正

### DIFF
--- a/FlexID.Calc/DataReader.cs
+++ b/FlexID.Calc/DataReader.cs
@@ -799,8 +799,10 @@ namespace FlexID.Calc
                     }
                     else
                     {
-                        // fromからtoへの移行割合 = 移行係数[/d] / fromから流出する移行係数[d/]の総計
-                        inflowRate = coeff / sumOfOutflowCoeff[organFrom];
+                        var sum = sumOfOutflowCoeff[organFrom];
+
+                        // fromからtoへの移行割合 = 移行係数[/d] / fromから流出する移行係数[/d]の総計
+                        inflowRate = sum == 0 ? 0.0 : coeff / sum;
                     }
 
                     organTo.Inflows.Add(new Inflow


### PR DESCRIPTION
#38 の実装不足。

プルトニウムのインプットにおいて、結合状態のHRTMから血液への移行係数(s<sub>b</sub>)がゼロとなっているが、これを素直に入力したところ結果がNaNとなってしまったことで問題を発見した。

修正として、ゼロ除算を行わないよう、条件分岐を追加した。