### PR TITLE
TestFilesフォルダへのアクセスにジャンクションを使用することをやめる

### DIFF
--- a/FlexID.Calc.Tests/FlexID.Calc.Tests.csproj
+++ b/FlexID.Calc.Tests/FlexID.Calc.Tests.csproj
@@ -15,8 +15,19 @@
     <ProjectReference Include="..\FlexID.Calc\FlexID.Calc.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if not exist &quot;$(TargetDir)TestFiles&quot;  mklink /J &quot;$(TargetDir)TestFiles&quot;  &quot;$(ProjectDir)TestFiles&quot;" />
+  <Target Name="CreateTestFilesDir" AfterTargets="PostBuildEvent">
+    <!--  For old junction 'TestFiles' directory.  -->
+    <RemoveDir Directories="$(TargetDir)TestFiles" />
+
+    <Delete Files="$(TargetDir)TestFiles" />
+    <Exec Command="echo $(ProjectDir)TestFiles&gt; $(TargetDir)TestFiles" />
+  </Target>
+
+  <Target Name="RemoveTestFilesDir" AfterTargets="AfterClean">
+    <!--  For old junction 'TestFiles' directory.  -->
+    <RemoveDir Directories="$(TargetDir)TestFiles" />
+
+    <Delete Files="$(TargetDir)TestFiles" />
   </Target>
 
 </Project>

