### PR TITLE
FlexID GUI で被ばく経路の代わりにインプットのタイトルを表示する

### DIFF
--- a/FlexID.Calc/InputDataReader.cs
+++ b/FlexID.Calc/InputDataReader.cs
@@ -1046,11 +1046,13 @@ namespace FlexID.Calc
             reader.DiscardBufferedData();
             lineNum = 0;
 
-            var firstLine = GetNextLine();
-            if (firstLine is null)
+            var title = GetNextLine();
+            if (title is null)
                 throw Program.Error("Reach to EOF while reading input file.");
 
             var data = new InputData();
+
+            data.Title = title;
 
             data.StartAge =
                 age == "Age:3month" /**/? 100 :
@@ -1064,6 +1066,10 @@ namespace FlexID.Calc
             {
                 var isProgeny = false;
             Lcont:
+                var firstLine = GetNextLine();
+                if (firstLine is null)
+                    throw Program.Error("Reach to EOF while reading input file.");
+
                 // 核種のヘッダ行を読み込む。
                 var values = firstLine.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -1114,9 +1120,6 @@ namespace FlexID.Calc
                             break;
 
                         isProgeny = true;
-                        firstLine = GetNextLine();
-                        if (firstLine is null)
-                            throw Program.Error("Reach to EOF while reading input file.");
                         goto Lcont;
                     }
 

--- a/FlexID/ViewModels/InputData.cs
+++ b/FlexID/ViewModels/InputData.cs
@@ -17,9 +17,9 @@ namespace FlexID.ViewModels
         public string FilePath { get; }
 
         /// <summary>
-        /// 計算モデルの種別(被ばく経路/化学形態)。
+        /// 計算モデルのタイトル(被ばく経路, 化学形態, etc.)。
         /// </summary>
-        public string ModelType { get; }
+        public string Title { get; }
 
         /// <summary>
         /// 計算モデルの親核種。
@@ -35,13 +35,13 @@ namespace FlexID.ViewModels
         /// コンストラクタ
         /// </summary>
         /// <param name="filePath"></param>
-        /// <param name="modelType"></param>
+        /// <param name="title"></param>
         /// <param name="nuclide"></param>
         /// <param name="hasProgeny"></param>
-        public InputData(string filePath, string modelType, string nuclide, bool hasProgeny)
+        public InputData(string filePath, string title, string nuclide, bool hasProgeny)
         {
             FilePath = filePath;
-            ModelType = modelType;
+            Title = title;
             Nuclide = nuclide;
             HasProgeny = hasProgeny;
         }
@@ -50,7 +50,7 @@ namespace FlexID.ViewModels
         {
             return obj is InputData other &&
                    FilePath == other.FilePath &&
-                   ModelType == other.ModelType &&
+                   Title == other.Title &&
                    Nuclide == other.Nuclide &&
                    HasProgeny == other.HasProgeny;
         }
@@ -59,16 +59,16 @@ namespace FlexID.ViewModels
         {
             int hashCode = -1273085575;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FilePath);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ModelType);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Title);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Nuclide);
             hashCode = hashCode * -1521134295 + HasProgeny.GetHashCode();
             return hashCode;
         }
 
-        public void Deconstruct(out string filePath, out string modelType, out string nuclide, out bool hasProgeny)
+        public void Deconstruct(out string filePath, out string title, out string nuclide, out bool hasProgeny)
         {
             filePath = FilePath;
-            modelType = ModelType;
+            title = Title;
             nuclide = Nuclide;
             hasProgeny = HasProgeny;
         }
@@ -109,11 +109,11 @@ namespace FlexID.ViewModels
                 if (parentNuclide is null)
                     continue;
 
-                var type = parentNuclide.IntakeRoute;
+                var title = data.Title;
                 var nuclide = parentNuclide.Nuclide;
                 var hasProgeny = data.Nuclides.Count > 1;
 
