### PR TITLE
FlexID GUIにおいて入力ファイルの拡張子とその内容を見て実行対象の一覧を作る

### DIFF
--- a/FlexID/ViewModels/InputData.cs
+++ b/FlexID/ViewModels/InputData.cs
@@ -1,8 +1,6 @@
 using FlexID.Calc;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 
 namespace FlexID.ViewModels
@@ -23,6 +21,11 @@ namespace FlexID.ViewModels
         public string ModelType { get; }
 
         /// <summary>
+        /// 計算モデルの親核種。
+        /// </summary>
+        public string Nuclide { get; }
+
+        /// <summary>
         /// 子孫核種の計算モデルを持っている場合は<c>true</c>。
         /// </summary>
         public bool HasProgeny { get; }
@@ -32,11 +35,13 @@ namespace FlexID.ViewModels
         /// </summary>
         /// <param name="filePath"></param>
         /// <param name="modelType"></param>
+        /// <param name="nuclide"></param>
         /// <param name="hasProgeny"></param>
-        public InputData(string filePath, string modelType, bool hasProgeny)
+        public InputData(string filePath, string modelType, string nuclide, bool hasProgeny)
         {
             FilePath = filePath;
             ModelType = modelType;
+            Nuclide = nuclide;
             HasProgeny = hasProgeny;
         }
 
@@ -45,22 +50,25 @@ namespace FlexID.ViewModels
             return obj is InputData other &&
                    FilePath == other.FilePath &&
                    ModelType == other.ModelType &&
+                   Nuclide == other.Nuclide &&
                    HasProgeny == other.HasProgeny;
         }
 
         public override int GetHashCode()
         {
-            int hashCode = -610616931;
+            int hashCode = -1273085575;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FilePath);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ModelType);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Nuclide);
             hashCode = hashCode * -1521134295 + HasProgeny.GetHashCode();
             return hashCode;
         }
 
-        public void Deconstruct(out string filePath, out string modelType, out bool hasProgeny)
+        public void Deconstruct(out string filePath, out string modelType, out string nuclide, out bool hasProgeny)
         {
             filePath = FilePath;
             modelType = ModelType;
+            nuclide = Nuclide;
             hasProgeny = HasProgeny;
         }
 
@@ -91,7 +99,7 @@ namespace FlexID.ViewModels
                     var type = parentNuclide.IntakeRoute;
                     var hasProgeny = data.Nuclides.Count > 1;
 
-                    inputs.Add(new InputData(inputFile, type, hasProgeny));
+                    inputs.Add(new InputData(inputFile, type, nuclide, hasProgeny));
                 }
                 catch
                 {
@@ -129,7 +137,7 @@ namespace FlexID.ViewModels
                     var type = parentNuclide.IntakeRoute;
                     var hasProgeny = data.Nuclides.Count > 1;
 
-                    inputs.Add(new InputData(inputFile, type, hasProgeny));
+                    inputs.Add(new InputData(inputFile, type, nuclide, hasProgeny));
                 }
                 catch
                 {

--- a/FlexID/ViewModels/InputEIRViewModel.cs
+++ b/FlexID/ViewModels/InputEIRViewModel.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -82,19 +81,18 @@ namespace FlexID.ViewModels
             const string InputDirPath = @"inp\EIR";
             var cacheNucInps = new Dictionary<string, List<InputData>>();
 
-            // EIR用のインプットフォルダにある核種の一覧を取得する。
-            try
+            // EIR用のインプットフォルダ配下に置かれたインプットファイルと、それらの核種の一覧を取得する。
+            foreach (var input in InputData.GetInputsEIR(InputDirPath))
             {
-                foreach (var x in Directory.EnumerateDirectories(InputDirPath))
+                var nuc = input.Nuclide;
+                if (!cacheNucInps.TryGetValue(nuc, out var inputs))
                 {
-                    var nuc = Path.GetFileName(x);
-                    Nuclides.Add(nuc);
+                    inputs = new List<InputData>();
+                    cacheNucInps.Add(nuc, inputs);
                 }
+                inputs.Add(input);
             }
-            catch (Exception e) when (e is IOException || e is SystemException)
-            {
-                // InputDirPathがない場合はNuclidesが空になる。
-            }
+            Nuclides.AddRange(cacheNucInps.Keys.OrderBy(nuc => nuc));
             SelectedNuclide.Value = Nuclides.FirstOrDefault();
 
             // 核種に対応する、選択されたインプット群。
@@ -102,12 +100,7 @@ namespace FlexID.ViewModels
             {
                 if (nuc is null)
                     return new List<InputData>();
-                if (!cacheNucInps.TryGetValue(nuc, out var inputs))
-                {
-                    inputs = InputData.GetInputsEIR(InputDirPath, nuc);
-                    cacheNucInps.Add(nuc, inputs);
-                }
-                return inputs;
+                return cacheNucInps[nuc];
             });
 
             selectedInputs.Subscribe(inputs =>


### PR DESCRIPTION
従来は`inp/OIR`や`inp/EIR`フォルダの直下に核種名でサブフォルダがあり、その下に核種毎のインプットが置かれていると仮定していた。しかしこれには任意のフォルダ名が使用できない、サブフォルダの下に名前で示される核種と整合しないインプットを置けてしまう、といった問題点があった。

このPRは、計算可能なインプットの探索を、所定のフォルダ配下の全階層から行うよう変更する。
核種による分類についても、インプットから実際の対象核種を読み込み、それに基づいて行うよう変更する。
これによって、核種と同じ名前のサブフォルダ配下になければいけない、という制約を除去する。
