### PR TITLE
核種に対する各インプットの共通化を図る

### DIFF
--- a/resources/inp/OIR/C-14/C-14_ing.inp
+++ b/resources/inp/OIR/C-14/C-14_ing.inp
@@ -12,6 +12,7 @@ C-14 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ C-14 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
@@ -12,6 +12,9 @@ C-14 Inhalation:Type-F_Barium
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ C-14 Inhalation:Type-F_Barium
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ C-14 Inhalation:Type-F_Barium
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model
   acc   ST0                   Other
@@ -55,14 +71,25 @@ C-14 Inhalation:Type-F_Barium
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.53 Table 3.3
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -79,8 +106,21 @@ C-14 Inhalation:Type-F_Barium
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.53 Table 3.3
 #   s_r[/d] = 100  (Inhaled particulate materials, Barium carbonate)
+#   s_s[/d] =   0  (Inhaled particulate materials, Barium carbonate)
   ALV-F                   Blood1                  100
   INT-F                   Blood1                  100
   bb-F                    Blood1                  100
@@ -92,7 +132,21 @@ C-14 Inhalation:Type-F_Barium
   LNET-F                  Blood1                  100
   LNTH-F                  Blood1                  100
 
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
@@ -12,6 +12,9 @@ C-14 Inhalation:Type-F_UnspecifiedGas
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
   acc   LNET-F                LN-ET
@@ -29,6 +33,7 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model
@@ -89,6 +94,9 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   LNTH-F                  Blood0                  100
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
@@ -12,6 +12,9 @@ C-14 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ C-14 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ C-14 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model
@@ -58,14 +74,25 @@ C-14 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.53 Table 3.3
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -82,8 +109,21 @@ C-14 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.53 Table 3.3
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood0                  100
   INT-F                   Blood0                  100
   bb-F                    Blood0                  100
@@ -95,7 +135,21 @@ C-14 Inhalation:Type-F
   LNET-F                  Blood0                  100
   LNTH-F                  Blood0                  100
 
+  ALV-S                   Blood0                    0
+  INT-S                   Blood0                    0
+  bb-S                    Blood0                    0
+  bbseq-S                 Blood0                    0
+  BB-S                    Blood0                    0
+  BBseq-S                 Blood0                    0
+  ET2-S                   Blood0                    0
+  ETseq-S                 Blood0                    0
+  LNET-S                  Blood0                    0
+  LNTH-S                  Blood0                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
@@ -12,6 +12,9 @@ C-14 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ C-14 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ C-14 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model
@@ -78,6 +83,7 @@ C-14 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -86,6 +92,7 @@ C-14 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -140,6 +147,9 @@ C-14 Inhalation:Type-M
   LNTH-S                  Blood0                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
@@ -12,6 +12,9 @@ C-14 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ C-14 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ C-14 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model
@@ -78,6 +83,7 @@ C-14 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -86,6 +92,7 @@ C-14 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -140,6 +147,9 @@ C-14 Inhalation:Type-S
   LNTH-S                  Blood0                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ca-45/Ca-45_ing.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_ing.inp
@@ -12,6 +12,7 @@ Ca-45 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Ca-45 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -42,15 +44,15 @@ Ca-45 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480           #  90.0%
-  Oralcavity              Oesophagus-S            720           #  10.0%
-  Oesophagus-F            St-con                12343           # 100.0%
-  Oesophagus-S            St-con                 2160           # 100.0%
-  St-con                  SI-con                   20.57        # 100.0%
-  SI-con                  RC-con                    6           #  60.0%
-  RC-con                  LC-con                    2           # 100.0%
-  LC-con                  RS-con                    2           # 100.0%
-  RS-con                  Faeces                    2           # 100.0%
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
+  Oesophagus-S            St-con                 2160
+  St-con                  SI-con                   20.57
+  SI-con                  RC-con                    6
+  RC-con                  LC-con                    2
+  LC-con                  RS-con                    2
+  RS-con                  Faeces                    2
 
 # ICRP Publ.134 p.118 Table 6.2
 #   fA = 0.4  (Ingested materials, All unspecified forms)

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
@@ -12,6 +12,9 @@ Ca-45 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ca-45 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ Ca-45 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -53,14 +69,25 @@ Ca-45 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.118 Table 6.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -77,8 +104,21 @@ Ca-45 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.118 Table 6.2
 #   s_r[/d] = 70  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood                    70
   INT-F                   Blood                    70
   bb-F                    Blood                    70
@@ -90,7 +130,21 @@ Ca-45 Inhalation:Type-F
   LNET-F                  Blood                    70
   LNTH-F                  Blood                    70
 
+  ALV-S                   Blood                     0
+  INT-S                   Blood                     0
+  bb-S                    Blood                     0
+  bbseq-S                 Blood                     0
+  BB-S                    Blood                     0
+  BBseq-S                 Blood                     0
+  ET2-S                   Blood                     0
+  ETseq-S                 Blood                     0
+  LNET-S                  Blood                     0
+  LNTH-S                  Blood                     0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
@@ -12,6 +12,9 @@ Ca-45 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ca-45 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ Ca-45 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -73,6 +78,7 @@ Ca-45 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -81,6 +87,7 @@ Ca-45 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -135,6 +142,9 @@ Ca-45 Inhalation:Type-M
   LNTH-S                  Blood                     0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
@@ -12,6 +12,9 @@ Ca-45 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ca-45 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ Ca-45 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -73,6 +78,7 @@ Ca-45 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -81,6 +87,7 @@ Ca-45 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -112,29 +119,32 @@ Ca-45 Inhalation:Type-S
 # ICRP Publ.134 p.118 Table 6.2
 #   s_r[/d] = 3     (Inhaled particulate materials, Absorption type S)
 #   s_s[/d] = 1E-4  (Inhaled particulate materials, Absorption type S)
+  ALV-F                   Blood                     3
+  INT-F                   Blood                     3
+  bb-F                    Blood                     3
+  bbseq-F                 Blood                     3
+  BB-F                    Blood                     3
+  BBseq-F                 Blood                     3
   ET2-F                   Blood                     3
   ETseq-F                 Blood                     3
   LNET-F                  Blood                     3
-  BB-F                    Blood                     3
-  BBseq-F                 Blood                     3
-  bb-F                    Blood                     3
-  bbseq-F                 Blood                     3
-  ALV-F                   Blood                     3
-  INT-F                   Blood                     3
   LNTH-F                  Blood                     3
 
+  ALV-S                   Blood                     1E-4
+  INT-S                   Blood                     1E-4
+  bb-S                    Blood                     1E-4
+  bbseq-S                 Blood                     1E-4
+  BB-S                    Blood                     1E-4
+  BBseq-S                 Blood                     1E-4
   ET2-S                   Blood                     1E-4
   ETseq-S                 Blood                     1E-4
   LNET-S                  Blood                     1E-4
-  BB-S                    Blood                     1E-4
-  BBseq-S                 Blood                     1E-4
-  bb-S                    Blood                     1E-4
-  bbseq-S                 Blood                     1E-4
-  ALV-S                   Blood                     1E-4
-  INT-S                   Blood                     1E-4
   LNTH-S                  Blood                     1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