-                yield return new InputData(inputFile, type, nuclide, hasProgeny);
+                yield return new InputData(inputFile, title, nuclide, hasProgeny);
             }
         }
 
@@ -153,11 +153,11 @@ namespace FlexID.ViewModels
                 if (parentNuclide is null)
                     continue;
 
-                var type = parentNuclide.IntakeRoute;
+                var title = data.Title;
                 var nuclide = parentNuclide.Nuclide;
                 var hasProgeny = data.Nuclides.Count > 1;
 
-                yield return new InputData(inputFile, type, nuclide, hasProgeny);
+                yield return new InputData(inputFile, title, nuclide, hasProgeny);
             }
         }
     }

--- a/FlexID/ViewModels/InputEIRViewModel.cs
+++ b/FlexID/ViewModels/InputEIRViewModel.cs
@@ -29,9 +29,9 @@ namespace FlexID.ViewModels
 
         public ReactivePropertySlim<bool> CalcProgeny { get; } = new ReactivePropertySlim<bool>();
 
-        public ObservableCollection<string> InputTitles { get; } = new ObservableCollection<string>();
+        public ObservableCollection<InputData> Inputs { get; } = new ObservableCollection<InputData>();
 
-        public ReactivePropertySlim<string> SelectedInputTitle { get; } = new ReactivePropertySlim<string>();
+        public ReactivePropertySlim<InputData> SelectedInput { get; } = new ReactivePropertySlim<InputData>();
 
         public ReactivePropertySlim<string> CalcTimeMeshFilePath { get; } = new ReactivePropertySlim<string>();
 
@@ -105,21 +105,15 @@ namespace FlexID.ViewModels
 
             selectedInputs.Subscribe(inputs =>
             {
-                // インプットの種別(被ばく経路/化学形態)の一覧を更新する。
-                var titles = inputs.Select(inp => inp.Title);
-                InputTitles.Clear();
-                InputTitles.AddRange(titles);
+                // インプットの一覧を更新する。
+                Inputs.Clear();
+                Inputs.AddRange(inputs);
 
-                SelectedInputTitle.Value = titles.FirstOrDefault();
+                SelectedInput.Value = inputs.FirstOrDefault();
             }).AddTo(Disposables);
 
-            // 核種とインプットのタイトルに対応する、選択されたインプット情報。
-            var selectedInput = selectedInputs.CombineLatest(SelectedInputTitle,
-                (inputs, title) => inputs?.FirstOrDefault(inp => inp.Title == title))
-                .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
-
             // 子孫核種を持つインプットに対してのみ、子孫核種の計算を選択可能にする。
-            HasProgeny = selectedInput.Select(inp => inp?.HasProgeny ?? false)
+            HasProgeny = SelectedInput.Select(inp => inp?.HasProgeny ?? false)
                 .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
 
             // 子孫核種の有無が切り替わった場合に、これを子孫核種の計算有無に反映する。
@@ -157,12 +151,13 @@ namespace FlexID.ViewModels
 
             }).AddTo(Disposables);
 
