### PR TITLE
ResultCheckerにおける新しいデータの組み込み手順を簡易化する

### DIFF
--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -33,7 +33,7 @@ namespace ResultChecker
                 }
             }
 
-            var targets = GetTargets().Where(t => patterns?.Any(pattern => pattern.IsMatch(t)) ?? true).ToArray();
+            var inputs = GetInputs().Where(inp => patterns?.Any(pattern => pattern.IsMatch(Path.GetFileNameWithoutExtension(inp))) ?? true).ToArray();
             var results = new ConcurrentBag<Result>();
 
             var parallelOptions = new ParallelOptions
@@ -42,11 +42,12 @@ namespace ResultChecker
             };
 
             // 並列に計算を実施する。
-            Parallel.ForEach(targets, parallelOptions, target =>
+            Parallel.ForEach(inputs, parallelOptions, inputPath =>
             {
+                var target = Path.GetFileNameWithoutExtension(inputPath);
                 try
                 {
-                    var result = CalcAndSummary(target);
+                    var result = CalcAndSummary(target, inputPath);
                     results.Add(result);
                     Console.WriteLine($"done: {target}");
                 }
@@ -86,10 +87,9 @@ namespace ResultChecker
             public (double Min, double Max) FractionsThyroid;
         }
 
-        static Result CalcAndSummary(string target)
+        static Result CalcAndSummary(string target, string inputPath)
         {
             var nuclide = target.Split('_')[0];
-            var inputPath = Path.Combine("inp", "OIR", nuclide, target + ".inp");
 
             var outputDir = "out";
             Directory.CreateDirectory(outputDir);

--- a/ResultChecker/Program_Taregts.cs
+++ b/ResultChecker/Program_Taregts.cs
@@ -25,120 +25,120 @@ namespace ResultChecker
         }
 
         /// <summary>
-        /// FlexIDに整備されているインプットと、OIRデータにおけるMaterialの対応を定義する。
+        /// FlexIDに整備されているインプットを列挙する。
         /// (核種についてはTargetの名称に含める仕様となっている)
         /// </summary>
         /// <returns></returns>
-        static IEnumerable<(string Target, string Material)> GetTargets()
+        static IEnumerable<string> GetTargets()
         {
-            yield return ("Ba-133_ing-Insoluble",       /**/"Ingestion, Insoluble forms: sulphate, titanate, fA=1E-4");
-            yield return ("Ba-133_ing-Soluble",         /**/"Ingestion, Soluble forms, fA=0.2");
-            yield return ("Ba-133_inh-TypeF",           /**/"Inhalation, Aerosols Type F, Barium chloride, carbonate, fA=0.2, 5 µm");
-            yield return ("Ba-133_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Barium sulphate, all unspecified forms, fA=4E-2, 5 µm");
-            yield return ("Ba-133_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=2E-3, 5 µm");
+            yield return "Ba-133_ing-Insoluble";
+            yield return "Ba-133_ing-Soluble";
+            yield return "Ba-133_inh-TypeF";
+            yield return "Ba-133_inh-TypeM";
+            yield return "Ba-133_inh-TypeS";
 
-            yield return ("C-14_ing",                   /**/"Ingestion, All chemical forms, fA=0.99");
-            yield return ("C-14_inh-TypeF",             /**/"Inhalation, Aerosols Type F, fA=0.99, 5 µm");
-            yield return ("C-14_inh-TypeF-Barium",      /**/"Inhalation, Aerosols Barium carbonate, fA=0.99, 5 µm");
-            yield return ("C-14_inh-TypeF-Gas",         /**/"Inhalation, Gas or vapour Type F, Unspecified , fA=0.99");
-            yield return ("C-14_inh-TypeM",             /**/"Inhalation, Aerosols Type M, All unspecified forms, fA=0.2, 5 µm");
-            yield return ("C-14_inh-TypeS",             /**/"Inhalation, Aerosols Type S, Elemental carbon, carbon tritide, fA=1E-2, 5 µm");
+            yield return "C-14_ing";
+            yield return "C-14_inh-TypeF";
+            yield return "C-14_inh-TypeF-Barium";
+            yield return "C-14_inh-TypeF-Gas";
+            yield return "C-14_inh-TypeM";
+            yield return "C-14_inh-TypeS";
 
-            yield return ("Ca-45_ing",                  /**/"Ingestion, All unspecified forms, fA=0.4");
-            yield return ("Ca-45_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Calcium chloride, fA=0.4, 5 µm");
-            yield return ("Ca-45_inh-TypeM",            /**/"Inhalation, Aerosols Type M, All unspecified forms, fA=8E-2, 5 µm");
-            yield return ("Ca-45_inh-TypeS",            /**/"Inhalation, Aerosols Type S, fA=4E-3, 5 µm");
+            yield return "Ca-45_ing";
+            yield return "Ca-45_inh-TypeF";
+            yield return "Ca-45_inh-TypeM";
+            yield return "Ca-45_inh-TypeS";
 
-            yield return ("Cs-134_ing-Insoluble",       /**/"Ingestion, Relatively insoluble forms, irradiated fuel fragments, fA=0.1");
-            yield return ("Cs-134_ing-Unspecified",     /**/"Ingestion, Caesium chloride, nitrate, sulphate; all unspecified compounds, fA=0.99");
-            yield return ("Cs-134_inh-TypeF",           /**/"Inhalation, Aerosols Type F, Caesium chloride, nitrate, sulphate, fA=0.99, 5 µm");
-            yield return ("Cs-134_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Irradiated fuel fragments, all unspecified forms, fA=0.2, 5 µm");
-            yield return ("Cs-134_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=1E-2, 5 µm");
+            yield return "Cs-134_ing-Insoluble";
+            yield return "Cs-134_ing-Unspecified";
+            yield return "Cs-134_inh-TypeF";
+            yield return "Cs-134_inh-TypeM";
+            yield return "Cs-134_inh-TypeS";
 
-            yield return ("Cs-137_ing-Insoluble",       /**/"Ingestion, Relatively insoluble forms, irradiated fuel fragments, fA=0.1");
-            yield return ("Cs-137_ing-Unspecified",     /**/"Ingestion, Caesium chloride, nitrate, sulphate; all unspecified compounds, fA=0.99");
-            yield return ("Cs-137_inh-TypeF",           /**/"Inhalation, Aerosols Type F, Caesium chloride, nitrate, sulphate, fA=0.99, 5 µm");
-            yield return ("Cs-137_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Irradiated fuel fragments, all unspecified forms, fA=0.2, 5 µm");
-            yield return ("Cs-137_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=1E-2, 5 µm");
+            yield return "Cs-137_ing-Insoluble";
+            yield return "Cs-137_ing-Unspecified";
+            yield return "Cs-137_inh-TypeF";
+            yield return "Cs-137_inh-TypeM";
+            yield return "Cs-137_inh-TypeS";
 
-            yield return ("Fe-59_ing",                  /**/"Ingestion, All unspecified forms, fA=0.1");
-            yield return ("Fe-59_inh-TypeF",            /**/"Inhalation, Aerosols Type F, fA=0.1, 5 µm");
-            yield return ("Fe-59_inh-TypeM",            /**/"Inhalation, Aerosols Type M, Ferric chloride, ferric oxide, all unspecified forms, fA=2E-2, 5 µm");
-            yield return ("Fe-59_inh-TypeS",            /**/"Inhalation, Aerosols Type S, Corrosion products, fA=1E-3, 5 µm");
+            yield return "Fe-59_ing";
+            yield return "Fe-59_inh-TypeF";
+            yield return "Fe-59_inh-TypeM";
+            yield return "Fe-59_inh-TypeS";
 
-            yield return ("H-3_ing-Organic",            /**/"Ingestion,  Biogenic forms, fA=0.99");
-            yield return ("H-3_ing-Insoluble",          /**/"Ingestion, Relatively insoluble forms, fA=0.1");
-            yield return ("H-3_ing-Soluble",            /**/"Ingestion, Soluble forms, fA=0.99");
-            yield return ("H-3_inh-TypeF-Gas",          /**/"Inhalation, Gas or vapour Type F, Unspecified , fA=0.99");
-            yield return ("H-3_inh-TypeF-Organic",      /**/"Inhalation, Aerosols Biogenic organic compounds, fA=0.99, 5 µm");
-            yield return ("H-3_inh-TypeF-Tritide",      /**/"Inhalation, Aerosols Type F, LaNiAl tritide, fA=0.99, 5 µm");
-            yield return ("H-3_inh-TypeM",              /**/"Inhalation, Aerosols Type M, All unspecified compounds, glass fragments, luminous paint, titanium tritide, zirconium tritide, fA=0.2, 5 µm");
-            yield return ("H-3_inh-TypeS",              /**/"Inhalation, Aerosols Type S, Carbon tritide, hafnium tritide, fA=1E-2, 5 µm");
+            yield return "H-3_ing-Organic";
+            yield return "H-3_ing-Insoluble";
+            yield return "H-3_ing-Soluble";
+            yield return "H-3_inh-TypeF-Gas";
+            yield return "H-3_inh-TypeF-Organic";
+            yield return "H-3_inh-TypeF-Tritide";
+            yield return "H-3_inh-TypeM";
+            yield return "H-3_inh-TypeS";
 
-            yield return ("I-129_ing",                  /**/"Ingestion, All unspecified forms, fA=0.99");
-            yield return ("I-129_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Sodium iodide, caesium chloride vector, silver iodide, all unspecified forms, fA=0.99, 5 µm");
-            yield return ("I-129_inh-TypeM",            /**/"Inhalation, Aerosols Type M, fA=0.2, 5 µm");
-            yield return ("I-129_inh-TypeS",            /**/"Inhalation, Aerosols Type S, fA=1E-2, 5 µm");
+            yield return "I-129_ing";
+            yield return "I-129_inh-TypeF";
+            yield return "I-129_inh-TypeM";
+            yield return "I-129_inh-TypeS";
 
-            yield return ("Mo-93_ing-Other",            /**/"Ingestion, All other forms, fA=0.9");
-            yield return ("Mo-93_ing-Sulphide",         /**/"Ingestion, Sulphide, fA=5E-2");
-            yield return ("Mo-93_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Chloride and ammonium molybdate, fA=0.9, 5 µm");
-            yield return ("Mo-93_inh-TypeM",            /**/"Inhalation, Aerosols Type M, Oxide and all unspecified forms, fA=0.18, 5 µm");
-            yield return ("Mo-93_inh-TypeS",            /**/"Inhalation, Aerosols Type S, fA=9E-3, 5 µm");
+            yield return "Mo-93_ing-Other";
+            yield return "Mo-93_ing-Sulphide";
+            yield return "Mo-93_inh-TypeF";
+            yield return "Mo-93_inh-TypeM";
+            yield return "Mo-93_inh-TypeS";
 
-            yield return ("Pu-238_ing-Insoluble",       /**/"Ingestion, Insoluble forms: oxides, fA=1E-5");
-            yield return ("Pu-238_ing-Unidentified",    /**/"Ingestion, Soluble forms: nitrate, chloride, bicarbonates, all other unidentified chemical forms, fA=5E-4");
-            yield return ("Pu-238_inh-TypeF",           /**/"Inhalation, Aerosols Type F, fA=5E-4, 5 µm");
-            yield return ("Pu-238_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Plutonium citrate, plutonium tri-butyl-phosphate, plutonium chloride, fA=1E-4, 5 µm");
-            yield return ("Pu-238_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=5E-6, 5 µm");
+            yield return "Pu-238_ing-Insoluble";
+            yield return "Pu-238_ing-Unidentified";
+            yield return "Pu-238_inh-TypeF";
+            yield return "Pu-238_inh-TypeM";
+            yield return "Pu-238_inh-TypeS";
 
-            yield return ("Pu-239_ing-Insoluble",       /**/"Ingestion, Insoluble forms: oxides, fA=1E-5");
-            yield return ("Pu-239_ing-Unidentified",    /**/"Ingestion, Soluble forms: nitrate, chloride, bicarbonates, all other unidentified chemical forms, fA=5E-4");
-            yield return ("Pu-239_inh-TypeF",           /**/"Inhalation, Aerosols Type F, fA=5E-4, 5 µm");
-            yield return ("Pu-239_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Plutonium citrate, plutonium tri-butyl-phosphate, plutonium chloride, fA=1E-4, 5 µm");
-            yield return ("Pu-239_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=5E-6, 5 µm");
-            yield return ("Pu-239_inj",                 /**/"Injection, fA=5E-4");
+            yield return "Pu-239_ing-Insoluble";
+            yield return "Pu-239_ing-Unidentified";
+            yield return "Pu-239_inh-TypeF";
+            yield return "Pu-239_inh-TypeM";
+            yield return "Pu-239_inh-TypeS";
+            yield return "Pu-239_inj";
 
-            yield return ("Pu-240_ing-Insoluble",       /**/"Ingestion, Insoluble forms: oxides, fA=1E-5");
-            yield return ("Pu-240_ing-Unidentified",    /**/"Ingestion, Soluble forms: nitrate, chloride, bicarbonates, all other unidentified chemical forms, fA=5E-4");
-            yield return ("Pu-240_inh-TypeF",           /**/"Inhalation, Aerosols Type F, fA=5E-4, 5 µm");
-            yield return ("Pu-240_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Plutonium citrate, plutonium tri-butyl-phosphate, plutonium chloride, fA=1E-4, 5 µm");
-            yield return ("Pu-240_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=5E-6, 5 µm");
+            yield return "Pu-240_ing-Insoluble";
+            yield return "Pu-240_ing-Unidentified";
+            yield return "Pu-240_inh-TypeF";
+            yield return "Pu-240_inh-TypeM";
+            yield return "Pu-240_inh-TypeS";
 
-            yield return ("Pu-241_ing-Insolube",        /**/"Ingestion, Insoluble forms: oxides, fA=1E-5");
-            yield return ("Pu-241_ing-Unidentified",    /**/"Ingestion, Soluble forms: nitrate, chloride, bicarbonates, all other unidentified chemical forms, fA=5E-4");
-            yield return ("Pu-241_inh-TypeF",           /**/"Inhalation, Aerosols Type F, fA=5E-4, 5 µm");
-            yield return ("Pu-241_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Plutonium citrate, plutonium tri-butyl-phosphate, plutonium chloride, fA=1E-4, 5 µm");
-            yield return ("Pu-241_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=5E-6, 5 µm");
+            yield return "Pu-241_ing-Insolube";
+            yield return "Pu-241_ing-Unidentified";
+            yield return "Pu-241_inh-TypeF";
+            yield return "Pu-241_inh-TypeM";
+            yield return "Pu-241_inh-TypeS";
 
-            yield return ("Pu-242_ing-Insoluble",       /**/"Ingestion, Insoluble forms: oxides, fA=1E-5");
-            yield return ("Pu-242_ing-Unidentified",    /**/"Ingestion, Soluble forms: nitrate, chloride, bicarbonates, all other unidentified chemical forms, fA=5E-4");
-            yield return ("Pu-242_inh-TypeF",           /**/"Inhalation, Aerosols Type F, fA=5E-4, 5 µm");
-            yield return ("Pu-242_inh-TypeM",           /**/"Inhalation, Aerosols Type M, Plutonium citrate, plutonium tri-butyl-phosphate, plutonium chloride, fA=1E-4, 5 µm");
-            yield return ("Pu-242_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=5E-6, 5 µm");
+            yield return "Pu-242_ing-Insoluble";
+            yield return "Pu-242_ing-Unidentified";
+            yield return "Pu-242_inh-TypeF";
+            yield return "Pu-242_inh-TypeM";
+            yield return "Pu-242_inh-TypeS";
 
-            yield return ("Ra-223_inh-TypeF",           /**/"Inhalation, Aerosols Type F, Nitrate, fA=0.2, 5 µm");
+            yield return "Ra-223_inh-TypeF";
 
-            yield return ("Ra-226_ing",                 /**/"Ingestion, All forms, fA=0.2");
-            yield return ("Ra-226_inh-TypeF",           /**/"Inhalation, Aerosols Type F, Nitrate, fA=0.2, 5 µm");
-            yield return ("Ra-226_inh-TypeM",           /**/"Inhalation, Aerosols Type M, All unspecified forms, fA=4E-2, 5 µm");
-            yield return ("Ra-226_inh-TypeS",           /**/"Inhalation, Aerosols Type S, fA=2E-3, 5 µm");
+            yield return "Ra-226_ing";
+            yield return "Ra-226_inh-TypeF";
+            yield return "Ra-226_inh-TypeM";
+            yield return "Ra-226_inh-TypeS";
 
-            yield return ("Sr-90_ing-Titanate",         /**/"Ingestion, Strontium titanate, fA=1E-2");
-            yield return ("Sr-90_ing-Other",            /**/"Ingestion, All other chemical forms, fA=0.25");
-            yield return ("Sr-90_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Strontium chloride, sulphate and carbonate, fA=0.25, 5 µm");
-            yield return ("Sr-90_inh-TypeM",            /**/"Inhalation, Aerosols Type M, Fuel fragments, all unspecified forms, fA=5E-2, 5 µm");
-            yield return ("Sr-90_inh-TypeS",            /**/"Inhalation, Aerosols Type S, FAP, PSL, fA=2.5E-3, 5 µm");
+            yield return "Sr-90_ing-Titanate";
+            yield return "Sr-90_ing-Other";
+            yield return "Sr-90_inh-TypeF";
+            yield return "Sr-90_inh-TypeM";
+            yield return "Sr-90_inh-TypeS";
 
-            yield return ("Tc-99_ing",                  /**/"Ingestion, All forms, fA=0.9");
-            yield return ("Tc-99_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Pertechnetate, Tc-DTPA, fA=0.9, 5 µm");
-            yield return ("Tc-99_inh-TypeM",            /**/"Inhalation, Aerosols Type M, All unspecified forms, fA=0.18, 5 µm");
-            yield return ("Tc-99_inh-TypeS",            /**/"Inhalation, Aerosols Type S, fA=9E-3, 5 µm");
+            yield return "Tc-99_ing";
+            yield return "Tc-99_inh-TypeF";
+            yield return "Tc-99_inh-TypeM";
+            yield return "Tc-99_inh-TypeS";
 
-            yield return ("Zn-65_ing",                  /**/"Ingestion, All forms, fA=0.5");
-            yield return ("Zn-65_inh-TypeF",            /**/"Inhalation, Aerosols Type F, Oxide, chromate, fA=0.5, 5 µm");
-            yield return ("Zn-65_inh-TypeM",            /**/"Inhalation, Aerosols Type M, Nitrate, phosphate, all unspecified compounds, fA=0.1, 5 µm");
-            yield return ("Zn-65_inh-TypeS",            /**/"Inhalation, Aerosols Type S, Corrosion products, fA=5E-3, 5 µm");
+            yield return "Zn-65_ing";
+            yield return "Zn-65_inh-TypeF";
+            yield return "Zn-65_inh-TypeM";
+            yield return "Zn-65_inh-TypeS";
         }
     }
 }