@@ -12,6 +12,7 @@ Cs-134 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -28,6 +29,7 @@ Cs-134 Ingestion:Insoluble
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
@@ -12,6 +12,7 @@ Cs-134 Ingestion:Unspecified
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -28,6 +29,7 @@ Cs-134 Ingestion:Unspecified
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
@@ -12,6 +12,9 @@ Cs-134 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -26,6 +29,7 @@ Cs-134 Inhalation:Type-F
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -37,7 +41,19 @@ Cs-134 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -69,14 +85,25 @@ Cs-134 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.137 p.142 Table 6.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -93,8 +120,21 @@ Cs-134 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.142 Table 6.2
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Plasma                  100
   INT-F                   Plasma                  100
   bb-F                    Plasma                  100
@@ -106,7 +146,21 @@ Cs-134 Inhalation:Type-F
   LNET-F                  Plasma                  100
   LNTH-F                  Plasma                  100
 
+  ALV-S                   Plasma                    0
+  INT-S                   Plasma                    0
+  bb-S                    Plasma                    0
+  bbseq-S                 Plasma                    0
+  BB-S                    Plasma                    0
+  BBseq-S                 Plasma                    0
+  ET2-S                   Plasma                    0
+  ETseq-S                 Plasma                    0
+  LNET-S                  Plasma                    0
+  LNTH-S                  Plasma                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
@@ -12,6 +12,9 @@ Cs-134 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -26,6 +29,7 @@ Cs-134 Inhalation:Type-M
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +53,7 @@ Cs-134 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -89,6 +94,7 @@ Cs-134 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -97,6 +103,7 @@ Cs-134 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -140,17 +147,20 @@ Cs-134 Inhalation:Type-M
   LNTH-F                  Plasma                    3
 
   ALV-S                   Plasma                    0.005
+  INT-S                   Plasma                    0.005
+  bb-S                    Plasma                    0.005
+  bbseq-S                 Plasma                    0.005
   BB-S                    Plasma                    0.005
   BBseq-S                 Plasma                    0.005
   ET2-S                   Plasma                    0.005
   ETseq-S                 Plasma                    0.005
-  INT-S                   Plasma                    0.005
   LNET-S                  Plasma                    0.005
   LNTH-S                  Plasma                    0.005
-  bb-S                    Plasma                    0.005
-  bbseq-S                 Plasma                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
@@ -12,6 +12,9 @@ Cs-134 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -26,6 +29,7 @@ Cs-134 Inhalation:Type-S
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +53,7 @@ Cs-134 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -89,6 +94,7 @@ Cs-134 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -97,6 +103,7 @@ Cs-134 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -151,6 +158,9 @@ Cs-134 Inhalation:Type-S
   LNTH-S                  Plasma                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
@@ -13,6 +13,7 @@ Cs-137 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -29,6 +30,7 @@ Cs-137 Ingestion:Insoluble
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -165,6 +167,7 @@ Cs-137 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
   acc   Liver                 Liver
@@ -230,6 +233,7 @@ Cs-137 Ingestion:Insoluble
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
@@ -13,6 +13,7 @@ Cs-137 Ingestion:Unspecified
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -29,6 +30,7 @@ Cs-137 Ingestion:Unspecified
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -165,6 +167,7 @@ Cs-137 Ingestion:Unspecified
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
   acc   Liver                 Liver
@@ -230,6 +233,7 @@ Cs-137 Ingestion:Unspecified
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
@@ -13,6 +13,9 @@ Cs-137 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -27,6 +30,7 @@ Cs-137 Inhalation:Type-F
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -38,7 +42,19 @@ Cs-137 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -70,14 +86,25 @@ Cs-137 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.137 p.142 Table 6.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -94,8 +121,21 @@ Cs-137 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.142 Table 6.2
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Plasma                  100
   INT-F                   Plasma                  100
   bb-F                    Plasma                  100
@@ -107,7 +147,21 @@ Cs-137 Inhalation:Type-F
   LNET-F                  Plasma                  100
   LNTH-F                  Plasma                  100
 
+  ALV-S                   Plasma                    0
+  INT-S                   Plasma                    0
+  bb-S                    Plasma                    0
+  bbseq-S                 Plasma                    0
+  BB-S                    Plasma                    0
+  BBseq-S                 Plasma                    0
+  ET2-S                   Plasma                    0
+  ETseq-S                 Plasma                    0
+  LNET-S                  Plasma                    0
+  LNTH-S                  Plasma                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -202,6 +256,8 @@ Cs-137 Inhalation:Type-F
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -209,6 +265,7 @@ Cs-137 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -220,7 +277,19 @@ Cs-137 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
   acc   Liver                 Liver
@@ -275,6 +344,8 @@ Cs-137 Inhalation:Type-F
 #-----------------------+---------------------+--------------
 
 # from parent to progeny
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-F     Oesophagus-F              ---
   Cs-137/Oesophagus-S     Oesophagus-S              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
@@ -284,6 +355,7 @@ Cs-137 Inhalation:Type-F
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -295,6 +367,18 @@ Cs-137 Inhalation:Type-F
   Cs-137/ALV-F            ALV-F                     ---
   Cs-137/INT-F            INT-F                     ---
   Cs-137/LNTH-F           LNTH-F                    ---
+  Cs-137/ET1-S            ET1-S                     ---
+  Cs-137/ET2-S            ET2-S                     ---
+  Cs-137/ETseq-S          ETseq-S                   ---
+  Cs-137/LNET-S           LNET-S                    ---
+  Cs-137/BB-S             BB-S                      ---
+  Cs-137/BBseq-S          BBseq-S                   ---
+  Cs-137/bb-S             bb-S                      ---
+  Cs-137/bbseq-S          bbseq-S                   ---
+  Cs-137/ALV-S            ALV-S                     ---
+  Cs-137/INT-S            INT-S                     ---
+  Cs-137/LNTH-S           LNTH-S                    ---
+
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
@@ -335,8 +419,21 @@ Cs-137 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.168 Table 7.2
 #   s_r[/d] = 20  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Plasma                   20
   INT-F                   Plasma                   20
   bb-F                    Plasma                   20
@@ -348,7 +445,21 @@ Cs-137 Inhalation:Type-F
   LNET-F                  Plasma                   20
   LNTH-F                  Plasma                   20
 
+  ALV-S                   Plasma                    0
+  INT-S                   Plasma                    0
+  bb-S                    Plasma                    0
+  bbseq-S                 Plasma                    0
+  BB-S                    Plasma                    0
+  BBseq-S                 Plasma                    0
+  ET2-S                   Plasma                    0
+  ETseq-S                 Plasma                    0
+  LNET-S                  Plasma                    0
+  LNTH-S                  Plasma                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
@@ -13,6 +13,9 @@ Cs-137 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -27,6 +30,7 @@ Cs-137 Inhalation:Type-M
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -50,6 +54,7 @@ Cs-137 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -90,6 +95,7 @@ Cs-137 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -98,6 +104,7 @@ Cs-137 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -141,17 +148,20 @@ Cs-137 Inhalation:Type-M
   LNTH-F                  Plasma                    3
 
   ALV-S                   Plasma                    0.005
+  INT-S                   Plasma                    0.005
+  bb-S                    Plasma                    0.005
+  bbseq-S                 Plasma                    0.005
   BB-S                    Plasma                    0.005
   BBseq-S                 Plasma                    0.005
   ET2-S                   Plasma                    0.005
   ETseq-S                 Plasma                    0.005
-  INT-S                   Plasma                    0.005
   LNET-S                  Plasma                    0.005
   LNTH-S                  Plasma                    0.005