-            RunCommand = calcStatus.CanExecute.ToAsyncReactiveCommand().WithSubscribe(async () =>
+            var canRun = calcStatus.CanExecute.CombineLatest(SelectedInput, (b, inp) => b && inp != null);
+            RunCommand = canRun.ToAsyncReactiveCommand().WithSubscribe(async () =>
             {
                 try
                 {
                     CheckParam();
-                    await RunAndView(selectedInput.Value);
+                    await RunAndView(SelectedInput.Value);
                 }
                 catch (Exception error)
                 {
@@ -204,7 +199,7 @@ namespace FlexID.ViewModels
             {
                 throw new Exception("Please select Nuclide.");
             }
-            if (SelectedInputTitle.Value is null)
+            if (SelectedInput.Value is null)
             {
                 throw new Exception("Please select Route of Intake.");
             }

--- a/FlexID/ViewModels/InputEIRViewModel.cs
+++ b/FlexID/ViewModels/InputEIRViewModel.cs
@@ -29,9 +29,9 @@ namespace FlexID.ViewModels
 
         public ReactivePropertySlim<bool> CalcProgeny { get; } = new ReactivePropertySlim<bool>();
 
-        public ObservableCollection<string> ModelTypes { get; } = new ObservableCollection<string>();
+        public ObservableCollection<string> InputTitles { get; } = new ObservableCollection<string>();
 
-        public ReactivePropertySlim<string> SelectedModelType { get; } = new ReactivePropertySlim<string>();
+        public ReactivePropertySlim<string> SelectedInputTitle { get; } = new ReactivePropertySlim<string>();
 
         public ReactivePropertySlim<string> CalcTimeMeshFilePath { get; } = new ReactivePropertySlim<string>();
 
@@ -106,16 +106,16 @@ namespace FlexID.ViewModels
             selectedInputs.Subscribe(inputs =>
             {
                 // インプットの種別(被ばく経路/化学形態)の一覧を更新する。
-                var types = inputs.Select(inp => inp.ModelType);
-                ModelTypes.Clear();
-                ModelTypes.AddRange(types);
+                var titles = inputs.Select(inp => inp.Title);
+                InputTitles.Clear();
+                InputTitles.AddRange(titles);
 
-                SelectedModelType.Value = types.FirstOrDefault();
+                SelectedInputTitle.Value = titles.FirstOrDefault();
             }).AddTo(Disposables);
 
-            // 核種とインプットの種別(被ばく経路/化学形態)に対応する、選択されたインプット情報。
-            var selectedInput = selectedInputs.CombineLatest(SelectedModelType,
-                (inputs, type) => inputs?.FirstOrDefault(inp => inp.ModelType == type))
+            // 核種とインプットのタイトルに対応する、選択されたインプット情報。
+            var selectedInput = selectedInputs.CombineLatest(SelectedInputTitle,
+                (inputs, title) => inputs?.FirstOrDefault(inp => inp.Title == title))
                 .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
 
             // 子孫核種を持つインプットに対してのみ、子孫核種の計算を選択可能にする。
@@ -204,7 +204,7 @@ namespace FlexID.ViewModels
             {
                 throw new Exception("Please select Nuclide.");
             }
-            if (SelectedModelType.Value is null)
+            if (SelectedInputTitle.Value is null)
             {
                 throw new Exception("Please select Route of Intake.");
             }

--- a/FlexID/ViewModels/InputOIRViewModel.cs
+++ b/FlexID/ViewModels/InputOIRViewModel.cs
@@ -29,9 +29,9 @@ namespace FlexID.ViewModels
 
         public ReactivePropertySlim<bool> CalcProgeny { get; } = new ReactivePropertySlim<bool>();
 
-        public ObservableCollection<string> ModelTypes { get; } = new ObservableCollection<string>();
+        public ObservableCollection<string> InputTitles { get; } = new ObservableCollection<string>();
 
-        public ReactivePropertySlim<string> SelectedModelType { get; } = new ReactivePropertySlim<string>();
+        public ReactivePropertySlim<string> SelectedInputTitle { get; } = new ReactivePropertySlim<string>();
 
         public ReactivePropertySlim<string> CalcTimeMeshFilePath { get; } = new ReactivePropertySlim<string>();
 
@@ -94,16 +94,16 @@ namespace FlexID.ViewModels
             selectedInputs.Subscribe(inputs =>
             {
                 // インプットの種別(被ばく経路/化学形態)の一覧を更新する。
-                var types = inputs.Select(inp => inp.ModelType);
-                ModelTypes.Clear();
-                ModelTypes.AddRange(types);
+                var titles = inputs.Select(inp => inp.Title);
+                InputTitles.Clear();
+                InputTitles.AddRange(titles);
 
-                SelectedModelType.Value = types.FirstOrDefault();
+                SelectedInputTitle.Value = titles.FirstOrDefault();
             }).AddTo(Disposables);
 
-            // 核種とインプットの種別(被ばく経路/化学形態)に対応する、選択されたインプット情報。
-            var selectedInput = selectedInputs.CombineLatest(SelectedModelType,
-                (inputs, type) => inputs?.FirstOrDefault(inp => inp.ModelType == type))
+            // 核種とインプットのタイトルに対応する、選択されたインプット情報。
+            var selectedInput = selectedInputs.CombineLatest(SelectedInputTitle,
+                (inputs, title) => inputs?.FirstOrDefault(inp => inp.Title == title))
                 .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
 
             // 子孫核種を持つインプットに対してのみ、子孫核種の計算を選択可能にする。
@@ -189,7 +189,7 @@ namespace FlexID.ViewModels
             {
                 throw new Exception("Please select Nuclide.");
             }
-            if (SelectedModelType.Value is null)
+            if (SelectedInputTitle.Value is null)
             {
                 throw new Exception("Please select Route of Intake.");
             }

--- a/FlexID/ViewModels/InputOIRViewModel.cs
+++ b/FlexID/ViewModels/InputOIRViewModel.cs
@@ -29,9 +29,9 @@ namespace FlexID.ViewModels
 
         public ReactivePropertySlim<bool> CalcProgeny { get; } = new ReactivePropertySlim<bool>();
 
-        public ObservableCollection<string> InputTitles { get; } = new ObservableCollection<string>();
+        public ObservableCollection<InputData> Inputs { get; } = new ObservableCollection<InputData>();
 
-        public ReactivePropertySlim<string> SelectedInputTitle { get; } = new ReactivePropertySlim<string>();
+        public ReactivePropertySlim<InputData> SelectedInput { get; } = new ReactivePropertySlim<InputData>();
 
         public ReactivePropertySlim<string> CalcTimeMeshFilePath { get; } = new ReactivePropertySlim<string>();
 
@@ -93,21 +93,15 @@ namespace FlexID.ViewModels
 
             selectedInputs.Subscribe(inputs =>
             {
-                // インプットの種別(被ばく経路/化学形態)の一覧を更新する。
-                var titles = inputs.Select(inp => inp.Title);
-                InputTitles.Clear();
-                InputTitles.AddRange(titles);
+                // インプットの一覧を更新する。
+                Inputs.Clear();
+                Inputs.AddRange(inputs);
 
-                SelectedInputTitle.Value = titles.FirstOrDefault();
+                SelectedInput.Value = inputs.FirstOrDefault();
             }).AddTo(Disposables);
 
-            // 核種とインプットのタイトルに対応する、選択されたインプット情報。
-            var selectedInput = selectedInputs.CombineLatest(SelectedInputTitle,
-                (inputs, title) => inputs?.FirstOrDefault(inp => inp.Title == title))
-                .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
-
             // 子孫核種を持つインプットに対してのみ、子孫核種の計算を選択可能にする。
-            HasProgeny = selectedInput.Select(inp => inp?.HasProgeny ?? false)
+            HasProgeny = SelectedInput.Select(inp => inp?.HasProgeny ?? false)
                 .ToReadOnlyReactivePropertySlim().AddTo(Disposables);
 
             // 子孫核種の有無が切り替わった場合に、これを子孫核種の計算有無に反映する。
@@ -143,12 +137,13 @@ namespace FlexID.ViewModels
 
             }).AddTo(Disposables);
 
-            RunCommand = calcStatus.CanExecute.ToAsyncReactiveCommand().WithSubscribe(async () =>
+            var canRun = calcStatus.CanExecute.CombineLatest(SelectedInput, (b, inp) => b && inp != null);
+            RunCommand = canRun.ToAsyncReactiveCommand().WithSubscribe(async () =>
             {
                 try
                 {
                     CheckParam();
-                    await RunAndView(selectedInput.Value);
+                    await RunAndView(SelectedInput.Value);
                 }
                 catch (Exception error)
                 {
@@ -189,7 +184,7 @@ namespace FlexID.ViewModels
             {
                 throw new Exception("Please select Nuclide.");
             }
-            if (SelectedInputTitle.Value is null)
+            if (SelectedInput.Value is null)
             {
                 throw new Exception("Please select Route of Intake.");
             }

--- a/FlexID/Views/InputEIRView.xaml
+++ b/FlexID/Views/InputEIRView.xaml
@@ -93,8 +93,9 @@
     <ComboBox
       Grid.Row="3"
       Grid.Column="1"
-      ItemsSource="{Binding InputTitles}"
-      SelectedValue="{Binding SelectedInputTitle.Value}" />
+      DisplayMemberPath="Title"
+      ItemsSource="{Binding Inputs}"
+      SelectedValue="{Binding SelectedInput.Value}" />
 
     <Label
       Grid.Row="4"

--- a/FlexID/Views/InputEIRView.xaml
+++ b/FlexID/Views/InputEIRView.xaml
@@ -89,12 +89,12 @@
     <Label
       Grid.Row="3"
       Grid.Column="0"
-      Content="Route / &#xA;Chemical Form" />
+      Content="Input Title &#xA;(Route, Form, etc)" />
     <ComboBox
       Grid.Row="3"
       Grid.Column="1"
-      ItemsSource="{Binding ModelTypes}"
-      SelectedValue="{Binding SelectedModelType.Value}" />
+      ItemsSource="{Binding InputTitles}"
+      SelectedValue="{Binding SelectedInputTitle.Value}" />
 
     <Label
       Grid.Row="4"

--- a/FlexID/Views/InputOIRView.xaml
+++ b/FlexID/Views/InputOIRView.xaml
@@ -93,8 +93,9 @@
     <ComboBox
       Grid.Row="3"
       Grid.Column="1"
-      ItemsSource="{Binding InputTitles}"
-      SelectedValue="{Binding SelectedInputTitle.Value}" />
+      DisplayMemberPath="Title"
+      ItemsSource="{Binding Inputs}"
+      SelectedValue="{Binding SelectedInput.Value}" />
 
     <Label
       Grid.Row="4"

--- a/FlexID/Views/InputOIRView.xaml
+++ b/FlexID/Views/InputOIRView.xaml
@@ -89,12 +89,12 @@
     <Label
       Grid.Row="3"
       Grid.Column="0"
-      Content="Route / &#xA;Chemical Form" />
+      Content="Input Title &#xA;(Route, Form, etc)" />
     <ComboBox
       Grid.Row="3"
       Grid.Column="1"
-      ItemsSource="{Binding ModelTypes}"
-      SelectedValue="{Binding SelectedModelType.Value}" />
+      ItemsSource="{Binding InputTitles}"
+      SelectedValue="{Binding SelectedInputTitle.Value}" />
 
     <Label
       Grid.Row="4"

--- a/resources/inp/EIR/Sr-90/Sr-90_ing.inp
+++ b/resources/inp/EIR/Sr-90/Sr-90_ing.inp
@@ -1,3 +1,4 @@
+Sr-90 Ingestion
  Sr-90 Ingestion                             6.596156E-05    0.0
  Age:3month
    1 input             inp      0.0        0     0      0.0        -


### PR DESCRIPTION
#105 に関連する変更。

OIR用のインプットには、任意の情報を記述可能な入力欄としてTitleセクションを用意している。これを被ばく経路に替えてFlexID GUIで表示するよう変更する。

EIR用のインプットについても、ファイルの1行目にOIR同様のTitle文字列を入力できるよう機能拡張し、FlexID GUIでこれを表示するようにする。

これらの変更によって、OIR/EIRのインプットに存在するIntakeRouteの記述を、FlexID GUIでは使用しないようになる。