### PR TITLE
ICRP Publ.133に含まれるNDXファイルを使用する

### DIFF
--- a/FlexID.Calc.Tests/SAFReadTests.cs
+++ b/FlexID.Calc.Tests/SAFReadTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System.Linq;
 
 namespace FlexID.Calc.Tests
 {
@@ -26,6 +27,89 @@ namespace FlexID.Calc.Tests
             var actualLines = SAFDataReader.ReadBET("Sr-90");
 
             CollectionAssert.AreEqual(expectLines, actualLines);
+        }
+
+        [TestMethod]
+        public void TestReadSourceRegions()
+        {
+            var sregions = SAFDataReader.ReadSourceRegions();
+            CollectionAssert.AreEqual(new[]
+            {
+                "O-cavity",    "O-mucosa",    "Teeth-S",     "Teeth-V",     "Tongue",
+                "Tonsils",     "Oesophag-s",  "Oesophag-f",  "Oesophag-w",  "St-cont",
+                "St-mucosa",   "St-wall",     "SI-cont",     "SI-mucosa",   "SI-wall",
+                "SI-villi",    "RC-cont",     "RC-mucosa",   "RC-wall",     "LC-cont",
+                "LC-mucosa",   "LC-wall",     "RS-cont",     "RS-mucosa",   "RS-wall",
+                "ET1-sur",     "ET2-sur",     "ET2-bnd",     "ET2-seq",     "LN-ET",
+                "Bronchi",     "Bronchi-b",   "Bronchi-q",   "Brchiole",    "Brchiole-b",
+                "Brchiole-q",  "ALV",         "LN-Th",       "Lungs",       "Adrenals",
+                "Blood",       "C-bone-S",    "C-bone-V",    "T-bone-S",    "T-bone-V",
+                "C-marrow",    "T-marrow",    "R-marrow",    "Y-marrow",    "Brain",
+                "Breast",      "Eye-lens",    "GB-wall",     "GB-cont",     "Ht-wall",
+                "Kidneys",     "Liver",       "LN-Sys",      "Ovaries",     "Pancreas",
+                "P-gland",     "Prostate",    "S-glands",    "Skin",        "Spleen",
+                "Testes",      "Thymus",      "Thyroid",     "Ureters",     "UB-wall",
+                "UB-cont",     "Uterus",      "Adipose",     "Cartilage",   "Muscle",
+                "ET1-wall",    "ET2-wall",    "Lung-Tis",    "RT-air",
+            }, sregions.Select(s => s.Name).ToArray());
+
+            CollectionAssert.AreEqual(new[]
+            {
+                0.0      , 3.583E-02, 0.000E+00, 5.000E-02, 7.300E-02,
+                3.000E-03, 0.000E+00, 0.000E+00, 4.000E-02, 2.500E-01,
+                4.639E-03, 1.500E-01, 3.500E-01, 3.696E-02, 6.500E-01,
+                1.252E-02, 1.500E-01, 2.010E-02, 1.500E-01, 7.500E-02,
+                1.875E-02, 1.500E-01, 7.500E-02, 1.128E-02, 7.000E-02,
+                0.000E+00, 0.000E+00, 2.472E-03, 4.504E-04, 1.500E-02,
+                0.000E+00, 1.727E-03, 2.918E-04, 0.000E+00, 4.891E-03,
+                1.252E-03, 1.100E+00, 1.500E-02, 1.200E+00, 1.400E-02,
+                5.600E+00, 0.000E+00, 4.400E+00, 0.000E+00, 1.100E+00,
+                2.790E-01, 3.371E+00, 1.170E+00, 2.480E+00, 1.450E+00,
+                2.500E-02, 4.000E-04, 1.000E-02, 5.800E-02, 3.300E-01,
+                3.100E-01, 1.800E+00, 1.484E-01, 0.000E+00, 1.400E-01,
+                6.000E-04, 1.700E-02, 8.500E-02, 3.300E+00, 1.500E-01,
+                3.500E-02, 2.500E-02, 2.000E-02, 1.600E-02, 5.000E-02,
+                2.000E-01, 0.000E+00, 1.723E+01, 1.100E+00, 2.900E+01,
+                2.923E-03, 2.923E-03, 5.000E-01, 0.000E+00,
+            }, sregions.Select(s => s.MaleMass).ToArray());
+
+            CollectionAssert.AreEqual(new[]
+            {
+                0.0      ,  2.245E-02,  0.000E+00,  4.000E-02,  6.000E-02,
+                3.000E-03,  0.000E+00,  0.000E+00,  3.500E-02,  2.300E-01,
+                4.639E-03,  1.400E-01,  2.800E-01,  3.432E-02,  6.000E-01,
+                1.252E-02,  1.600E-01,  1.773E-02,  1.450E-01,  8.000E-02,
+                1.726E-02,  1.450E-01,  8.000E-02,  1.039E-02,  7.000E-02,
+                0.000E+00,  0.000E+00,  2.137E-03,  3.894E-04,  1.200E-02,
+                0.000E+00,  1.552E-03,  2.622E-04,  0.000E+00,  4.703E-03,
+                1.204E-03,  9.000E-01,  1.200E-02,  9.500E-01,  1.300E-02,
+                4.100E+00,  0.000E+00,  3.200E+00,  0.000E+00,  8.000E-01,
+                2.580E-01,  2.442E+00,  9.000E-01,  1.800E+00,  1.300E+00,
+                5.000E-01,  4.000E-04,  8.000E-03,  4.800E-02,  2.500E-01,
+                2.750E-01,  1.400E+00,  1.187E-01,  1.100E-02,  1.200E-01,
+                6.000E-04,  0.000E+00,  7.000E-02,  2.300E+00,  1.300E-01,
+                0.000E+00,  2.000E-02,  1.700E-02,  1.500E-02,  4.000E-02,
+                2.000E-01,  8.000E-02,  2.141E+01,  9.000E-01,  1.750E+01,
+                2.526E-03,  2.526E-03,  4.200E-01,  0.000E+00,
+            }, sregions.Select(s => s.FemaleMass).ToArray());
+        }
+
+        [TestMethod]
+        public void TestReadTargetRegions()
+        {
+            var tregions = SAFDataReader.ReadTargetRegions();
+            CollectionAssert.AreEqual(new[]
+            {
+                "O-mucosa",     "Oesophagus",   "St-stem",      "SI-stem",      "RC-stem",
+                "LC-stem",      "RS-stem",      "ET1-bas",      "ET2-bas",      "LN-ET",
+                "Bronch-bas",   "Bronch-sec",   "Bchiol-sec",   "AI",           "LN-Th",
+                "R-marrow",     "Endost-BS",    "Brain",        "Eye-lens",     "P-gland",
+                "Tongue",       "Tonsils",      "S-glands",     "Thyroid",      "Breast",
+                "Thymus",       "Ht-wall",      "Adrenals",     "Liver",        "Pancreas",
+                "Kidneys",      "Spleen",       "GB-wall",      "Ureters",      "UB-wall",
+                "Ovaries",      "Testes",       "Prostate",     "Uterus",       "LN-Sys",
+                "Skin",         "Adipose",      "Muscle",
+            }, tregions.Select(t => t.Name).ToArray());
         }
 
         [TestMethod]