--- a/ResultChecker/Program_Taregts.cs
+++ b/ResultChecker/Program_Taregts.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace ResultChecker
@@ -25,120 +27,22 @@ namespace ResultChecker
         }
 
         /// <summary>
-        /// FlexIDに整備されているインプットを列挙する。
-        /// (核種についてはTargetの名称に含める仕様となっている)
+        /// FlexIDに整備されているインプットのファイルパスを列挙する。
         /// </summary>
         /// <returns></returns>
-        static IEnumerable<string> GetTargets()
+        static IEnumerable<string> GetInputs()
         {
-            yield return "Ba-133_ing-Insoluble";
-            yield return "Ba-133_ing-Soluble";
-            yield return "Ba-133_inh-TypeF";
-            yield return "Ba-133_inh-TypeM";
-            yield return "Ba-133_inh-TypeS";
+            const string baseDir = @"inp\OIR";
 
-            yield return "C-14_ing";
-            yield return "C-14_inh-TypeF";
-            yield return "C-14_inh-TypeF-Barium";
-            yield return "C-14_inh-TypeF-Gas";
-            yield return "C-14_inh-TypeM";
-            yield return "C-14_inh-TypeS";
-
-            yield return "Ca-45_ing";
-            yield return "Ca-45_inh-TypeF";
-            yield return "Ca-45_inh-TypeM";
-            yield return "Ca-45_inh-TypeS";
-
-            yield return "Cs-134_ing-Insoluble";
-            yield return "Cs-134_ing-Unspecified";
-            yield return "Cs-134_inh-TypeF";
-            yield return "Cs-134_inh-TypeM";
-            yield return "Cs-134_inh-TypeS";
-
-            yield return "Cs-137_ing-Insoluble";
-            yield return "Cs-137_ing-Unspecified";
-            yield return "Cs-137_inh-TypeF";
-            yield return "Cs-137_inh-TypeM";
-            yield return "Cs-137_inh-TypeS";
-
-            yield return "Fe-59_ing";
-            yield return "Fe-59_inh-TypeF";
-            yield return "Fe-59_inh-TypeM";
-            yield return "Fe-59_inh-TypeS";
-
-            yield return "H-3_ing-Organic";
-            yield return "H-3_ing-Insoluble";
-            yield return "H-3_ing-Soluble";
-            yield return "H-3_inh-TypeF-Gas";
-            yield return "H-3_inh-TypeF-Organic";
-            yield return "H-3_inh-TypeF-Tritide";
-            yield return "H-3_inh-TypeM";
-            yield return "H-3_inh-TypeS";
-
-            yield return "I-129_ing";
-            yield return "I-129_inh-TypeF";
-            yield return "I-129_inh-TypeM";
-            yield return "I-129_inh-TypeS";
-
-            yield return "Mo-93_ing-Other";
-            yield return "Mo-93_ing-Sulphide";
-            yield return "Mo-93_inh-TypeF";
-            yield return "Mo-93_inh-TypeM";
-            yield return "Mo-93_inh-TypeS";
-
-            yield return "Pu-238_ing-Insoluble";
-            yield return "Pu-238_ing-Unidentified";
-            yield return "Pu-238_inh-TypeF";
-            yield return "Pu-238_inh-TypeM";
-            yield return "Pu-238_inh-TypeS";
-
-            yield return "Pu-239_ing-Insoluble";
-            yield return "Pu-239_ing-Unidentified";
-            yield return "Pu-239_inh-TypeF";
-            yield return "Pu-239_inh-TypeM";
-            yield return "Pu-239_inh-TypeS";
-            yield return "Pu-239_inj";
-
-            yield return "Pu-240_ing-Insoluble";
-            yield return "Pu-240_ing-Unidentified";
-            yield return "Pu-240_inh-TypeF";
-            yield return "Pu-240_inh-TypeM";
-            yield return "Pu-240_inh-TypeS";
-
-            yield return "Pu-241_ing-Insolube";
-            yield return "Pu-241_ing-Unidentified";
-            yield return "Pu-241_inh-TypeF";
-            yield return "Pu-241_inh-TypeM";
-            yield return "Pu-241_inh-TypeS";
-
-            yield return "Pu-242_ing-Insoluble";
-            yield return "Pu-242_ing-Unidentified";
-            yield return "Pu-242_inh-TypeF";
-            yield return "Pu-242_inh-TypeM";
-            yield return "Pu-242_inh-TypeS";
-
-            yield return "Ra-223_inh-TypeF";
-
-            yield return "Ra-226_ing";
-            yield return "Ra-226_inh-TypeF";
-            yield return "Ra-226_inh-TypeM";
-            yield return "Ra-226_inh-TypeS";
-
-            yield return "Sr-90_ing-Titanate";
-            yield return "Sr-90_ing-Other";
-            yield return "Sr-90_inh-TypeF";
-            yield return "Sr-90_inh-TypeM";
-            yield return "Sr-90_inh-TypeS";
-
-            yield return "Tc-99_ing";
-            yield return "Tc-99_inh-TypeF";
-            yield return "Tc-99_inh-TypeM";
-            yield return "Tc-99_inh-TypeS";
-
-            yield return "Zn-65_ing";
-            yield return "Zn-65_inh-TypeF";
-            yield return "Zn-65_inh-TypeM";
-            yield return "Zn-65_inh-TypeS";
+            try
+            {
+                return Directory.EnumerateFiles(baseDir, "*.inp", SearchOption.AllDirectories);
+            }
+            catch (Exception e) when (e is IOException || e is SystemException)
+            {
+                // baseDirが存在しない場合など。
+                return Enumerable.Empty<string>();
+            }
         }
     }
 }

--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -175,7 +175,7 @@ namespace ResultChecker
         static void WriteResultSheet(ExcelWorksheet sheet, Result res)
         {
             var actualActs = GetResultRetentions(res.Target);
-            var expectActs = GetExpectRetentions(res.Target, res.Material);
+            var expectActs = GetExpectRetentions(res.Target, out _);
 
             sheet.Cells[1, 1].Value = res.Target;
 


### PR DESCRIPTION
Close #130 .

各インプットの計算実施後、まず残留放射能について比較実施し、この時に預託線量の期待値を引くためのキーを組み立てる。このキーを使って預託実行線量の比較を行う。

この変更によって、インプットと期待値の対応関係についてハードコードしていた箇所を削除し、これを自動検出する処理に置き換えることができた。