-  bb-S                    Plasma                    0.005
-  bbseq-S                 Plasma                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -246,6 +256,8 @@ Cs-137 Inhalation:Type-M
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -253,6 +265,7 @@ Cs-137 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -276,6 +289,7 @@ Cs-137 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
   acc   Liver                 Liver
@@ -330,6 +344,8 @@ Cs-137 Inhalation:Type-M
 #-----------------------+---------------------+--------------
 
 # from parent to progeny
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-F     Oesophagus-F              ---
   Cs-137/Oesophagus-S     Oesophagus-S              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
@@ -339,6 +355,7 @@ Cs-137 Inhalation:Type-M
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -361,6 +378,7 @@ Cs-137 Inhalation:Type-M
   Cs-137/ALV-S            ALV-S                     ---
   Cs-137/INT-S            INT-S                     ---
   Cs-137/LNTH-S           LNTH-S                    ---
+
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
@@ -439,6 +457,9 @@ Cs-137 Inhalation:Type-M
   LNTH-S                  Plasma                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
@@ -13,6 +13,9 @@ Cs-137 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
@@ -27,6 +30,7 @@ Cs-137 Inhalation:Type-S
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -50,6 +54,7 @@ Cs-137 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   RBC                   Blood
   acc   Liver                 Liver
@@ -90,6 +95,7 @@ Cs-137 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -98,6 +104,7 @@ Cs-137 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -152,6 +159,9 @@ Cs-137 Inhalation:Type-S
   LNTH-S                  Plasma                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -246,6 +256,8 @@ Cs-137 Inhalation:Type-S
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -253,6 +265,7 @@ Cs-137 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -276,6 +289,7 @@ Cs-137 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
   acc   Liver                 Liver
@@ -330,6 +344,8 @@ Cs-137 Inhalation:Type-S
 #-----------------------+---------------------+--------------
 
 # from parent to progeny
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-F     Oesophagus-F              ---
   Cs-137/Oesophagus-S     Oesophagus-S              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
@@ -339,6 +355,7 @@ Cs-137 Inhalation:Type-S
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -361,6 +378,7 @@ Cs-137 Inhalation:Type-S
   Cs-137/ALV-S            ALV-S                     ---
   Cs-137/INT-S            INT-S                     ---
   Cs-137/LNTH-S           LNTH-S                    ---
+
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
@@ -439,6 +457,9 @@ Cs-137 Inhalation:Type-S
   LNTH-S                  Plasma                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Fe-59/Fe-59_ing.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_ing.inp
@@ -12,6 +12,7 @@ Fe-59 Ingestion:Unspecified
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -22,6 +23,7 @@ Fe-59 Ingestion:Unspecified
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood
   acc   RBC                   Blood
@@ -45,6 +47,7 @@ Fe-59 Ingestion:Unspecified
 
   input                   Oralcavity              100.0%
 
+# ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-F           6480
   Oralcavity              Oesophagus-S            720
   Oesophagus-F            St-con                12343

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
@@ -12,6 +12,9 @@ Fe-59 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Fe-59 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -31,7 +35,19 @@ Fe-59 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood
   acc   RBC                   Blood
@@ -57,14 +73,25 @@ Fe-59 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.136 Table 7.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -81,8 +108,21 @@ Fe-59 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.136 Table 7.2
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   OtherPlasma             100
   INT-F                   OtherPlasma             100
   bb-F                    OtherPlasma             100
@@ -94,7 +134,21 @@ Fe-59 Inhalation:Type-F
   LNET-F                  OtherPlasma             100
   LNTH-F                  OtherPlasma             100
 
+  ALV-S                   OtherPlasma               0
+  INT-S                   OtherPlasma               0
+  bb-S                    OtherPlasma               0
+  bbseq-S                 OtherPlasma               0
+  BB-S                    OtherPlasma               0
+  BBseq-S                 OtherPlasma               0
+  ET2-S                   OtherPlasma               0
+  ETseq-S                 OtherPlasma               0
+  LNET-S                  OtherPlasma               0
+  LNTH-S                  OtherPlasma               0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
@@ -12,6 +12,9 @@ Fe-59 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Fe-59 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -43,6 +47,7 @@ Fe-59 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood
   acc   RBC                   Blood
@@ -139,6 +144,9 @@ Fe-59 Inhalation:Type-M
   LNTH-S                  OtherPlasma               0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
@@ -12,6 +12,9 @@ Fe-59 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Fe-59 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -43,6 +47,7 @@ Fe-59 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood
   acc   RBC                   Blood
@@ -139,6 +144,9 @@ Fe-59 Inhalation:Type-S
   LNTH-S                  OtherPlasma               1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
@@ -12,6 +12,7 @@ H-3 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ H-3 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other

--- a/resources/inp/OIR/H-3/H-3_ing-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Organic.inp
@@ -12,6 +12,7 @@ H-3 Ingestion:Organic
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ H-3 Ingestion:Organic
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other

--- a/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
@@ -12,6 +12,7 @@ H-3 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ H-3 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
@@ -12,6 +12,9 @@ H-3 Inhalation:Type-F_Gas
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ H-3 Inhalation:Type-F_Gas
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
   acc   LNET-F                LN-ET
@@ -29,6 +33,7 @@ H-3 Inhalation:Type-F_Gas
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other
@@ -80,6 +85,9 @@ H-3 Inhalation:Type-F_Gas
   LNTH-F                  Blood                   100
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
@@ -12,6 +12,9 @@ H-3 Inhalation:Type-F_Organic
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ H-3 Inhalation:Type-F_Organic
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ H-3 Inhalation:Type-F_Organic
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   mix   mix-Blood             ---
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
@@ -50,15 +66,26 @@ H-3 Inhalation:Type-F_Organic
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.21 Table 2.3
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
-  input                   Environment              18.04%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
+  input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -74,8 +101,21 @@ H-3 Inhalation:Type-F_Organic
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.21 Table 2.3
 #   s_r[/d] = 100  (Inhaled particulate materials, Biogenic organic compounds)
+#   s_s[/d] =   0  (Inhaled particulate materials, Biogenic organic compounds)
   ALV-F                   mix-Blood               100
   INT-F                   mix-Blood               100
   bb-F                    mix-Blood               100
@@ -87,7 +127,21 @@ H-3 Inhalation:Type-F_Organic
   LNET-F                  mix-Blood               100
   LNTH-F                  mix-Blood               100
 
+  ALV-S                   mix-Blood                 0
+  INT-S                   mix-Blood                 0
+  bb-S                    mix-Blood                 0
+  bbseq-S                 mix-Blood                 0
+  BB-S                    mix-Blood                 0
+  BBseq-S                 mix-Blood                 0
+  ET2-S                   mix-Blood                 0
+  ETseq-S                 mix-Blood                 0
+  LNET-S                  mix-Blood                 0
+  LNTH-S                  mix-Blood                 0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
@@ -12,6 +12,9 @@ H-3 Inhalation:Type-F_LaNiAlTritide
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other
@@ -49,14 +65,25 @@ H-3 Inhalation:Type-F_LaNiAlTritide
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.21 Table 2.3
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -73,8 +100,21 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.21 Table 2.3
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood                   100
   INT-F                   Blood                   100
   bb-F                    Blood                   100
@@ -86,7 +126,21 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   LNET-F                  Blood                   100
   LNTH-F                  Blood                   100
 