--- a/FlexID.Calc.Tests/InputReadTests.cs
+++ b/FlexID.Calc.Tests/InputReadTests.cs
@@ -109,7 +109,7 @@ namespace FlexID.Calc.Tests
         [DataRow("OIR_old_Pu-241_inh-TypeS")]
         public void Test_OIR_old(string target)
         {
-            var inputPath = Path.Combine("TestFiles", "InputRead", target + ".inp");
+            var inputPath = TestFiles.Combine("InputRead", target + ".inp");
 
             var calcProgeny = true;
             var data = new DataReader(inputPath, calcProgeny).Read_OIR();

--- a/FlexID.Calc.Tests/ParameterTests.cs
+++ b/FlexID.Calc.Tests/ParameterTests.cs
@@ -8,7 +8,7 @@ namespace FlexID.Calc.Tests
     [TestClass]
     public class ParameterTests
     {
-        private const string ParamDir = @"TestFiles\parameter";
+        private string ParamDir => TestFiles.Combine("parameter");
 
         [TestMethod]
         [DynamicData(nameof(ValidCases), DynamicDataSourceType.Method)]

--- a/FlexID.Calc.Tests/TestCalc.cs
+++ b/FlexID.Calc.Tests/TestCalc.cs
@@ -11,7 +11,7 @@ namespace FlexID.Calc.Tests
         [DataRow("test_ing.inp")]
         public void Test(string target)
         {
-            var TargetDir = @"TestFiles\TestCalc";
+            var TargetDir = TestFiles.Combine("TestCalc");
             var ExpectDir = Path.Combine(TargetDir, "Expect");
             var ResultDir = Path.Combine(TargetDir, "Result~");
             var TargetName = Path.GetFileNameWithoutExtension(target);

--- a/FlexID.Calc.Tests/TestHelpers.cs
+++ b/FlexID.Calc.Tests/TestHelpers.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace FlexID.Calc.Tests
+{
+    class TestFiles
+    {
+        static TestFiles()
+        {
+            var assembly = Assembly.GetAssembly(typeof(TestFiles));
+            var assemblyDir = Path.GetDirectoryName(assembly.Location);
+
+            testFilesDir = File.ReadLines(Path.Combine(assemblyDir, "TestFiles")).First();
+        }
+
+        private static string testFilesDir;
+
+        public static string Combine(params string[] paths)
+        {
+            return Path.Combine(testFilesDir, Path.Combine(paths));
+        }
+
+        public static string ReplaceVar(string str, string pattern = "$(TestFiles)")
+        {
+            return str.Replace(pattern, testFilesDir);
+        }
+    }
+}

--- a/FlexID.Calc.Tests/TimeMeshTests.cs
+++ b/FlexID.Calc.Tests/TimeMeshTests.cs
@@ -75,13 +75,14 @@ namespace FlexID.Calc.Tests
         }
 
         [TestMethod]
-        [DataRow("TestFiles/TimeMesh/calc-time.dat")]
-        [DataRow("TestFiles/TimeMesh/out-time.dat")]
+        [DataRow("$(TestFiles)/TimeMesh/calc-time.dat")]
+        [DataRow("$(TestFiles)/TimeMesh/out-time.dat")]
         [DataRow("lib/time.dat")]
         [DataRow("lib/out-time.dat")]
         [DataRow("lib/out-per-h.dat")]
         public void ReadTimeMeshFile(string filePath)
         {
+            filePath = TestFiles.ReplaceVar(filePath);
             var timeMesh = new TimeMesh(filePath);
         }
 

--- a/FlexID.Calc.Tests/TrialCalcTests.cs
+++ b/FlexID.Calc.Tests/TrialCalcTests.cs
@@ -7,7 +7,7 @@ namespace FlexID.Calc.Tests
     [TestClass]
     public class TrialCalcTests
     {
-        private const string TestDir = @"TestFiles/TrialCalc";
+        private string TestDir => TestFiles.Combine("TrialCalc");
 
         [TestMethod]
         [DataRow("Ba-133_ing-Insoluble")]
@@ -107,7 +107,7 @@ namespace FlexID.Calc.Tests
             var outputPath = Path.Combine(resultDir, target);
 
             var cTimeMeshFile = @"lib\time.dat";
-            var oTimeMeshFile = @"TestFiles\TrialCalc\out-time.dat";
+            var oTimeMeshFile = Path.Combine(TestDir, "out-time.dat");
 
             var commitmentPeriod = "50years";
 
@@ -136,12 +136,12 @@ namespace FlexID.Calc.Tests
         }
 
         [TestMethod]
-        [DataRow(@"Sr-90_ing", "3months old")]
-        [DataRow(@"Sr-90_ing", "1years old")]
-        [DataRow(@"Sr-90_ing", "5years old")]
-        [DataRow(@"Sr-90_ing", "10years old")]
-        [DataRow(@"Sr-90_ing", "15years old")]
-        [DataRow(@"Sr-90_ing", "Adult")]
+        [DataRow("Sr-90_ing", "3months old")]
+        [DataRow("Sr-90_ing", "1years old")]
+        [DataRow("Sr-90_ing", "5years old")]
+        [DataRow("Sr-90_ing", "10years old")]
+        [DataRow("Sr-90_ing", "15years old")]
+        [DataRow("Sr-90_ing", "Adult")]
         public void Test_EIR(string target, string exposureAge)
         {
             var nuclide = target.Split('_')[0];
@@ -154,7 +154,7 @@ namespace FlexID.Calc.Tests
             var outputPath = Path.Combine(resultDir, target);
 
             var cTimeMeshFile = @"lib\time.dat";
-            var oTimeMeshFile = @"TestFiles\TrialCalc\out-time.dat";
+            var oTimeMeshFile = Path.Combine(TestDir, "out-time.dat");
 
             var commitmentPeriod =
                 exposureAge == "3months old" /**/? "25450days" : // 70years - 100days = 25550days - 100days

--- a/S-Coefficient.Tests/DataReaderTests.cs
+++ b/S-Coefficient.Tests/DataReaderTests.cs
@@ -10,7 +10,7 @@ namespace S_Coefficient.Tests
         public void TestReadRAD()
         {
             var actual = DataReader.ReadRAD("Ca-45");
-            var expected = File.ReadAllLines(@"TestFiles\ReadRadExpected.txt");
+            var expected = File.ReadAllLines(TestFiles.Combine("ReadRadExpected.txt"));
 
             CollectionAssert.AreEqual(expected, actual);
         }
@@ -19,7 +19,7 @@ namespace S_Coefficient.Tests
         public void TestReadBET()
         {
             var actual = DataReader.ReadBET("Sr-90");
-            var expected = File.ReadAllLines(@"TestFiles\ReadBetExpected.txt");
+            var expected = File.ReadAllLines(TestFiles.Combine("ReadBetExpected.txt"));
 
             CollectionAssert.AreEqual(expected, actual);
         }

--- a/S-Coefficient.Tests/PostProcessTests.cs
+++ b/S-Coefficient.Tests/PostProcessTests.cs
@@ -10,15 +10,16 @@ namespace S_Coefficient.Tests
         [TestMethod]
         public void Test()
         {
-            var sourceLines = File.ReadAllLines(Path.Combine("TestFiles", "PostProcessing", "source.txt"));
+            var sourceFile = TestFiles.Combine("PostProcessing", "source.txt");
+            var sourceLines = File.ReadAllLines(sourceFile);
 
             var resultLines = PostProcessing.Program.FormatFile(sourceLines).ToArray();
 
             // 目視確認用。
-            //var resultFile = Path.Combine("TestFiles", "PostProcessing", "~result.txt");
+            //var resultFile = TestFiles.Combine("PostProcessing", "~result.txt");
             //File.WriteAllLines(resultFile, resultLines);
 
-            var expectFile = Path.Combine("TestFiles", "PostProcessing", "expect.txt");
+            var expectFile = TestFiles.Combine("PostProcessing", "expect.txt");
             var expectLines = File.ReadAllLines(expectFile).ToArray();
             CollectionAssert.AreEqual(expectLines, resultLines);
         }

--- a/S-Coefficient.Tests/S-Coefficient.Tests.csproj
+++ b/S-Coefficient.Tests/S-Coefficient.Tests.csproj
@@ -16,8 +16,19 @@
     <ProjectReference Include="..\S-coefficient\S-Coefficient.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if not exist &quot;$(TargetDir)TestFiles&quot;  mklink /J &quot;$(TargetDir)TestFiles&quot;  &quot;$(ProjectDir)TestFiles&quot;" />
+  <Target Name="CreateTestFilesDir" AfterTargets="PostBuildEvent">
+    <!--  For old junction 'TestFiles' directory.  -->
+    <RemoveDir Directories="$(TargetDir)TestFiles" />
+
+    <Delete Files="$(TargetDir)TestFiles" />
+    <Exec Command="echo $(ProjectDir)TestFiles&gt; $(TargetDir)TestFiles" />
+  </Target>
+
+  <Target Name="RemoveTestFilesDir" AfterTargets="AfterClean">
+    <!--  For old junction 'TestFiles' directory.  -->
+    <RemoveDir Directories="$(TargetDir)TestFiles" />
+
+    <Delete Files="$(TargetDir)TestFiles" />
   </Target>
 
 </Project>

--- a/S-Coefficient.Tests/TestHelpers.cs
+++ b/S-Coefficient.Tests/TestHelpers.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace S_Coefficient.Tests
+{
+    class TestFiles
+    {
+        static TestFiles()
+        {
+            var assembly = Assembly.GetAssembly(typeof(TestFiles));
+            var assemblyDir = Path.GetDirectoryName(assembly.Location);
+
+            testFilesDir = File.ReadLines(Path.Combine(assemblyDir, "TestFiles")).First();
+        }
+
+        private static string testFilesDir;
+
+        public static string Combine(params string[] paths)
+        {
+            return Path.Combine(testFilesDir, Path.Combine(paths));
+        }
+
+        public static string ReplaceVar(string str, string pattern = "$(TestFiles)")
+        {
+            return str.Replace(pattern, testFilesDir);
+        }
+    }
+}


### PR DESCRIPTION
Close #62.

テストプロジェクトのビルド後処理として`TestFiles`というテキストファイルを書き出し、この中に実際のTestFilesフォルダへのフルパスを書き込む。 テスト実行処理はこれを読み取り、TestFilesフォルダへのフルパスを解決する。