### PR TITLE
線源領域Otherの内訳を調整する機能を追加

### DIFF
--- a/FlexID.Calc.Tests/InputOtherCalcTests.cs
+++ b/FlexID.Calc.Tests/InputOtherCalcTests.cs
@@ -1,0 +1,259 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlexID.Calc.Tests
+{
+    using static InputErrorTestHelpers;
+
+    [TestClass]
+    public class InputOtherCalcTests
+    {
+        List<string> ExpectOtherSourceRegions(InputData data) =>
+            data.SourceRegions.Where(s => s.MaleID != 0 || s.FemaleID != 0)
+                              .Select(sr => sr.Name).ToList();
+
+        void Include(List<string> list, string item)
+        {
+            // 包含設定：リストに存在しない場合に追加する。
+            if (!list.Contains(item))
+                list.Add(item);
+        }
+
+        void Exclude(List<string> list, string item)
+        {
+            // 除外設定：リストに存在する場合に削除する。
+            var n = list.RemoveAll(x => x == item);
+            Assert.IsTrue(n == 0 || n == 1);
+        }
+
+        /// <summary>
+        /// 何も調整されない場合のOtherの内訳をテストする。
+        /// </summary>
+        [TestMethod]
+        public void TestAdjustNothing()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[nuclide]",
+                "  Sr-90  xxxx    6.596156E-05  0.0",
+                "",
+                "[Sr-90:compartment]",
+                "  inp    input      ---",
+                "  acc    ST0        Other",
+                "",
+                "[Sr-90:transfer]",
+                "  input  ST0        100%",
+            });
+
+            var data = reader.Read_OIR();
+            var expectOtherSourceRegions = ExpectOtherSourceRegions(data);
+
+            CollectionAssert.AreEquivalent(new[]
+            {
+                "O-mucosa",    "Teeth-V",     "Tonsils",     "Oesophag-w",  "St-wall",
+                "SI-wall",     "RC-wall",     "LC-wall",     "RS-wall",     "LN-ET",
+                "LN-Th",       "Adrenals",    "C-bone-V",    "T-bone-V",    "R-marrow",
+                "Y-marrow",    "Brain",       "Breast",      "Eye-lens",    "GB-wall",
+                "Ht-wall",     "Kidneys",     "Liver",       "LN-Sys",      "Ovaries",
+                "Pancreas",    "P-gland",     "Prostate",    "S-glands",    "Skin",
+                "Spleen",      "Testes",      "Thymus",      "Thyroid",     "Ureters",
+                "UB-wall",     "Uterus",      "Adipose",     "Cartilage",   "Muscle",
+                "ET1-wall",    "ET2-wall",    "Lung-Tis",
+            }, expectOtherSourceRegions);
+
+            CollectionAssert.AreEqual(expectOtherSourceRegions, data.Nuclides[0].OtherSourceRegions);
+        }
+
+        /// <summary>
+        /// コンパートメントとして明示された線源領域をOtherの内訳から除く処理をテストする。
+        /// </summary>
+        [TestMethod]
+        public void TestAdjustOther()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[nuclide]",
+                "  Sr-90  xxxx    6.596156E-05  0.0",
+                "",
+                "[Sr-90:compartment]",
+                "  inp    input             ---",
+                "  acc    ST0               Other",
+                "  acc    C-bone-S          C-bone-S",
+                "  acc    Exch-C-bone-V     C-bone-V",
+                "  acc    Noch-C-bone-V     C-bone-V",
+                "  acc    T-bone-S          T-bone-S",
+                "  acc    Exch-T-bone-V     T-bone-V",
+                "  acc    Noch-T-bone-V     T-bone-V",
+                "",
+                "[Sr-90:transfer]",
+                "  input  ST0        100%",
+            });
+
+            var data = reader.Read_OIR();
+            var expectOtherSourceRegions = ExpectOtherSourceRegions(data);
+
+            // コンパートメントとして明示されているためOtherの内訳から除外される。
+            Exclude(expectOtherSourceRegions, "C-bone-V");
+            Exclude(expectOtherSourceRegions, "T-bone-V");
+
+            CollectionAssert.AreEqual(expectOtherSourceRegions, data.Nuclides[0].OtherSourceRegions);
+        }
+
+        [TestMethod]
+        public void TestAdjustOtherByParameterOfInput()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[parameter]",
+                "IncludeOtherSourceRegions = O-cavity Oesophag-s Oesophag-w C-bone-V",
+                "ExcludeOtherSourceRegions = O-mucosa Oesophag-f",
+                "",
+                "[nuclide]",
+                "  Sr-90  xxxx    6.596156E-05  0.0",
+                "",
+                "[Sr-90:compartment]",
+                "  inp    input             ---",
+                "  acc    ST0               Other",
+                "  acc    C-bone-S          C-bone-S",
+                "  acc    Exch-C-bone-V     C-bone-V",
+                "  acc    Noch-C-bone-V     C-bone-V",
+                "  acc    T-bone-S          T-bone-S",
+                "  acc    Exch-T-bone-V     T-bone-V",
+                "  acc    Noch-T-bone-V     T-bone-V",
+                "",
+                "[Sr-90:transfer]",
+                "  input  ST0        100%",
+            });
+
+            var data = reader.Read_OIR();
+            var expectOtherSourceRegions = ExpectOtherSourceRegions(data);
+
+            Include(expectOtherSourceRegions, "O-cavity");
+            Include(expectOtherSourceRegions, "Oesophag-s");
+            Include(expectOtherSourceRegions, "Oesophag-w");    // 既にOtherの内訳に含まれている
+            Include(expectOtherSourceRegions, "C-bone-V");      // 既にOtherの内訳に含まれている
+            Exclude(expectOtherSourceRegions, "O-mucosa");
+            Exclude(expectOtherSourceRegions, "Oesophag-f");    // 既にOtherの内訳に含まれていない
+
+            // コンパートメントとして明示されているためOtherの内訳から除外される。
+            Exclude(expectOtherSourceRegions, "C-bone-V");
+            Exclude(expectOtherSourceRegions, "T-bone-V");
+
+            CollectionAssert.AreEqual(expectOtherSourceRegions, data.Nuclides[0].OtherSourceRegions);
+        }
+
+        [TestMethod]
+        public void TestAdjustOtherByParameterOfNuclide()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[nuclide]",
+                "  Sr-90  xxxx    6.596156E-05  0.0",
+                "",
+                "[Sr-90:parameter]",
+                "IncludeOtherSourceRegions = O-cavity Oesophag-s Oesophag-w C-bone-V",
+                "ExcludeOtherSourceRegions = O-mucosa Oesophag-f",
+                "",
+                "[Sr-90:compartment]",
+                "  inp    input             ---",
+                "  acc    ST0               Other",
+                "  acc    C-bone-S          C-bone-S",
+                "  acc    Exch-C-bone-V     C-bone-V",
+                "  acc    Noch-C-bone-V     C-bone-V",
+                "  acc    T-bone-S          T-bone-S",
+                "  acc    Exch-T-bone-V     T-bone-V",
+                "  acc    Noch-T-bone-V     T-bone-V",
+                "",
+                "[Sr-90:transfer]",
+                "  input  ST0        100%",
+            });
+
+            var data = reader.Read_OIR();
+            var expectOtherSourceRegions = ExpectOtherSourceRegions(data);
+
+            Include(expectOtherSourceRegions, "O-cavity");
+            Include(expectOtherSourceRegions, "Oesophag-s");
+            Include(expectOtherSourceRegions, "Oesophag-w");    // 既にOtherの内訳に含まれている
+            Include(expectOtherSourceRegions, "C-bone-V");      // 既にOtherの内訳に含まれている
+            Exclude(expectOtherSourceRegions, "O-mucosa");
+            Exclude(expectOtherSourceRegions, "Oesophag-f");    // 既にOtherの内訳に含まれていない
+
+            // コンパートメントとして明示されているためOtherの内訳から除外される。
+            Exclude(expectOtherSourceRegions, "C-bone-V");
+            Exclude(expectOtherSourceRegions, "T-bone-V");
+
+            CollectionAssert.AreEqual(expectOtherSourceRegions, data.Nuclides[0].OtherSourceRegions);
+        }
+
+        [TestMethod]
+        public void TestAdjustOtherByParameterOfNuclideAndInput()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[parameter]",
+                "IncludeOtherSourceRegions = O-cavity Oesophag-s Oesophag-w C-bone-V",
+                "ExcludeOtherSourceRegions = O-mucosa Oesophag-f",
+                "",
+                "[nuclide]",
+                "  Sr-90  xxxx    6.596156E-05  0.0",
+                "",
+                "[Sr-90:parameter]",
+                "IncludeOtherSourceRegions = Tonsils Oesophag-f St-cont",
+                "ExcludeOtherSourceRegions = St-wall SI-mucosa",
+                "",
+                "[Sr-90:compartment]",
+                "  inp    input             ---",
+                "  acc    ST0               Other",
+                "  acc    C-bone-S          C-bone-S",
+                "  acc    Exch-C-bone-V     C-bone-V",
+                "  acc    Noch-C-bone-V     C-bone-V",
+                "  acc    T-bone-S          T-bone-S",
+                "  acc    Exch-T-bone-V     T-bone-V",
+                "  acc    Noch-T-bone-V     T-bone-V",
+                "",
+                "[Sr-90:transfer]",
+                "  input  ST0        100%",
+            });
+
+            var data = reader.Read_OIR();
+            var expectOtherSourceRegions = ExpectOtherSourceRegions(data);
+
+            // from input parameters
+            Include(expectOtherSourceRegions, "O-cavity");
+            Include(expectOtherSourceRegions, "Oesophag-s");
+            Include(expectOtherSourceRegions, "Oesophag-w");    // 既にOtherの内訳に含まれている
+            Include(expectOtherSourceRegions, "C-bone-V");      // 既にOtherの内訳に含まれている
+            Exclude(expectOtherSourceRegions, "O-mucosa");
+            Exclude(expectOtherSourceRegions, "Oesophag-f");    // 既にOtherの内訳に含まれていない
+
+            // from Sr-90 parameters
+            Include(expectOtherSourceRegions, "Tonsils");       // 既にOtherの内訳に含まれている
+            Include(expectOtherSourceRegions, "Oesophag-f");    // インプットのExclude指定＜核種のInclude指定
+            Include(expectOtherSourceRegions, "St-cont");
+            Exclude(expectOtherSourceRegions, "St-wall");
+            Exclude(expectOtherSourceRegions, "SI-mucosa");     // 既にOtherの内訳に含まれていない
+
+            // コンパートメントとして明示されているためOtherの内訳から除外される。
+            Exclude(expectOtherSourceRegions, "C-bone-V");
+            Exclude(expectOtherSourceRegions, "T-bone-V");
+
+            CollectionAssert.AreEqual(expectOtherSourceRegions, data.Nuclides[0].OtherSourceRegions);
+        }
+    }
+}