+  ALV-S                   Blood                     0
+  INT-S                   Blood                     0
+  bb-S                    Blood                     0
+  bbseq-S                 Blood                     0
+  BB-S                    Blood                     0
+  BBseq-S                 Blood                     0
+  ET2-S                   Blood                     0
+  ETseq-S                 Blood                     0
+  LNET-S                  Blood                     0
+  LNTH-S                  Blood                     0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
@@ -12,6 +12,9 @@ H-3 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ H-3 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ H-3 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other
@@ -69,6 +74,7 @@ H-3 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -77,6 +83,7 @@ H-3 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -131,6 +138,9 @@ H-3 Inhalation:Type-M
   LNTH-S                  Blood                     0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
@@ -12,6 +12,9 @@ H-3 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ H-3 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ H-3 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
   acc   OBT1                  Other
@@ -69,6 +74,7 @@ H-3 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -77,6 +83,7 @@ H-3 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -131,6 +138,9 @@ H-3 Inhalation:Type-S
   LNTH-S                  Blood                     1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/I-129/I-129_ing.inp
+++ b/resources/inp/OIR/I-129/I-129_ing.inp
@@ -12,6 +12,7 @@ I-129 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
   acc   Oesophagus-f          Oesophag-f
@@ -26,6 +27,7 @@ I-129 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   Liver1                Liver

--- a/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
@@ -12,7 +12,10 @@ I-129 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -24,6 +27,7 @@ I-129 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -35,7 +39,19 @@ I-129 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   Liver1                Liver
@@ -61,14 +77,25 @@ I-129 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.137 p.97 Table 5.3
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -85,8 +112,21 @@ I-129 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.97 Table 5.3
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood1                  100
   INT-F                   Blood1                  100
   bb-F                    Blood1                  100
@@ -98,7 +138,21 @@ I-129 Inhalation:Type-F
   LNET-F                  Blood1                  100
   LNTH-F                  Blood1                  100
 
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
@@ -12,7 +12,10 @@ I-129 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -24,6 +27,7 @@ I-129 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -47,6 +51,7 @@ I-129 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   Liver1                Liver
@@ -81,6 +86,7 @@ I-129 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -89,6 +95,7 @@ I-129 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -143,6 +150,9 @@ I-129 Inhalation:Type-M
   LNTH-S                  Blood1                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
@@ -12,7 +12,10 @@ I-129 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -24,6 +27,7 @@ I-129 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -47,6 +51,7 @@ I-129 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   Liver1                Liver
@@ -81,6 +86,7 @@ I-129 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -89,6 +95,7 @@ I-129 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -143,6 +150,9 @@ I-129 Inhalation:Type-S
   LNTH-S                  Blood1                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
@@ -23,7 +23,6 @@ Mo-93 Ingestion:Other
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
@@ -23,7 +23,6 @@ Mo-93 Ingestion:Sulphide
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
@@ -25,8 +25,21 @@ Mo-93 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -34,7 +47,6 @@ Mo-93 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -54,14 +66,25 @@ Mo-93 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.305 Table 14.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -78,8 +101,21 @@ Mo-93 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.305 Table 14.2
 #   s_r[/d] = 30  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood1                   30
   INT-F                   Blood1                   30
   bb-F                    Blood1                   30
@@ -91,7 +127,21 @@ Mo-93 Inhalation:Type-F
   LNET-F                  Blood1                   30
   LNTH-F                  Blood1                   30
 
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -136,8 +186,21 @@ Mo-93 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -185,8 +248,21 @@ Mo-93 Inhalation:Type-F
   Mo-93/ALV-F             ALV-F                     ---
   Mo-93/INT-F             INT-F                     ---
   Mo-93/LNTH-F            LNTH-F                    ---
+  Mo-93/ET1-S             ET1-S                     ---
+  Mo-93/ET2-S             ET2-S                     ---
+  Mo-93/ETseq-S           ETseq-S                   ---
+  Mo-93/LNET-S            LNET-S                    ---
+  Mo-93/BB-S              BB-S                      ---
+  Mo-93/BBseq-S           BBseq-S                   ---
+  Mo-93/bb-S              bb-S                      ---
+  Mo-93/bbseq-S           bbseq-S                   ---
+  Mo-93/ALV-S             ALV-S                     ---
+  Mo-93/INT-S             INT-S                     ---
+  Mo-93/LNTH-S            LNTH-S                    ---
   Mo-93/Environment       Environment               ---
 
+  Mo-93/Oralcavity        Oralcavity                ---
+  Mo-93/Oesophagus-F      Oesophagus-F              ---
   Mo-93/Oesophagus-S      Oesophagus-S              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
@@ -246,6 +322,18 @@ Mo-93 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.45 Para.37
 #   For all radionuclides with the exception of noble gases:
 #   • The parameter values (s_r, s_s) describing absorption of the inhaled parent from the
@@ -254,6 +342,7 @@ Mo-93 Inhalation:Type-F
 #
 # ICRP Publ.134 p.305 Table 14.2(Molybdenium)
 #   s_r[/d] = 30  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood1                   30
   INT-F                   Blood1                   30
   bb-F                    Blood1                   30
@@ -265,7 +354,21 @@ Mo-93 Inhalation:Type-F
   LNET-F                  Blood1                   30
   LNTH-F                  Blood1                   30
 
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
@@ -38,6 +38,8 @@ Mo-93 Inhalation:Type-M
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -45,7 +47,6 @@ Mo-93 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -74,6 +75,7 @@ Mo-93 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -82,6 +84,7 @@ Mo-93 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -136,6 +139,9 @@ Mo-93 Inhalation:Type-M
   LNTH-S                  Blood1                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -193,6 +199,8 @@ Mo-93 Inhalation:Type-M
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -253,6 +261,8 @@ Mo-93 Inhalation:Type-M
   Mo-93/LNTH-S            LNTH-S                    ---
   Mo-93/Environment       Environment               ---
 
+  Mo-93/Oralcavity        Oralcavity                ---
+  Mo-93/Oesophagus-F      Oesophagus-F              ---
   Mo-93/Oesophagus-S      Oesophagus-S              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
@@ -356,6 +366,9 @@ Mo-93 Inhalation:Type-M
   LNTH-S                  Blood1                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
@@ -38,6 +38,8 @@ Mo-93 Inhalation:Type-S
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -45,7 +47,6 @@ Mo-93 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -74,6 +75,7 @@ Mo-93 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -82,6 +84,7 @@ Mo-93 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -136,6 +139,9 @@ Mo-93 Inhalation:Type-S
   LNTH-S                  Blood1                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
@@ -193,6 +199,8 @@ Mo-93 Inhalation:Type-S
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -253,6 +261,8 @@ Mo-93 Inhalation:Type-S
   Mo-93/LNTH-S            LNTH-S                    ---
   Mo-93/Environment       Environment               ---
 
+  Mo-93/Oralcavity        Oralcavity                ---
+  Mo-93/Oesophagus-F      Oesophagus-F              ---
   Mo-93/Oesophagus-S      Oesophagus-S              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
@@ -356,6 +366,9 @@ Mo-93 Inhalation:Type-S
   LNTH-S                  Blood1                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
@@ -12,6 +12,7 @@ Pu-238 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-238 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
@@ -12,6 +12,7 @@ Pu-238 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-238 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
@@ -12,6 +12,9 @@ Pu-238 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-238 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,6 +34,17 @@ Pu-238 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   acc   ET2-B                 ET2-sur
   acc   ETseq-B               ET2-seq
   acc   LNET-B                LN-ET
