### PR TITLE
Viewerにおける出力ファイルリストの取得、およびその中の1つの出力ファイルを読み込む処理を見直す

### DIFF
--- a/FlexID.Viewer/FlexID.Viewer.csproj
+++ b/FlexID.Viewer/FlexID.Viewer.csproj
@@ -28,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FlexID.Calc\FlexID.Calc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <AutoGen>True</AutoGen>

--- a/FlexID.Viewer/FodyWeavers.xml
+++ b/FlexID.Viewer/FodyWeavers.xml
@@ -1,3 +1,7 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura>
+    <ExcludeAssemblies>
+      FlexID.Calc
+    </ExcludeAssemblies>
+  </Costura>
 </Weavers>

--- a/FlexID.Viewer/Views/MainWindow.xaml
+++ b/FlexID.Viewer/Views/MainWindow.xaml
@@ -69,9 +69,9 @@
             Height="30"
             VerticalAlignment="Center"
             FontSize="14"
-            Text="{Binding ResultFilePath.Value}">
+            Text="{Binding OutputFilePath.Value}">
             <i:Interaction.Behaviors>
-              <vb:PathDropBehavior AllowDropPath="SingleFile" DropCommand="{Binding SelectResultFilePathCommand}" />
+              <vb:PathDropBehavior AllowDropPath="SingleFile" DropCommand="{Binding SelectOutputFilePathCommand}" />
               <vb:PathPasteBehavior />
             </i:Interaction.Behaviors>
           </TextBox>
@@ -81,7 +81,7 @@
             Height="30"
             VerticalAlignment="Center"
             Controls:ControlsHelper.ContentCharacterCasing="Normal"
-            Command="{Binding SelectResultFilePathCommand}"
+            Command="{Binding SelectOutputFilePathCommand}"
             Content="Browse"
             FontSize="14"
             FontWeight="Normal" />
@@ -91,7 +91,7 @@
             Grid.Column="0"
             VerticalAlignment="Center"
             FontSize="14"
-            Text="Result Type" />
+            Text="Output Type" />
           <ComboBox
             Grid.Row="2"
             Grid.Column="1"
@@ -101,8 +101,8 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
             FontSize="14"
-            ItemsSource="{Binding ComboList, UpdateSourceTrigger=PropertyChanged}"
-            SelectedItem="{Binding SelectCombo.Value}" />
+            ItemsSource="{Binding OutputTypes}"
+            SelectedItem="{Binding SelectedOutputType.Value}" />
 
           <TextBlock
             Grid.Row="4"
@@ -349,8 +349,8 @@
             Height="30"
             Margin="0,0,20,0"
             FontSize="14"
-            ItemsSource="{Binding ComboList, UpdateSourceTrigger=PropertyChanged}"
-            SelectedItem="{Binding SelectCombo.Value}" />
+            ItemsSource="{Binding OutputTypes}"
+            SelectedItem="{Binding SelectedOutputType.Value}" />
         </StackPanel>
 
         <DataGrid


### PR DESCRIPTION
ViewModelは画面操作に応じてModelのSetXXXメソッドを呼び、これによって内部状態が更新される、というI/Fに整理する。 設定タイミングは以下の4つの処理に分けられる。

1. 出力ファイルのパスを設定することで、当該ファイルと同じフォルダにある出力ファイル種別のリストを設定する(`SetTypes`)
2. 選択された出力ファイル種別に応じて出力ファイルデータを読み込み、モデル状態を設定する(`SetOutput`)
3. 表示対象の出力タイムステップ変更に応じて、コンターの数値および色を設定する(`SetValues`）
4. カラーバーにおける上限・下限値の変更に応じて、コンターの色を設定する(`SetColors`)

出力ファイルの読み込みには #98 で追加したFlexID.Calcのクラスを使用するため、FlexID.Viewerはこれに依存する形となる。

さらに、コンター表示用の辞書についてキーを予め設定しておくことで、XAMLバインドエラーを解消する。