--- a/FlexID.Calc/DotNetExtensions.cs
+++ b/FlexID.Calc/DotNetExtensions.cs
@@ -1,8 +1,27 @@
 using System.Collections.Generic;
 
+namespace System.Collections.Generic
+{
+    internal static class Extensions
+    {
+        public static V GetValueOrDefault<K, V>(this IReadOnlyDictionary<K, V> dictionary, K key)
+        {
+            if (dictionary.TryGetValue(key, out var value))
+                return value;
+            return default;
+        }
+
+        public static V GetValueOrDefault<K, V>(this IReadOnlyDictionary<K, V> dictionary, K key, V value)
+        {
+            if (dictionary.TryGetValue(key, out var val))
+                return val;
+            return value;
+        }
+    }
+}
 namespace System.Linq
 {
-    internal static class LinqExtension
+    internal static class Extensions
     {
         private static (T1, T2) ZipSelector2<T1, T2>(T1 v1, T2 v2) => (v1, v2);
 


### PR DESCRIPTION
#81 にて、本機能の必要性が生じた。

OIR用のインプットに`[parameter]`セクションを追加し、ここでOtherに対して追加する、あるいは除外する線源領域のリストを設定できるようにする。

設定はインプット全体と核種毎に行える。設定の優先度は、以下の規則に従う。
- 包含指定＜除外指定＜コンパートメントで明示
- インプット全体に対する指定＜特定の核種に対する指定

設定イメージ：

```
[title]
dummy

[parameter]
IncludeOtherSourceRegions = O-cavity Oesophag-s Oesophag-w C-bone-V
ExcludeOtherSourceRegions = O-mucosa Oesophag-f

[nuclide]
  Sr-90  xxxx    6.596156E-05  0.0

[Sr-90:parameter]
IncludeOtherSourceRegions = Tonsils Oesophag-f St-cont
ExcludeOtherSourceRegions = St-wall SI-mucosa

[Sr-90:compartment]
...
```