@@ -41,6 +56,7 @@ Pu-238 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -71,14 +87,25 @@ Pu-238 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.141 p.337 Table 22.11
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -95,14 +122,29 @@ Pu-238 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.67 Fig.3.5
 # ICRP Publ.130 p.68 Para.107
 # ICRP Publ.141 p.337 Table 22.11 & footnote*
 #   s_r[/d] = 0.4    (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] = 0      (Inhaled particulate materials, Absorption type F)
 #   f_b[/d] = 0.002
 #   s_b[/d] = 0                             (HRTM-B to blood)
 #      fb  * s_r = 0.002 * 0.4 = 0.0008     (HRTM-F to HRTM-B)
+#      fb  * s_s = 0.002 * 0   = 0          (HRTM-S to HRTM-B)
 #   (1-fb) * s_r = 0.998 * 0.4 = 0.3992     (HRTM-F to blood)
+#   (1-fb) * s_s = 0.998 * 0   = 0          (HRTM-S to blood)
 #
   ALV-F                   ALV-B                     0.0008
   INT-F                   INT-B                     0.0008
@@ -115,6 +157,17 @@ Pu-238 Inhalation:Type-F
   LNET-F                  LNET-B                    0.0008
   LNTH-F                  LNTH-B                    0.0008
 
+  ALV-S                   ALV-B                     0
+  INT-S                   INT-B                     0
+  bb-S                    bb-B                      0
+  bbseq-S                 bbseq-B                   0
+  BB-S                    BB-B                      0
+  BBseq-S                 BBseq-B                   0
+  ET2-S                   ET2-B                     0
+  ETseq-S                 ETseq-B                   0
+  LNET-S                  LNET-B                    0
+  LNTH-S                  LNTH-B                    0
+
   ALV-F                   Blood1                    0.3992
   INT-F                   Blood1                    0.3992
   bb-F                    Blood1                    0.3992
@@ -125,6 +178,17 @@ Pu-238 Inhalation:Type-F
   ETseq-F                 Blood1                    0.3992
   LNET-F                  Blood1                    0.3992
   LNTH-F                  Blood1                    0.3992
+
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
 
   ALV-B                   Blood1                    0
   INT-B                   Blood1                    0
@@ -138,6 +202,9 @@ Pu-238 Inhalation:Type-F
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
@@ -12,6 +12,9 @@ Pu-238 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-238 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-238 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-238 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-238 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-238 Inhalation:Type-M
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
@@ -12,6 +12,9 @@ Pu-238 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-238 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-238 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-238 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-238 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-238 Inhalation:Type-S
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
@@ -12,6 +12,7 @@ Pu-239 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-239 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
@@ -12,6 +12,7 @@ Pu-239 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-239 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
@@ -12,6 +12,9 @@ Pu-239 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-239 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,6 +34,17 @@ Pu-239 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   acc   ET2-B                 ET2-sur
   acc   ETseq-B               ET2-seq
   acc   LNET-B                LN-ET
@@ -41,6 +56,7 @@ Pu-239 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -71,14 +87,25 @@ Pu-239 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.141 p.337 Table 22.11
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -95,14 +122,29 @@ Pu-239 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.67 Fig.3.5
 # ICRP Publ.130 p.68 Para.107
 # ICRP Publ.141 p.337 Table 22.11 & footnote*
 #   s_r[/d] = 0.4    (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] = 0      (Inhaled particulate materials, Absorption type F)
 #   f_b[/d] = 0.002
 #   s_b[/d] = 0                             (HRTM-B to blood)
 #      fb  * s_r = 0.002 * 0.4 = 0.0008     (HRTM-F to HRTM-B)
+#      fb  * s_s = 0.002 * 0   = 0          (HRTM-S to HRTM-B)
 #   (1-fb) * s_r = 0.998 * 0.4 = 0.3992     (HRTM-F to blood)
+#   (1-fb) * s_s = 0.998 * 0   = 0          (HRTM-S to blood)
 #
   ALV-F                   ALV-B                     0.0008
   INT-F                   INT-B                     0.0008
@@ -115,6 +157,17 @@ Pu-239 Inhalation:Type-F
   LNET-F                  LNET-B                    0.0008
   LNTH-F                  LNTH-B                    0.0008
 
+  ALV-S                   ALV-B                     0
+  INT-S                   INT-B                     0
+  bb-S                    bb-B                      0
+  bbseq-S                 bbseq-B                   0
+  BB-S                    BB-B                      0
+  BBseq-S                 BBseq-B                   0
+  ET2-S                   ET2-B                     0
+  ETseq-S                 ETseq-B                   0
+  LNET-S                  LNET-B                    0
+  LNTH-S                  LNTH-B                    0
+
   ALV-F                   Blood1                    0.3992
   INT-F                   Blood1                    0.3992
   bb-F                    Blood1                    0.3992
@@ -125,6 +178,17 @@ Pu-239 Inhalation:Type-F
   ETseq-F                 Blood1                    0.3992
   LNET-F                  Blood1                    0.3992
   LNTH-F                  Blood1                    0.3992
+
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
 
   ALV-B                   Blood1                    0
   INT-B                   Blood1                    0
@@ -138,6 +202,9 @@ Pu-239 Inhalation:Type-F
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
@@ -12,6 +12,9 @@ Pu-239 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-239 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-239 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-239 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-239 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-239 Inhalation:Type-M
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
@@ -12,6 +12,9 @@ Pu-239 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-239 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-239 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-239 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-239 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-239 Inhalation:Type-S
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-239/Pu-239_inj.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inj.inp
@@ -12,11 +12,17 @@ Pu-239 Injection
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
+  acc   Oesophagus-S          Oesophag-s
+  acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood0                Blood
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -47,6 +53,11 @@ Pu-239 Injection
   input                   Blood0                  100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
+  Oesophagus-S            St-con                 2160
+  St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
   LC-con                  RS-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
@@ -12,6 +12,7 @@ Pu-240 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-240 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -59,6 +61,7 @@ Pu-240 Ingestion:Insoluble
   RC-con                  LC-con                    2
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
+
 # ICRP Publ.141 p.337 Table 22.11
 #   fA = 1E-5   (Ingested materials, Insoluble forms)
 #   λ(SI->Blood) = fA*λ(SI->RC)/(1-fA) = 1E-5 * 6 / (1 - 1E-5) = 6.000060000600006E-5

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
@@ -12,6 +12,7 @@ Pu-240 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-240 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
@@ -12,6 +12,9 @@ Pu-240 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-240 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,6 +34,17 @@ Pu-240 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   acc   ET2-B                 ET2-sur
   acc   ETseq-B               ET2-seq
   acc   LNET-B                LN-ET
@@ -41,6 +56,7 @@ Pu-240 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -71,14 +87,25 @@ Pu-240 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.141 p.337 Table 22.11
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -95,14 +122,29 @@ Pu-240 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.67 Fig.3.5
 # ICRP Publ.130 p.68 Para.107
 # ICRP Publ.141 p.337 Table 22.11 & footnote*
 #   s_r[/d] = 0.4    (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] = 0      (Inhaled particulate materials, Absorption type F)
 #   f_b[/d] = 0.002
 #   s_b[/d] = 0                             (HRTM-B to blood)
 #      fb  * s_r = 0.002 * 0.4 = 0.0008     (HRTM-F to HRTM-B)
