### PR TITLE
コンパートメント名称に"mix"が含まれる場合にここからの標的領域への線量寄与が計算されない問題を修正

### DIFF
--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -379,9 +379,6 @@ namespace FlexID.Calc
                     if (organ.SourceRegion is null)
                         continue;
 
-                    if (organ.Name.Contains("mix"))
-                        continue;
-
                     // コンパートメントの残留放射能がゼロの場合は何もしない。
                     var activity = Act.CalcNow[organ.Index].end * calcDeltaT;
                     if (activity == 0)

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -234,9 +234,6 @@ namespace FlexID.Calc
                     if (organ.SourceRegion is null)
                         continue;
 
-                    if (organ.Name.Contains("mix"))
-                        continue;
-
                     // コンパートメントの残留放射能がゼロの場合は何もしない。
                     var activity = Act.CalcNow[organ.Index].end * calcDeltaT;
                     if (activity == 0)


### PR DESCRIPTION
もともとは`mix-Blood`コンパートメントを線量計算から除外するための処理だったと思われるが、現在は機能としてmixを設定したコンパートメントは 対応する線源領域を設定できないよう入力チェックが掛かっており、また線源領域が未設定のコンパートメントは線量計算の対象から自動的に外れるため、 この判定は既に不要となっている。

組み込み済みのインプットに対しては実害がないため対処が後回しとなっていたが、今後ユーザー定義のインプットを処理する場合には問題となるため、ここで修正する。