--- a/FlexID.Calc/CalcScoeff.cs
+++ b/FlexID.Calc/CalcScoeff.cs
@@ -2,6 +2,7 @@ using MathNet.Numerics.Interpolation;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace FlexID.Calc
 {
@@ -303,41 +304,10 @@ namespace FlexID.Calc
 
         private IEnumerable<string> GenerateScoeffFileContent(double[] outData)
         {
-            var sourceRegions = new[]
-            {
-                "O-cavity",     "O-mucosa",     "Teeth-S",      "Teeth-V",      "Tongue",
-                "Tonsils",      "Oesophag-s",   "Oesophag-f",   "Oesophag-w",   "St-cont",
-                "St-mucosa",    "St-wall",      "SI-cont",      "SI-mucosa",    "SI-wall",
-                "SI-villi",     "RC-cont",      "RC-mucosa",    "RC-wall",      "LC-cont",
-                "LC-mucosa",    "LC-wall",      "RS-cont",      "RS-mucosa",    "RS-wall",
-                "ET1-sur",      "ET2-sur",      "ET2-bnd",      "ET2-seq",      "LN-ET",
-                "Bronchi",      "Bronchi-b",    "Bronchi-q",    "Brchiole",     "Brchiole-b",
-                "Brchiole-q",   "ALV",          "LN-Th",        "Lungs",        "Adrenals",
-                "Blood",        "C-bone-S",     "C-bone-V",     "T-bone-S",     "T-bone-V",
-                "C-marrow",     "T-marrow",     "R-marrow",     "Y-marrow",     "Brain",
-                "Breast",       "Eye-lens",     "GB-wall",      "GB-cont",      "Ht-wall",
-                "Kidneys",      "Liver",        "LN-Sys",       "Ovaries",      "Pancreas",
-                "P-gland",      "Prostate",     "S-glands",     "Skin",         "Spleen",
-                "Testes",       "Thymus",       "Thyroid",      "Ureters",      "UB-wall",
-                "UB-cont",      "Uterus",       "Adipose",      "Cartilage",    "Muscle",
-                "ET1-wall",     "ET2-wall",     "Lung-Tis",     "RT-air",
-            };
-
-            var targetTissues = new[]
-            {
-                "O-mucosa",     "Oesophagus",   "St-stem",      "SI-stem",      "RC-stem",
-                "LC-stem",      "RS-stem",      "ET1-bas",      "ET2-bas",      "LN-ET",
-                "Bronch-bas",   "Bronch-sec",   "Bchiol-sec",   "AI",           "LN-Th",
-                "R-marrow",     "Endost-BS",    "Brain",        "Eye-lens",     "P-gland",
-                "Tongue",       "Tonsils",      "S-glands",     "Thyroid",      "Breast",
-                "Thymus",       "Ht-wall",      "Adrenals",     "Liver",        "Pancreas",
-                "Kidneys",      "Spleen",       "GB-wall",      "Ureters",      "UB-wall",
-                "Ovaries",      "Testes",       "Prostate",     "Uterus",       "LN-Sys",
-                "Skin",         "Adipose",      "Muscle",
-            };
-
-            var nT = targetTissues.Length;
+            var sourceRegions = safdata.SourceRegions.Select(s => s.Name).ToArray();
+            var targetRegions = safdata.TargetRegions.Select(t => t.Name).ToArray();
             var nS = sourceRegions.Length;
+            var nT = targetRegions.Length;
 
             {
                 var line = $"{"  T/S",-10}";
@@ -350,9 +320,9 @@ namespace FlexID.Calc
             }
             for (var iT = 0; iT < nT; iT++)
             {
-                var targetTissue = targetTissues[iT];
+                var targetRegion = targetRegions[iT];
 
-                var line = $"{targetTissue,-10}";
+                var line = $"{targetRegion,-10}";
 
                 for (var iS = 0; iS < nS; iS++)
                 {

--- a/FlexID.Calc/FlexID.Calc.csproj
+++ b/FlexID.Calc/FlexID.Calc.csproj
@@ -25,7 +25,9 @@
   <ItemGroup>
     <None Include="$(SolutionDir)resources/lib/ICRP-07.BET" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(SolutionDir)resources/lib/ICRP-07.RAD" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(SolutionDir)resources/lib/rcp-a?_*_2017-03-07.SAF" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(SolutionDir)resources/lib/rcp-a?_*_????-??-??.SAF" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(SolutionDir)resources/lib/sregions_????-??-??.NDX" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(SolutionDir)resources/lib/torgans_????-??-??.NDX" LinkBase="lib" CopyToOutputDirectory="PreserveNewest" />
 
     <None Include="$(SolutionDir)resources/inp/OIR/**/*.inp" LinkBase="inp/OIR" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(SolutionDir)resources/inp/EIR/**/*.inp" LinkBase="inp/EIR" CopyToOutputDirectory="PreserveNewest" />

--- a/FlexID.Calc/LinqExtension.cs
+++ b/FlexID.Calc/LinqExtension.cs
@@ -8,7 +8,34 @@ namespace System.Linq
 
         public static IEnumerable<(T1, T2)> Zip<T1, T2>(this IEnumerable<T1> source1, IEnumerable<T2> source2)
         {
+            if (source1 is null)
+                throw new ArgumentNullException(nameof(source1));
+            if (source2 is null)
+                throw new ArgumentNullException(nameof(source2));
+
             return source1.Zip(source2, ZipSelector2);
+        }
+
+        public static IEnumerable<T> Prepend<T>(this IEnumerable<T> source, T element)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            yield return element;
+
+            foreach (var item in source)
+                yield return item;
+        }
+
+        public static IEnumerable<T> Append<T>(this IEnumerable<T> source, T element)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            foreach (var item in source)
+                yield return item;
+
+            yield return element;
         }
     }
 }

--- a/resources/lib/.gitignore
+++ b/resources/lib/.gitignore
@@ -1,3 +1,4 @@
 *.BET
 *.RAD
 *.SAF
+*.NDX


### PR DESCRIPTION
S係数データ作成処理、および残留放射能と線量計算処理において、ICRP Publ.133のSupplemental Dataに含まれる`sregions_2016-08-12.NDX`と`torgans_2016-08-12.NDX`を直接読み込むようにする。

これによって、線源領域や標的領域の名称、線源領域の重量などの情報を外部化できるようになる。

2つのファイルはSAFファイルなどと同じく`resources/lib`フォルダに置くことを要求する。