+#      fb  * s_s = 0.002 * 0   = 0          (HRTM-S to HRTM-B)
 #   (1-fb) * s_r = 0.998 * 0.4 = 0.3992     (HRTM-F to blood)
+#   (1-fb) * s_s = 0.998 * 0   = 0          (HRTM-S to blood)
 #
   ALV-F                   ALV-B                     0.0008
   INT-F                   INT-B                     0.0008
@@ -115,6 +157,17 @@ Pu-240 Inhalation:Type-F
   LNET-F                  LNET-B                    0.0008
   LNTH-F                  LNTH-B                    0.0008
 
+  ALV-S                   ALV-B                     0
+  INT-S                   INT-B                     0
+  bb-S                    bb-B                      0
+  bbseq-S                 bbseq-B                   0
+  BB-S                    BB-B                      0
+  BBseq-S                 BBseq-B                   0
+  ET2-S                   ET2-B                     0
+  ETseq-S                 ETseq-B                   0
+  LNET-S                  LNET-B                    0
+  LNTH-S                  LNTH-B                    0
+
   ALV-F                   Blood1                    0.3992
   INT-F                   Blood1                    0.3992
   bb-F                    Blood1                    0.3992
@@ -125,6 +178,17 @@ Pu-240 Inhalation:Type-F
   ETseq-F                 Blood1                    0.3992
   LNET-F                  Blood1                    0.3992
   LNTH-F                  Blood1                    0.3992
+
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
 
   ALV-B                   Blood1                    0
   INT-B                   Blood1                    0
@@ -138,6 +202,9 @@ Pu-240 Inhalation:Type-F
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
@@ -12,6 +12,9 @@ Pu-240 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-240 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-240 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-240 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-240 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-240 Inhalation:Type-M
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
@@ -12,6 +12,9 @@ Pu-240 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-240 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-240 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-240 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-240 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-240 Inhalation:Type-S
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
@@ -12,6 +12,7 @@ Pu-241 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-241 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
@@ -12,6 +12,7 @@ Pu-241 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-241 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
@@ -12,6 +12,9 @@ Pu-241 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-241 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,6 +34,17 @@ Pu-241 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   acc   ET2-B                 ET2-sur
   acc   ETseq-B               ET2-seq
   acc   LNET-B                LN-ET
@@ -41,6 +56,7 @@ Pu-241 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -71,14 +87,25 @@ Pu-241 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.141 p.337 Table 22.11
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -95,14 +122,29 @@ Pu-241 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.67 Fig.3.5
 # ICRP Publ.130 p.68 Para.107
 # ICRP Publ.141 p.337 Table 22.11 & footnote*
 #   s_r[/d] = 0.4    (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] = 0      (Inhaled particulate materials, Absorption type F)
 #   f_b[/d] = 0.002
 #   s_b[/d] = 0                             (HRTM-B to blood)
 #      fb  * s_r = 0.002 * 0.4 = 0.0008     (HRTM-F to HRTM-B)
+#      fb  * s_s = 0.002 * 0   = 0          (HRTM-S to HRTM-B)
 #   (1-fb) * s_r = 0.998 * 0.4 = 0.3992     (HRTM-F to blood)
+#   (1-fb) * s_s = 0.998 * 0   = 0          (HRTM-S to blood)
 #
   ALV-F                   ALV-B                     0.0008
   INT-F                   INT-B                     0.0008
@@ -115,6 +157,17 @@ Pu-241 Inhalation:Type-F
   LNET-F                  LNET-B                    0.0008
   LNTH-F                  LNTH-B                    0.0008
 
+  ALV-S                   ALV-B                     0
+  INT-S                   INT-B                     0
+  bb-S                    bb-B                      0
+  bbseq-S                 bbseq-B                   0
+  BB-S                    BB-B                      0
+  BBseq-S                 BBseq-B                   0
+  ET2-S                   ET2-B                     0
+  ETseq-S                 ETseq-B                   0
+  LNET-S                  LNET-B                    0
+  LNTH-S                  LNTH-B                    0
+
   ALV-F                   Blood1                    0.3992
   INT-F                   Blood1                    0.3992
   bb-F                    Blood1                    0.3992
@@ -125,6 +178,17 @@ Pu-241 Inhalation:Type-F
   ETseq-F                 Blood1                    0.3992
   LNET-F                  Blood1                    0.3992
   LNTH-F                  Blood1                    0.3992
+
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
 
   ALV-B                   Blood1                    0
   INT-B                   Blood1                    0
@@ -138,6 +202,9 @@ Pu-241 Inhalation:Type-F
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
@@ -12,6 +12,9 @@ Pu-241 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-241 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-241 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-241 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-241 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-241 Inhalation:Type-M
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
@@ -12,6 +12,9 @@ Pu-241 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-241 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-241 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-241 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-241 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-241 Inhalation:Type-S
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
@@ -12,6 +12,7 @@ Pu-242 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-242 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
@@ -12,6 +12,7 @@ Pu-242 Ingestion:Soluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Pu-242 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
@@ -12,6 +12,9 @@ Pu-242 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-242 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,6 +34,17 @@ Pu-242 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   acc   ET2-B                 ET2-sur
   acc   ETseq-B               ET2-seq
   acc   LNET-B                LN-ET
@@ -41,6 +56,7 @@ Pu-242 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -71,14 +87,25 @@ Pu-242 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.141 p.337 Table 22.11
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -95,14 +122,29 @@ Pu-242 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.130 p.67 Fig.3.5
 # ICRP Publ.130 p.68 Para.107
 # ICRP Publ.141 p.337 Table 22.11 & footnote*
 #   s_r[/d] = 0.4    (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] = 0      (Inhaled particulate materials, Absorption type F)
 #   f_b[/d] = 0.002
 #   s_b[/d] = 0                             (HRTM-B to blood)
 #      fb  * s_r = 0.002 * 0.4 = 0.0008     (HRTM-F to HRTM-B)
+#      fb  * s_s = 0.002 * 0   = 0          (HRTM-S to HRTM-B)
 #   (1-fb) * s_r = 0.998 * 0.4 = 0.3992     (HRTM-F to blood)
+#   (1-fb) * s_s = 0.998 * 0   = 0          (HRTM-S to blood)
 #
   ALV-F                   ALV-B                     0.0008
   INT-F                   INT-B                     0.0008
@@ -115,6 +157,17 @@ Pu-242 Inhalation:Type-F
   LNET-F                  LNET-B                    0.0008
   LNTH-F                  LNTH-B                    0.0008
 
+  ALV-S                   ALV-B                     0
+  INT-S                   INT-B                     0
+  bb-S                    bb-B                      0
+  bbseq-S                 bbseq-B                   0
+  BB-S                    BB-B                      0
+  BBseq-S                 BBseq-B                   0
+  ET2-S                   ET2-B                     0
+  ETseq-S                 ETseq-B                   0
+  LNET-S                  LNET-B                    0
+  LNTH-S                  LNTH-B                    0
+
   ALV-F                   Blood1                    0.3992
   INT-F                   Blood1                    0.3992
   bb-F                    Blood1                    0.3992
@@ -125,6 +178,17 @@ Pu-242 Inhalation:Type-F
   ETseq-F                 Blood1                    0.3992
   LNET-F                  Blood1                    0.3992
   LNTH-F                  Blood1                    0.3992
+
+  ALV-S                   Blood1                    0
+  INT-S                   Blood1                    0
+  bb-S                    Blood1                    0
+  bbseq-S                 Blood1                    0
+  BB-S                    Blood1                    0
+  BBseq-S                 Blood1                    0
+  ET2-S                   Blood1                    0
+  ETseq-S                 Blood1                    0
+  LNET-S                  Blood1                    0
+  LNTH-S                  Blood1                    0
 
   ALV-B                   Blood1                    0
   INT-B                   Blood1                    0
@@ -138,6 +202,9 @@ Pu-242 Inhalation:Type-F
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
@@ -12,6 +12,9 @@ Pu-242 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-242 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-242 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-242 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-242 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-242 Inhalation:Type-M
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
@@ -12,6 +12,9 @@ Pu-242 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Pu-242 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -52,6 +56,7 @@ Pu-242 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -91,6 +96,7 @@ Pu-242 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -99,6 +105,7 @@ Pu-242 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -195,6 +202,9 @@ Pu-242 Inhalation:Type-S
   LNTH-B                  Blood1                    0
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
@@ -12,6 +12,9 @@ Ra-223 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ra-223 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ Ra-223 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -57,14 +73,25 @@ Ra-223 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.137 p.325 Table 13.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -81,8 +108,21 @@ Ra-223 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.325 Table 13.2
 #   s_r[/d] = 10  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood                    10
   INT-F                   Blood                    10
   bb-F                    Blood                    10
@@ -94,7 +134,21 @@ Ra-223 Inhalation:Type-F
   LNET-F                  Blood                    10
   LNTH-F                  Blood                    10
 
+  ALV-S                   Blood                     0
+  INT-S                   Blood                     0
+  bb-S                    Blood                     0
+  bbseq-S                 Blood                     0
+  BB-S                    Blood                     0
+  BBseq-S                 Blood                     0
+  ET2-S                   Blood                     0
+  ETseq-S                 Blood                     0
+  LNET-S                  Blood                     0
+  LNTH-S                  Blood                     0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ra-226/Ra-226_ing.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_ing.inp
@@ -12,6 +12,7 @@ Ra-226 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -21,6 +22,7 @@ Ra-226 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -46,15 +48,15 @@ Ra-226 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480           #  90.0%
-  Oralcavity              Oesophagus-S            720           #  10.0%
-  Oesophagus-F            St-con                12343           # 100.0%
-  Oesophagus-S            St-con                 2160           # 100.0%
-  St-con                  SI-con                   20.57        # 100.0%
-  SI-con                  RC-con                    6           #  80.0%
-  RC-con                  LC-con                    2           # 100.0%
-  LC-con                  RS-con                    2           # 100.0%
-  RS-con                  Faeces                    2           # 100.0%
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
+  Oesophagus-S            St-con                 2160
+  St-con                  SI-con                   20.57
+  SI-con                  RC-con                    6
+  RC-con                  LC-con                    2
+  LC-con                  RS-con                    2
+  RS-con                  Faeces                    2
 
 # ICRP Publ.137 p.325 Table 13.2
 #   fA = 0.2   (Ingested materials, All forms)

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
@@ -12,6 +12,9 @@ Ra-226 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ra-226 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -30,7 +34,19 @@ Ra-226 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -57,14 +73,25 @@ Ra-226 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.137 p.325 Table 13.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -81,8 +108,21 @@ Ra-226 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.137 p.325 Table 13.2
 #   s_r[/d] = 10  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood                    10
   INT-F                   Blood                    10
   bb-F                    Blood                    10
@@ -94,7 +134,21 @@ Ra-226 Inhalation:Type-F
   LNET-F                  Blood                    10
   LNTH-F                  Blood                    10
 
+  ALV-S                   Blood                     0
+  INT-S                   Blood                     0
+  bb-S                    Blood                     0
+  bbseq-S                 Blood                     0
+  BB-S                    Blood                     0
+  BBseq-S                 Blood                     0
+  ET2-S                   Blood                     0
+  ETseq-S                 Blood                     0
+  LNET-S                  Blood                     0
+  LNTH-S                  Blood                     0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
@@ -12,6 +12,9 @@ Ra-226 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ra-226 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ Ra-226 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -77,6 +82,7 @@ Ra-226 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -85,6 +91,7 @@ Ra-226 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -139,6 +146,9 @@ Ra-226 Inhalation:Type-M
   LNTH-S                  Blood                     0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
@@ -12,6 +12,9 @@ Ra-226 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -19,6 +22,7 @@ Ra-226 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -42,6 +46,7 @@ Ra-226 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -77,6 +82,7 @@ Ra-226 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -85,6 +91,7 @@ Ra-226 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -139,6 +146,9 @@ Ra-226 Inhalation:Type-S
   LNTH-S                  Blood                     1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Tc-99/Tc-99_ing.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_ing.inp
@@ -27,6 +27,7 @@ Tc-99 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Blood                 Blood
   acc   Liver1                Liver
   acc   Liver2                Liver
@@ -52,6 +53,7 @@ Tc-99 Ingestion
 
   input                   Oralcavity              100.0%
 
+# ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720
   Oesophagus-f            St-con                12343

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
@@ -12,7 +12,10 @@ Tc-99 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -25,6 +28,7 @@ Tc-99 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -36,7 +40,19 @@ Tc-99 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   Liver1                Liver
   acc   Liver2                Liver
@@ -64,14 +80,25 @@ Tc-99 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.322 Table 15.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -88,8 +115,21 @@ Tc-99 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.322 Table 15.2
 #   s_r[/d] = 100  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =   0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Blood                   100
   INT-F                   Blood                   100
   bb-F                    Blood                   100
@@ -101,7 +141,21 @@ Tc-99 Inhalation:Type-F
   LNET-F                  Blood                   100
   LNTH-F                  Blood                   100
 
+  ALV-S                   Blood                     0
+  INT-S                   Blood                     0
+  bb-S                    Blood                     0
+  bbseq-S                 Blood                     0
+  BB-S                    Blood                     0
+  BBseq-S                 Blood                     0
+  ET2-S                   Blood                     0
+  ETseq-S                 Blood                     0
+  LNET-S                  Blood                     0
+  LNTH-S                  Blood                     0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
@@ -12,7 +12,10 @@ Tc-99 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -25,6 +28,7 @@ Tc-99 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +52,7 @@ Tc-99 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   Liver1                Liver
   acc   Liver2                Liver
@@ -84,6 +89,7 @@ Tc-99 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -92,6 +98,7 @@ Tc-99 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -146,6 +153,9 @@ Tc-99 Inhalation:Type-M
   LNTH-S                  Blood                     0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
@@ -12,7 +12,10 @@ Tc-99 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
   acc   Oesophagus-sRe        Oesophag-s
   acc   St-wall               St-wall
@@ -25,6 +28,7 @@ Tc-99 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +52,7 @@ Tc-99 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Blood                 Blood
   acc   Liver1                Liver
   acc   Liver2                Liver
@@ -84,6 +89,7 @@ Tc-99 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -92,6 +98,7 @@ Tc-99 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -146,6 +153,9 @@ Tc-99 Inhalation:Type-S
   LNTH-S                  Blood                     1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
   Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Zn-65/Zn-65_ing.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_ing.inp
@@ -12,6 +12,7 @@ Zn-65 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
@@ -22,6 +23,7 @@ Zn-65 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   Plasma                Blood
   acc   ST0                   Other
   acc   ST1                   Other

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
@@ -12,6 +12,9 @@ Zn-65 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Zn-65 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -31,7 +35,19 @@ Zn-65 Inhalation:Type-F
   acc   ALV-F                 ALV
   acc   INT-F                 ALV
   acc   LNTH-F                LN-Th
+  acc   ET1-S                 ET1-sur
+  acc   ET2-S                 ET2-sur
+  acc   ETseq-S               ET2-seq
+  acc   LNET-S                LN-ET
+  acc   BB-S                  Bronchi
+  acc   BBseq-S               Bronchi-q
+  acc   bb-S                  Brchiole
+  acc   bbseq-S               Brchiole-q
+  acc   ALV-S                 ALV
+  acc   INT-S                 ALV
+  acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -59,14 +75,25 @@ Zn-65 Inhalation:Type-F
 # ICRP Publ.130 p.65 Fig.3.4 footnote
 # ICRP Publ.134 p.186 Table 9.2
 #     f_r = 1 (100%)
-  input                   ET1-F                    47.94%       # =          47.94%
-  input                   ET2-F                    25.76836%    # = 99.8% of 25.82%
-  input                   ETseq-F                   0.05164%    # =  0.2% of 25.82%
-  input                   BB-F                      1.77644%    # = 99.8% of  1.78%
-  input                   BBseq-F                   0.00356%    # =  0.2% of  1.78%
-  input                   bb-F                      1.0978%     # = 99.8% of  1.10%
-  input                   bbseq-F                   0.0022%     # =  0.2% of  1.10%
-  input                   ALV-F                     5.32%       # =           5.32%
+# 1 - f_r = 0   (0%)
+  input                   ET1-F                    47.94%       # = 100% of          47.94%
+  input                   ET2-F                    25.76836%    # = 100% of 99.8% of 25.82%
+  input                   ETseq-F                   0.05164%    # = 100% of  0.2% of 25.82%
+  input                   BB-F                      1.77644%    # = 100% of 99.8% of  1.78%
+  input                   BBseq-F                   0.00356%    # = 100% of  0.2% of  1.78%
+  input                   bb-F                      1.0978%     # = 100% of 99.8% of  1.10%
+  input                   bbseq-F                   0.0022%     # = 100% of  0.2% of  1.10%
+  input                   ALV-F                     5.32%       # = 100% of           5.32%
+
+  input                   ET1-S                     0.0%        # =   0%          of 47.94%
+  input                   ET2-S                     0.0%        # =   0% of 99.8% of 25.82%
+  input                   ETseq-S                   0.0%        # =   0% of  0.2% of 25.82%
+  input                   BB-S                      0.0%        # =   0% of 99.8% of  1.78%
+  input                   BBseq-S                   0.0%        # =   0% of  0.2% of  1.78%
+  input                   bb-S                      0.0%        # =   0% of 99.8% of  1.10%
+  input                   bbseq-S                   0.0%        # =   0% of  0.2% of  1.10%
+  input                   ALV-S                     0.0%        # =   0%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -83,8 +110,21 @@ Zn-65 Inhalation:Type-F
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
 
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-S            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
 # ICRP Publ.134 p.186 Table 9.2
 #   s_r[/d] = 30  (Inhaled particulate materials, Absorption type F)
+#   s_s[/d] =  0  (Inhaled particulate materials, Absorption type F)
   ALV-F                   Plasma                   30
   INT-F                   Plasma                   30
   bb-F                    Plasma                   30
@@ -96,7 +136,21 @@ Zn-65 Inhalation:Type-F
   LNET-F                  Plasma                   30
   LNTH-F                  Plasma                   30
 
+  ALV-S                   Plasma                    0
+  INT-S                   Plasma                    0
+  bb-S                    Plasma                    0
+  bbseq-S                 Plasma                    0
+  BB-S                    Plasma                    0
+  BBseq-S                 Plasma                    0
+  ET2-S                   Plasma                    0
+  ETseq-S                 Plasma                    0
+  LNET-S                  Plasma                    0
+  LNTH-S                  Plasma                    0
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
@@ -12,6 +12,9 @@ Zn-65 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Zn-65 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -43,6 +47,7 @@ Zn-65 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -79,6 +84,7 @@ Zn-65 Inhalation:Type-M
   input                   bb-F                      0.21956%    # = 20% of 99.8% of  1.10%
   input                   bbseq-F                   0.00044%    # = 20% of  0.2% of  1.10%
   input                   ALV-F                     1.064%      # = 20%          of  5.32%
+
   input                   ET1-S                    38.352%      # = 80%          of 47.94%
   input                   ET2-S                    20.614688%   # = 80% of 99.8% of 25.82%
   input                   ETseq-S                   0.041312%   # = 80% of  0.2% of 25.82%
@@ -87,6 +93,7 @@ Zn-65 Inhalation:Type-M
   input                   bb-S                      0.87824%    # = 80% of 99.8% of  1.10%
   input                   bbseq-S                   0.00176%    # = 80% of  0.2% of  1.10%
   input                   ALV-S                     4.256%      # = 80%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -141,6 +148,9 @@ Zn-65 Inhalation:Type-M
   LNTH-S                  Plasma                    0.005
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
@@ -12,6 +12,9 @@ Zn-65 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-F          Oesophag-f
   acc   Oesophagus-S          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
@@ -20,6 +23,7 @@ Zn-65 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -43,6 +47,7 @@ Zn-65 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
   acc   Plasma                Blood
   acc   ST0                   Other
   acc   ST1                   Other
@@ -79,6 +84,7 @@ Zn-65 Inhalation:Type-S
   input                   bb-F                      0.010978%   # =  1% of 99.8% of  1.10%
   input                   bbseq-F                   0.000022%   # =  1% of  0.2% of  1.10%
   input                   ALV-F                     0.0532%     # =  1%          of  5.32%
+
   input                   ET1-S                    47.4606%     # = 99%          of 47.94%
   input                   ET2-S                    25.5106764%  # = 99% of 99.8% of 25.82%
   input                   ETseq-S                   0.0511236%  # = 99% of  0.2% of 25.82%
@@ -87,6 +93,7 @@ Zn-65 Inhalation:Type-S
   input                   bb-S                      1.086822%   # = 99% of 99.8% of  1.10%
   input                   bbseq-S                   0.002178%   # = 99% of  0.2% of  1.10%
   input                   ALV-S                     5.2668%     # = 99%          of  5.32%
+
   input                   Environment              18.04%       # = 100% - 81.96%
 
 # ICRP Publ.130 p.65 Fig.3.4
@@ -141,6 +148,9 @@ Zn-65 Inhalation:Type-S
   LNTH-S                  Plasma                    1E-4
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
+  Oralcavity              Oesophagus-F           6480
+  Oralcavity              Oesophagus-S            720
+  Oesophagus-F            St-con                12343
   Oesophagus-S            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6


### PR DESCRIPTION
Issue #137 (PR #138)にて実装した機能を前提に、OIRのインプットについて以下の変更を実施する。

- 吸入摂取Type-F,M,Sのインプットにおいて、経口摂取と同様にOralcavityから始まるHATMのコンパートメントを全て定義する。
- 吸入摂取Type-Fのインプットにおいて、HRTMの遅い吸収を定義するコンパートメント群をType-M,Sと同様に定義する。

この変更がResultCheckerによる計算結果(outファイル)に差異が生じないことを確認している。