### PR TITLE
OIRインプットについてコンパートメントや移行経路の定義順を調整

### DIFF
--- a/resources/inp/OIR/Ba-133/Ba-133_ing-Insoluble.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Ba-133 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -48,10 +48,10 @@ Ba-133 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ba-133/Ba-133_ing-Insoluble.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_ing-Insoluble.inp
@@ -22,6 +22,8 @@ Ba-133 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other
@@ -33,8 +35,6 @@ Ba-133 Ingestion:Insoluble
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ba-133:transfer]
 #-----------------------+---------------------+--------------
@@ -61,6 +61,9 @@ Ba-133 Ingestion:Insoluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.175 Table 7.3
   Plasma                  UB-con                    2.24
   Plasma                  RC-con                   20.16
@@ -82,6 +85,3 @@ Ba-133 Ingestion:Insoluble
   Exch-C-bone-V           Noch-C-bone-V             0.0042
   Noch-C-bone-V           Plasma                    0.0000821
   Noch-T-bone-V           Plasma                    0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ba-133/Ba-133_ing-Soluble.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_ing-Soluble.inp
@@ -22,6 +22,8 @@ Ba-133 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other
@@ -33,8 +35,6 @@ Ba-133 Ingestion:Soluble
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ba-133:transfer]
 #-----------------------+---------------------+--------------
@@ -61,6 +61,9 @@ Ba-133 Ingestion:Soluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.175 Table 7.3
   Plasma                  UB-con                    2.24
   Plasma                  RC-con                   20.16
@@ -82,6 +85,3 @@ Ba-133 Ingestion:Soluble
   Exch-C-bone-V           Noch-C-bone-V             0.0042
   Noch-C-bone-V           Plasma                    0.0000821
   Noch-T-bone-V           Plasma                    0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ba-133/Ba-133_ing-Soluble.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_ing-Soluble.inp
@@ -14,8 +14,8 @@ Ba-133 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -48,10 +48,10 @@ Ba-133 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
@@ -22,6 +22,8 @@ Ba-133 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ba-133 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ba-133:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ba-133 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.175 Table 7.3
   Plasma                  UB-con                    2.24
   Plasma                  RC-con                   20.16
@@ -176,6 +179,3 @@ Ba-133 Inhalation:Type-F
   Exch-C-bone-V           Noch-C-bone-V             0.0042
   Noch-C-bone-V           Plasma                    0.0000821
   Noch-T-bone-V           Plasma                    0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
@@ -14,8 +14,8 @@ Ba-133 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ba-133 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ba-133 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ba-133 Inhalation:Type-F
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeF.inp
@@ -13,18 +13,6 @@ Ba-133 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ba-133 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
@@ -13,18 +13,6 @@ Ba-133 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ba-133 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
@@ -14,8 +14,8 @@ Ba-133 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ba-133 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ba-133 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ba-133 Inhalation:Type-M
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeM.inp
@@ -22,6 +22,8 @@ Ba-133 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ba-133 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ba-133:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ba-133 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.175 Table 7.3
   Plasma                  UB-con                    2.24
   Plasma                  RC-con                   20.16
@@ -176,6 +179,3 @@ Ba-133 Inhalation:Type-M
   Exch-C-bone-V           Noch-C-bone-V             0.0042
   Noch-C-bone-V           Plasma                    0.0000821
   Noch-T-bone-V           Plasma                    0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
@@ -14,8 +14,8 @@ Ba-133 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ba-133 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ba-133 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ba-133 Inhalation:Type-S
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
@@ -22,6 +22,8 @@ Ba-133 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ba-133 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ba-133:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ba-133 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.175 Table 7.3
   Plasma                  UB-con                    2.24
   Plasma                  RC-con                   20.16
@@ -176,6 +179,3 @@ Ba-133 Inhalation:Type-S
   Exch-C-bone-V           Noch-C-bone-V             0.0042
   Noch-C-bone-V           Plasma                    0.0000821
   Noch-T-bone-V           Plasma                    0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
+++ b/resources/inp/OIR/Ba-133/Ba-133_inh-TypeS.inp
@@ -13,18 +13,6 @@ Ba-133 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ba-133 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/C-14/C-14_ing.inp
+++ b/resources/inp/OIR/C-14/C-14_ing.inp
@@ -14,8 +14,8 @@ C-14 Ingestion
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -53,10 +53,10 @@ C-14 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/C-14/C-14_ing.inp
+++ b/resources/inp/OIR/C-14/C-14_ing.inp
@@ -22,6 +22,8 @@ C-14 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model
@@ -38,8 +40,6 @@ C-14 Ingestion
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -65,6 +65,9 @@ C-14 Ingestion
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood0                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2
@@ -100,6 +103,3 @@ C-14 Ingestion
   Sys-Tis(short)          Blood0                    0.0924
   Sys-Tis(short)          RC-con                    0.0693
   Sys-Tis(long)           Blood1                    0.0099
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
@@ -13,18 +13,6 @@ C-14 Inhalation:Type-F_Barium
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ C-14 Inhalation:Type-F_Barium
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood         # CO2 model
   acc   Blood2                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
@@ -14,8 +14,8 @@ C-14 Inhalation:Type-F_Barium
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -104,7 +104,7 @@ C-14 Inhalation:Type-F_Barium
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -116,7 +116,7 @@ C-14 Inhalation:Type-F_Barium
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -144,10 +144,10 @@ C-14 Inhalation:Type-F_Barium
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Barium.inp
@@ -22,6 +22,8 @@ C-14 Inhalation:Type-F_Barium
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -59,8 +61,6 @@ C-14 Inhalation:Type-F_Barium
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -157,6 +157,9 @@ C-14 Inhalation:Type-F_Barium
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2
   Blood1                  Excreta(skin)             0.3
@@ -182,6 +185,3 @@ C-14 Inhalation:Type-F_Barium
   C-bone-S                Blood1                    0.01733
   T-bone-V                Blood1                    0.000493
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
@@ -14,8 +14,8 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -82,7 +82,7 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
 
   ALV-F                   Blood0                $sr
@@ -97,10 +97,10 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   LNTH-F                  Blood0                $sr
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
@@ -13,6 +13,17 @@ C-14 Inhalation:Type-F_UnspecifiedGas
 #-----+---------------------+---------------
   inp   input                 ---
 
+  acc   ET2-F                 ET2-sur
+  acc   ETseq-F               ET2-seq
+  acc   LNET-F                LN-ET
+  acc   BB-F                  Bronchi
+  acc   BBseq-F               Bronchi-q
+  acc   bb-F                  Brchiole
+  acc   bbseq-F               Brchiole-q
+  acc   ALV-F                 ALV
+  acc   INT-F                 ALV
+  acc   LNTH-F                LN-Th
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
@@ -24,17 +35,6 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   exc   Faeces                ---
   acc   UB-con                UB-cont
   exc   Urine                 ---
-
-  acc   ET2-F                 ET2-sur
-  acc   ETseq-F               ET2-seq
-  acc   LNET-F                LN-ET
-  acc   BB-F                  Bronchi
-  acc   BBseq-F               Bronchi-q
-  acc   bb-F                  Brchiole
-  acc   bbseq-F               Brchiole-q
-  acc   ALV-F                 ALV
-  acc   INT-F                 ALV
-  acc   LNTH-F                LN-Th
 
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF-Gas.inp
@@ -22,6 +22,8 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,8 +51,6 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -110,6 +110,9 @@ C-14 Inhalation:Type-F_UnspecifiedGas
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood0                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2
   Blood1                  Excreta(skin)             0.3
@@ -144,6 +147,3 @@ C-14 Inhalation:Type-F_UnspecifiedGas
   Sys-Tis(short)          Blood0                    0.0924
   Sys-Tis(short)          RC-con                    0.0693
   Sys-Tis(long)           Blood1                    0.0099
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
@@ -22,6 +22,8 @@ C-14 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -62,8 +64,6 @@ C-14 Inhalation:Type-F
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -160,6 +160,9 @@ C-14 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood0                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2
   Blood1                  Excreta(skin)             0.3
@@ -194,6 +197,3 @@ C-14 Inhalation:Type-F
   Sys-Tis(short)          Blood0                    0.0924
   Sys-Tis(short)          RC-con                    0.0693
   Sys-Tis(long)           Blood1                    0.0099
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
@@ -13,18 +13,6 @@ C-14 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ C-14 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeF.inp
@@ -14,8 +14,8 @@ C-14 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -107,7 +107,7 @@ C-14 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ C-14 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ C-14 Inhalation:Type-F
   LNTH-S                  Blood0                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
@@ -14,8 +14,8 @@ C-14 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -107,7 +107,7 @@ C-14 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ C-14 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ C-14 Inhalation:Type-M
   LNTH-S                  Blood0                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
@@ -13,18 +13,6 @@ C-14 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ C-14 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeM.inp
@@ -22,6 +22,8 @@ C-14 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -62,8 +64,6 @@ C-14 Inhalation:Type-M
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -157,11 +157,11 @@ C-14 Inhalation:Type-M
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood0                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
@@ -13,18 +13,6 @@ C-14 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ C-14 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood0                Blood         # Generic model
   acc   Blood1                Blood         # CO2 model

--- a/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
@@ -22,6 +22,8 @@ C-14 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -62,8 +64,6 @@ C-14 Inhalation:Type-S
   acc   T-bone-V              T-bone-V
   exc   Exhalation            ---
   exc   Excreta(skin)         ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [C-14:transfer]
 #-----------------------+---------------------+--------------
@@ -157,11 +157,11 @@ C-14 Inhalation:Type-S
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood0                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.66 Table 3.5
   Blood1                  Exhalation               36.2

--- a/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
+++ b/resources/inp/OIR/C-14/C-14_inh-TypeS.inp
@@ -14,8 +14,8 @@ C-14 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -107,7 +107,7 @@ C-14 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ C-14 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ C-14 Inhalation:Type-S
   LNTH-S                  Blood0                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ca-45/Ca-45_ing.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_ing.inp
@@ -14,8 +14,8 @@ Ca-45 Ingestion
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -48,10 +48,10 @@ Ca-45 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ca-45/Ca-45_ing.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_ing.inp
@@ -22,6 +22,8 @@ Ca-45 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other
@@ -33,8 +35,6 @@ Ca-45 Ingestion
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ca-45:transfer]
 #-----------------------+---------------------+--------------
@@ -61,6 +61,9 @@ Ca-45 Ingestion
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.121 Table 6.3
   Blood                   UB-con                    0.60
   Blood                   RC-con                    0.45
@@ -82,6 +85,3 @@ Ca-45 Ingestion
   Exch-C-bone-V           Noch-C-bone-V             0.004159
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
@@ -22,6 +22,8 @@ Ca-45 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ca-45 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ca-45:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ca-45 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.121 Table 6.3
   Blood                   UB-con                    0.60
   Blood                   RC-con                    0.45
@@ -176,6 +179,3 @@ Ca-45 Inhalation:Type-F
   Exch-C-bone-V           Noch-C-bone-V             0.004159
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
@@ -14,8 +14,8 @@ Ca-45 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ca-45 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ca-45 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ca-45 Inhalation:Type-F
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeF.inp
@@ -13,18 +13,6 @@ Ca-45 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ca-45 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
@@ -14,8 +14,8 @@ Ca-45 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ca-45 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ca-45 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ca-45 Inhalation:Type-M
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
@@ -22,6 +22,8 @@ Ca-45 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ca-45 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ca-45:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ca-45 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.121 Table 6.3
   Blood                   UB-con                    0.60
   Blood                   RC-con                    0.45
@@ -176,6 +179,3 @@ Ca-45 Inhalation:Type-M
   Exch-C-bone-V           Noch-C-bone-V             0.004159
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeM.inp
@@ -13,18 +13,6 @@ Ca-45 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ca-45 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
@@ -13,18 +13,6 @@ Ca-45 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ca-45 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
@@ -14,8 +14,8 @@ Ca-45 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -102,7 +102,7 @@ Ca-45 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -114,7 +114,7 @@ Ca-45 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -142,10 +142,10 @@ Ca-45 Inhalation:Type-S
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
+++ b/resources/inp/OIR/Ca-45/Ca-45_inh-TypeS.inp
@@ -22,6 +22,8 @@ Ca-45 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -57,8 +59,6 @@ Ca-45 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ca-45:transfer]
 #-----------------------+---------------------+--------------
@@ -155,6 +155,9 @@ Ca-45 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.121 Table 6.3
   Blood                   UB-con                    0.60
   Blood                   RC-con                    0.45
@@ -176,6 +179,3 @@ Ca-45 Inhalation:Type-S
   Exch-C-bone-V           Noch-C-bone-V             0.004159
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
@@ -29,6 +29,8 @@ Cs-134 Ingestion:Insoluble
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -49,8 +51,6 @@ Cs-134 Ingestion:Insoluble
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-134:transfer]
 #-----------------------+---------------------+--------------
@@ -81,6 +81,9 @@ Cs-134 Ingestion:Insoluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
@@ -145,6 +148,3 @@ Cs-134 Ingestion:Insoluble
   RS-wall                 RS-con                    0.21
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Cs-134 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -65,10 +65,10 @@ Cs-134 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
@@ -29,6 +29,8 @@ Cs-134 Ingestion:Unspecified
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -49,8 +51,6 @@ Cs-134 Ingestion:Unspecified
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-134:transfer]
 #-----------------------+---------------------+--------------
@@ -81,6 +81,9 @@ Cs-134 Ingestion:Unspecified
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
@@ -145,6 +148,3 @@ Cs-134 Ingestion:Unspecified
   RS-wall                 RS-con                    0.21
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_ing-Unspecified.inp
@@ -14,8 +14,8 @@ Cs-134 Ingestion:Unspecified
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -65,10 +65,10 @@ Cs-134 Ingestion:Unspecified
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
@@ -13,25 +13,6 @@ Cs-134 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -55,6 +36,25 @@ Cs-134 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
@@ -14,8 +14,8 @@ Cs-134 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -119,7 +119,7 @@ Cs-134 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -131,7 +131,7 @@ Cs-134 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -159,10 +159,10 @@ Cs-134 Inhalation:Type-F
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeF.inp
@@ -29,6 +29,8 @@ Cs-134 Inhalation:Type-F
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -73,8 +75,6 @@ Cs-134 Inhalation:Type-F
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-134:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Cs-134 Inhalation:Type-F
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -239,6 +242,3 @@ Cs-134 Inhalation:Type-F
   RS-wall                 RS-con                    0.21
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
@@ -13,25 +13,6 @@ Cs-134 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -55,6 +36,25 @@ Cs-134 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
@@ -29,6 +29,8 @@ Cs-134 Inhalation:Type-M
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -73,8 +75,6 @@ Cs-134 Inhalation:Type-M
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-134:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Cs-134 Inhalation:Type-M
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -239,6 +242,3 @@ Cs-134 Inhalation:Type-M
   RS-wall                 RS-con                    0.21
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeM.inp
@@ -14,8 +14,8 @@ Cs-134 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -119,7 +119,7 @@ Cs-134 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -131,7 +131,7 @@ Cs-134 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -159,10 +159,10 @@ Cs-134 Inhalation:Type-M
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
@@ -13,25 +13,6 @@ Cs-134 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -55,6 +36,25 @@ Cs-134 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
@@ -14,8 +14,8 @@ Cs-134 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -119,7 +119,7 @@ Cs-134 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -131,7 +131,7 @@ Cs-134 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -159,10 +159,10 @@ Cs-134 Inhalation:Type-S
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-134/Cs-134_inh-TypeS.inp
@@ -29,6 +29,8 @@ Cs-134 Inhalation:Type-S
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -73,8 +75,6 @@ Cs-134 Inhalation:Type-S
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-134:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Cs-134 Inhalation:Type-S
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -239,6 +242,3 @@ Cs-134 Inhalation:Type-S
   RS-wall                 RS-con                    0.21
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
@@ -30,6 +30,8 @@ Cs-137 Ingestion:Insoluble
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -50,8 +52,6 @@ Cs-137 Ingestion:Insoluble
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-137:transfer]
 #-----------------------+---------------------+--------------
@@ -82,6 +82,9 @@ Cs-137 Ingestion:Insoluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
@@ -147,9 +150,6 @@ Cs-137 Ingestion:Insoluble
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Ba-137m:compartment]
 #-----+---------------------| S-Coefficient
@@ -164,6 +164,8 @@ Cs-137 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
@@ -185,8 +187,6 @@ Cs-137 Ingestion:Insoluble
   acc   T-bone-S              T-bone-S
   acc   C-bone-S              C-bone-S
   acc   Other                 Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   acc   Cartilage             Cartilage
   acc   Exch-T-bone-V         T-bone-V
   acc   Exch-C-bone-V         C-bone-V
@@ -233,12 +233,12 @@ Cs-137 Ingestion:Insoluble
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
   Cs-137/RBC              Dec-RBC                   ---
   Cs-137/SkeletalMuscle   Dec-Muscle                ---
   Cs-137/St-wall          Dec-St-wall               ---
@@ -273,6 +273,9 @@ Cs-137 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.152-154 Para.317
   # > Barium produced in skeletal muscle and red blood cells transfers to plasma at the
@@ -392,6 +395,3 @@ Cs-137 Ingestion:Insoluble
   Exch-C-bone-V           Noch-C-bone-V             0.042       #  30.2158% of 0.139/d  # 0.0042 = 30.2158% of 0.0139の間違いか？
   Noch-C-bone-V           Plasma                    4.93E-4     # 100.0%                # 0.0000821 の間違いか？
   Noch-T-bone-V           Plasma                    8.21E-5     # 100.0%                # 0.000493 の間違いか？
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Insoluble.inp
@@ -15,8 +15,8 @@ Cs-137 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -66,10 +66,10 @@ Cs-137 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -156,8 +156,8 @@ Cs-137 Ingestion:Insoluble
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -223,8 +223,8 @@ Cs-137 Ingestion:Insoluble
 
 # from parent to progeny
   Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-F     Oesophagus-F              ---
-  Cs-137/Oesophagus-S     Oesophagus-S              ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
   Cs-137/SI-con           SI-con                    ---
@@ -261,10 +261,10 @@ Cs-137 Ingestion:Insoluble
   Cs-137/Other2           Dec-Other2                ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
@@ -30,6 +30,8 @@ Cs-137 Ingestion:Unspecified
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -50,8 +52,6 @@ Cs-137 Ingestion:Unspecified
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-137:transfer]
 #-----------------------+---------------------+--------------
@@ -82,6 +82,9 @@ Cs-137 Ingestion:Unspecified
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
@@ -147,9 +150,6 @@ Cs-137 Ingestion:Unspecified
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Ba-137m:compartment]
 #-----+---------------------| S-Coefficient
@@ -164,6 +164,8 @@ Cs-137 Ingestion:Unspecified
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
@@ -185,8 +187,6 @@ Cs-137 Ingestion:Unspecified
   acc   T-bone-S              T-bone-S
   acc   C-bone-S              C-bone-S
   acc   Other                 Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   acc   Cartilage             Cartilage
   acc   Exch-T-bone-V         T-bone-V
   acc   Exch-C-bone-V         C-bone-V
@@ -233,12 +233,12 @@ Cs-137 Ingestion:Unspecified
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
   Cs-137/RBC              Dec-RBC                   ---
   Cs-137/SkeletalMuscle   Dec-Muscle                ---
   Cs-137/St-wall          Dec-St-wall               ---
@@ -273,6 +273,9 @@ Cs-137 Ingestion:Unspecified
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.152-154 Para.317
   # > Barium produced in skeletal muscle and red blood cells transfers to plasma at the
@@ -392,6 +395,3 @@ Cs-137 Ingestion:Unspecified
   Exch-C-bone-V           Noch-C-bone-V             0.042       #  30.2158% of 0.139/d  # 0.0042 = 30.2158% of 0.0139の間違いか？
   Noch-C-bone-V           Plasma                    4.93E-4     # 100.0%                # 0.0000821 の間違いか？
   Noch-T-bone-V           Plasma                    8.21E-5     # 100.0%                # 0.000493 の間違いか？
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_ing-Unspecified.inp
@@ -15,8 +15,8 @@ Cs-137 Ingestion:Unspecified
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -66,10 +66,10 @@ Cs-137 Ingestion:Unspecified
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -156,8 +156,8 @@ Cs-137 Ingestion:Unspecified
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -223,8 +223,8 @@ Cs-137 Ingestion:Unspecified
 
 # from parent to progeny
   Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-F     Oesophagus-F              ---
-  Cs-137/Oesophagus-S     Oesophagus-S              ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
   Cs-137/SI-con           SI-con                    ---
@@ -261,10 +261,10 @@ Cs-137 Ingestion:Unspecified
   Cs-137/Other2           Dec-Other2                ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
@@ -14,25 +14,6 @@ Cs-137 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -56,6 +37,25 @@ Cs-137 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -249,18 +249,6 @@ Cs-137 Inhalation:Type-F
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -284,6 +272,18 @@ Cs-137 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
@@ -342,20 +342,6 @@ Cs-137 Inhalation:Type-F
   $fA = 0.2
 
 # from parent to progeny
-  Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-f     Oesophagus-f              ---
-  Cs-137/Oesophagus-s     Oesophagus-s              ---
-  Cs-137/St-con           St-con                    ---
-  Cs-137/St-conRe         St-con                    ---
-  Cs-137/SI-con           SI-con                    ---
-  Cs-137/SI-conRe         SI-con                    ---
-  Cs-137/RC-con           RC-con                    ---
-  Cs-137/LC-con           LC-con                    ---
-  Cs-137/RS-con           RS-con                    ---
-  Cs-137/Faeces           Faeces                    ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
-
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -378,6 +364,20 @@ Cs-137 Inhalation:Type-F
   Cs-137/ALV-S            ALV-S                     ---
   Cs-137/INT-S            INT-S                     ---
   Cs-137/LNTH-S           LNTH-S                    ---
+
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
+  Cs-137/St-con           St-con                    ---
+  Cs-137/St-conRe         St-con                    ---
+  Cs-137/SI-con           SI-con                    ---
+  Cs-137/SI-conRe         SI-con                    ---
+  Cs-137/RC-con           RC-con                    ---
+  Cs-137/LC-con           LC-con                    ---
+  Cs-137/RS-con           RS-con                    ---
+  Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
@@ -30,6 +30,8 @@ Cs-137 Inhalation:Type-F
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -74,8 +76,6 @@ Cs-137 Inhalation:Type-F
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-137:transfer]
 #-----------------------+---------------------+--------------
@@ -177,6 +177,9 @@ Cs-137 Inhalation:Type-F
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -241,9 +244,6 @@ Cs-137 Inhalation:Type-F
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Ba-137m:compartment]
 #-----+---------------------| S-Coefficient
@@ -258,6 +258,8 @@ Cs-137 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -303,8 +305,6 @@ Cs-137 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   C-bone-S              C-bone-S
   acc   Other                 Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   acc   Cartilage             Cartilage
   acc   Exch-T-bone-V         T-bone-V
   acc   Exch-C-bone-V         C-bone-V
@@ -353,6 +353,8 @@ Cs-137 Inhalation:Type-F
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
@@ -380,8 +382,6 @@ Cs-137 Inhalation:Type-F
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
   Cs-137/RBC              Dec-RBC                   ---
   Cs-137/SkeletalMuscle   Dec-Muscle                ---
   Cs-137/St-wall          Dec-St-wall               ---
@@ -464,6 +464,9 @@ Cs-137 Inhalation:Type-F
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.152-154 Para.317
   # > Barium produced in skeletal muscle and red blood cells transfers to plasma at the
@@ -583,6 +586,3 @@ Cs-137 Inhalation:Type-F
   Exch-C-bone-V           Noch-C-bone-V             0.042       #  30.2158% of 0.139/d  # 0.0042 = 30.2158% of 0.0139の間違いか？
   Noch-C-bone-V           Plasma                    4.93E-4     # 100.0%                # 0.0000821 の間違いか？
   Noch-T-bone-V           Plasma                    8.21E-5     # 100.0%                # 0.000493 の間違いか？
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeF.inp
@@ -15,8 +15,8 @@ Cs-137 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -120,7 +120,7 @@ Cs-137 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -132,7 +132,7 @@ Cs-137 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -160,10 +160,10 @@ Cs-137 Inhalation:Type-F
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -250,8 +250,8 @@ Cs-137 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -343,8 +343,8 @@ Cs-137 Inhalation:Type-F
 
 # from parent to progeny
   Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-F     Oesophagus-F              ---
-  Cs-137/Oesophagus-S     Oesophagus-S              ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
   Cs-137/SI-con           SI-con                    ---
@@ -412,7 +412,7 @@ Cs-137 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -424,7 +424,7 @@ Cs-137 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -452,10 +452,10 @@ Cs-137 Inhalation:Type-F
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
@@ -14,25 +14,6 @@ Cs-137 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -56,6 +37,25 @@ Cs-137 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -249,18 +249,6 @@ Cs-137 Inhalation:Type-M
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -284,6 +272,18 @@ Cs-137 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
@@ -342,20 +342,6 @@ Cs-137 Inhalation:Type-M
   $fA = 0.04
 
 # from parent to progeny
-  Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-f     Oesophagus-f              ---
-  Cs-137/Oesophagus-s     Oesophagus-s              ---
-  Cs-137/St-con           St-con                    ---
-  Cs-137/St-conRe         St-con                    ---
-  Cs-137/SI-con           SI-con                    ---
-  Cs-137/SI-conRe         SI-con                    ---
-  Cs-137/RC-con           RC-con                    ---
-  Cs-137/LC-con           LC-con                    ---
-  Cs-137/RS-con           RS-con                    ---
-  Cs-137/Faeces           Faeces                    ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
-
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -378,6 +364,20 @@ Cs-137 Inhalation:Type-M
   Cs-137/ALV-S            ALV-S                     ---
   Cs-137/INT-S            INT-S                     ---
   Cs-137/LNTH-S           LNTH-S                    ---
+
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
+  Cs-137/St-con           St-con                    ---
+  Cs-137/St-conRe         St-con                    ---
+  Cs-137/SI-con           SI-con                    ---
+  Cs-137/SI-conRe         SI-con                    ---
+  Cs-137/RC-con           RC-con                    ---
+  Cs-137/LC-con           LC-con                    ---
+  Cs-137/RS-con           RS-con                    ---
+  Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
@@ -30,6 +30,8 @@ Cs-137 Inhalation:Type-M
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -74,8 +76,6 @@ Cs-137 Inhalation:Type-M
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-137:transfer]
 #-----------------------+---------------------+--------------
@@ -177,6 +177,9 @@ Cs-137 Inhalation:Type-M
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -241,9 +244,6 @@ Cs-137 Inhalation:Type-M
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Ba-137m:compartment]
 #-----+---------------------| S-Coefficient
@@ -258,6 +258,8 @@ Cs-137 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -303,8 +305,6 @@ Cs-137 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   C-bone-S              C-bone-S
   acc   Other                 Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   acc   Cartilage             Cartilage
   acc   Exch-T-bone-V         T-bone-V
   acc   Exch-C-bone-V         C-bone-V
@@ -353,6 +353,8 @@ Cs-137 Inhalation:Type-M
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
@@ -380,8 +382,6 @@ Cs-137 Inhalation:Type-M
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
   Cs-137/RBC              Dec-RBC                   ---
   Cs-137/SkeletalMuscle   Dec-Muscle                ---
   Cs-137/St-wall          Dec-St-wall               ---
@@ -464,6 +464,9 @@ Cs-137 Inhalation:Type-M
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.152-154 Para.317
   # > Barium produced in skeletal muscle and red blood cells transfers to plasma at the
@@ -583,6 +586,3 @@ Cs-137 Inhalation:Type-M
   Exch-C-bone-V           Noch-C-bone-V             0.042       #  30.2158% of 0.139/d  # 0.0042 = 30.2158% of 0.0139の間違いか？
   Noch-C-bone-V           Plasma                    4.93E-4     # 100.0%                # 0.0000821 の間違いか？
   Noch-T-bone-V           Plasma                    8.21E-5     # 100.0%                # 0.000493 の間違いか？
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeM.inp
@@ -15,8 +15,8 @@ Cs-137 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -120,7 +120,7 @@ Cs-137 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -132,7 +132,7 @@ Cs-137 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -160,10 +160,10 @@ Cs-137 Inhalation:Type-M
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -250,8 +250,8 @@ Cs-137 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -343,8 +343,8 @@ Cs-137 Inhalation:Type-M
 
 # from parent to progeny
   Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-F     Oesophagus-F              ---
-  Cs-137/Oesophagus-S     Oesophagus-S              ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
   Cs-137/SI-con           SI-con                    ---
@@ -412,7 +412,7 @@ Cs-137 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -424,7 +424,7 @@ Cs-137 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -452,10 +452,10 @@ Cs-137 Inhalation:Type-M
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
@@ -15,8 +15,8 @@ Cs-137 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-wall               St-wall
   acc   St-con                St-cont
   acc   St-conRe              St-cont
@@ -120,7 +120,7 @@ Cs-137 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -132,7 +132,7 @@ Cs-137 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -160,10 +160,10 @@ Cs-137 Inhalation:Type-S
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -250,8 +250,8 @@ Cs-137 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -343,8 +343,8 @@ Cs-137 Inhalation:Type-S
 
 # from parent to progeny
   Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-F     Oesophagus-F              ---
-  Cs-137/Oesophagus-S     Oesophagus-S              ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
   Cs-137/St-con           St-con                    ---
   Cs-137/St-conRe         St-con                    ---
   Cs-137/SI-con           SI-con                    ---
@@ -412,7 +412,7 @@ Cs-137 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -424,7 +424,7 @@ Cs-137 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -452,10 +452,10 @@ Cs-137 Inhalation:Type-S
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
@@ -30,6 +30,8 @@ Cs-137 Inhalation:Type-S
   acc   RS-wall               RS-wall
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -74,8 +76,6 @@ Cs-137 Inhalation:Type-S
   acc   Other1                Other
   acc   Other2                Other
   exc   Excreta(sweat)        ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Cs-137:transfer]
 #-----------------------+---------------------+--------------
@@ -177,6 +177,9 @@ Cs-137 Inhalation:Type-S
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.147 Table 6.3
   Plasma                  RBC                       1.8
   Plasma                  SkeletalMuscle           30.0
@@ -241,9 +244,6 @@ Cs-137 Inhalation:Type-S
   Other1                  Plasma                    0.762
   Other2                  Plasma                    0.00141
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Ba-137m:compartment]
 #-----+---------------------| S-Coefficient
@@ -258,6 +258,8 @@ Cs-137 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -303,8 +305,6 @@ Cs-137 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   C-bone-S              C-bone-S
   acc   Other                 Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   acc   Cartilage             Cartilage
   acc   Exch-T-bone-V         T-bone-V
   acc   Exch-C-bone-V         C-bone-V
@@ -353,6 +353,8 @@ Cs-137 Inhalation:Type-S
   Cs-137/LC-con           LC-con                    ---
   Cs-137/RS-con           RS-con                    ---
   Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
@@ -380,8 +382,6 @@ Cs-137 Inhalation:Type-S
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---
   Cs-137/C-bone-S         C-bone-S                  ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
   Cs-137/RBC              Dec-RBC                   ---
   Cs-137/SkeletalMuscle   Dec-Muscle                ---
   Cs-137/St-wall          Dec-St-wall               ---
@@ -464,6 +464,9 @@ Cs-137 Inhalation:Type-S
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.152-154 Para.317
   # > Barium produced in skeletal muscle and red blood cells transfers to plasma at the
@@ -583,6 +586,3 @@ Cs-137 Inhalation:Type-S
   Exch-C-bone-V           Noch-C-bone-V             0.042       #  30.2158% of 0.139/d  # 0.0042 = 30.2158% of 0.0139の間違いか？
   Noch-C-bone-V           Plasma                    4.93E-4     # 100.0%                # 0.0000821 の間違いか？
   Noch-T-bone-V           Plasma                    8.21E-5     # 100.0%                # 0.000493 の間違いか？
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
+++ b/resources/inp/OIR/Cs-137/Cs-137_inh-TypeS.inp
@@ -14,25 +14,6 @@ Cs-137 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-wall               SI-wall
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-wall               LC-wall
-  acc   LC-con                LC-cont
-  acc   RS-wall               RS-wall
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -56,6 +37,25 @@ Cs-137 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-wall               SI-wall
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-wall               LC-wall
+  acc   LC-con                LC-cont
+  acc   RS-wall               RS-wall
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   RBC                   Blood
@@ -249,18 +249,6 @@ Cs-137 Inhalation:Type-S
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -284,6 +272,18 @@ Cs-137 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   Ht-wall               Ht-wall
@@ -342,20 +342,6 @@ Cs-137 Inhalation:Type-S
   $fA = 0.002
 
 # from parent to progeny
-  Cs-137/Oralcavity       Oralcavity                ---
-  Cs-137/Oesophagus-f     Oesophagus-f              ---
-  Cs-137/Oesophagus-s     Oesophagus-s              ---
-  Cs-137/St-con           St-con                    ---
-  Cs-137/St-conRe         St-con                    ---
-  Cs-137/SI-con           SI-con                    ---
-  Cs-137/SI-conRe         SI-con                    ---
-  Cs-137/RC-con           RC-con                    ---
-  Cs-137/LC-con           LC-con                    ---
-  Cs-137/RS-con           RS-con                    ---
-  Cs-137/Faeces           Faeces                    ---
-  Cs-137/UB-con           UB-con                    ---
-  Cs-137/Urine            Urine                     ---
-
   Cs-137/ET1-F            ET1-F                     ---
   Cs-137/ET2-F            ET2-F                     ---
   Cs-137/ETseq-F          ETseq-F                   ---
@@ -378,6 +364,20 @@ Cs-137 Inhalation:Type-S
   Cs-137/ALV-S            ALV-S                     ---
   Cs-137/INT-S            INT-S                     ---
   Cs-137/LNTH-S           LNTH-S                    ---
+
+  Cs-137/Oralcavity       Oralcavity                ---
+  Cs-137/Oesophagus-f     Oesophagus-f              ---
+  Cs-137/Oesophagus-s     Oesophagus-s              ---
+  Cs-137/St-con           St-con                    ---
+  Cs-137/St-conRe         St-con                    ---
+  Cs-137/SI-con           SI-con                    ---
+  Cs-137/SI-conRe         SI-con                    ---
+  Cs-137/RC-con           RC-con                    ---
+  Cs-137/LC-con           LC-con                    ---
+  Cs-137/RS-con           RS-con                    ---
+  Cs-137/Faeces           Faeces                    ---
+  Cs-137/UB-con           UB-con                    ---
+  Cs-137/Urine            Urine                     ---
 
   Cs-137/Plasma           Plasma                    ---
   Cs-137/T-bone-S         T-bone-S                  ---

--- a/resources/inp/OIR/Fe-59/Fe-59_ing.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_ing.inp
@@ -14,8 +14,8 @@ Fe-59 Ingestion:Unspecified
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -53,10 +53,10 @@ Fe-59 Ingestion:Unspecified
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Fe-59/Fe-59_ing.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_ing.inp
@@ -23,6 +23,8 @@ Fe-59 Ingestion:Unspecified
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood
@@ -36,8 +38,6 @@ Fe-59 Ingestion:Unspecified
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   exc   Excreta               ---
 
 [Fe-59:transfer]
@@ -69,6 +69,9 @@ Fe-59 Ingestion:Unspecified
   SI-con                  OtherPlasma           $(fA    * 6 / (1 - fA   ))
   SI-conRe                OtherPlasma           $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.143 Table 7.3
   OtherPlasma             PlasmaTrans              70
   OtherPlasma             UB-con                    0.01
@@ -98,6 +101,3 @@ Fe-59 Ingestion:Unspecified
   Other2(Parenc)          Other1(Trans)             0.00127
   Other2(Parenc)          Excreta                   0.00057
   Other2(Parenc)          UB-con                    0.00003
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
@@ -14,8 +14,8 @@ Fe-59 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -107,7 +107,7 @@ Fe-59 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ Fe-59 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ Fe-59 Inhalation:Type-F
   LNTH-S                  OtherPlasma           $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
@@ -23,6 +23,8 @@ Fe-59 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -60,8 +62,6 @@ Fe-59 Inhalation:Type-F
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   exc   Excreta               ---
 
 [Fe-59:transfer]
@@ -163,6 +163,9 @@ Fe-59 Inhalation:Type-F
   SI-con                  OtherPlasma           $(fA    * 6 / (1 - fA   ))
   SI-conRe                OtherPlasma           $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.143 Table 7.3
   OtherPlasma             PlasmaTrans              70
   OtherPlasma             UB-con                    0.01
@@ -192,6 +195,3 @@ Fe-59 Inhalation:Type-F
   Other2(Parenc)          Other1(Trans)             0.00127
   Other2(Parenc)          Excreta                   0.00057
   Other2(Parenc)          UB-con                    0.00003
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
@@ -13,19 +13,6 @@ Fe-59 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Fe-59 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
@@ -23,6 +23,8 @@ Fe-59 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -60,8 +62,6 @@ Fe-59 Inhalation:Type-M
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   exc   Excreta               ---
 
 [Fe-59:transfer]
@@ -163,6 +163,9 @@ Fe-59 Inhalation:Type-M
   SI-con                  OtherPlasma           $(fA    * 6 / (1 - fA   ))
   SI-conRe                OtherPlasma           $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.143 Table 7.3
   OtherPlasma             PlasmaTrans              70
   OtherPlasma             UB-con                    0.01
@@ -192,6 +195,3 @@ Fe-59 Inhalation:Type-M
   Other2(Parenc)          Other1(Trans)             0.00127
   Other2(Parenc)          Excreta                   0.00057
   Other2(Parenc)          UB-con                    0.00003
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
@@ -13,19 +13,6 @@ Fe-59 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Fe-59 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
@@ -14,8 +14,8 @@ Fe-59 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -107,7 +107,7 @@ Fe-59 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ Fe-59 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ Fe-59 Inhalation:Type-M
   LNTH-S                  OtherPlasma           $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
@@ -14,8 +14,8 @@ Fe-59 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -107,7 +107,7 @@ Fe-59 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -119,7 +119,7 @@ Fe-59 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -147,10 +147,10 @@ Fe-59 Inhalation:Type-S
   LNTH-S                  OtherPlasma           $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
@@ -23,6 +23,8 @@ Fe-59 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -60,8 +62,6 @@ Fe-59 Inhalation:Type-S
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
   exc   Excreta               ---
 
 [Fe-59:transfer]
@@ -163,6 +163,9 @@ Fe-59 Inhalation:Type-S
   SI-con                  OtherPlasma           $(fA    * 6 / (1 - fA   ))
   SI-conRe                OtherPlasma           $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.143 Table 7.3
   OtherPlasma             PlasmaTrans              70
   OtherPlasma             UB-con                    0.01
@@ -192,6 +195,3 @@ Fe-59 Inhalation:Type-S
   Other2(Parenc)          Other1(Trans)             0.00127
   Other2(Parenc)          Excreta                   0.00057
   Other2(Parenc)          UB-con                    0.00003
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
@@ -13,19 +13,6 @@ Fe-59 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Fe-59 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   OtherPlasma           Blood
   acc   PlasmaTrans           Blood

--- a/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
@@ -22,6 +22,8 @@ H-3 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
@@ -29,8 +31,6 @@ H-3 Ingestion:Insoluble
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -57,6 +57,9 @@ H-3 Ingestion:Insoluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -68,6 +71,3 @@ H-3 Ingestion:Insoluble
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Insoluble.inp
@@ -14,8 +14,8 @@ H-3 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -44,10 +44,10 @@ H-3 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_ing-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Organic.inp
@@ -22,6 +22,8 @@ H-3 Ingestion:Organic
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
@@ -29,8 +31,6 @@ H-3 Ingestion:Organic
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -60,6 +60,9 @@ H-3 Ingestion:Organic
   SI-con                  Blood                 $(fA * 6 / (1 - fA) / 2)
   SI-con                  OBT1                  $(fA * 6 / (1 - fA) / 2)
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -71,6 +74,3 @@ H-3 Ingestion:Organic
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_ing-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Organic.inp
@@ -14,8 +14,8 @@ H-3 Ingestion:Organic
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -44,10 +44,10 @@ H-3 Ingestion:Organic
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
@@ -22,6 +22,8 @@ H-3 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other
@@ -29,8 +31,6 @@ H-3 Ingestion:Soluble
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -57,6 +57,9 @@ H-3 Ingestion:Soluble
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -68,6 +71,3 @@ H-3 Ingestion:Soluble
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
+++ b/resources/inp/OIR/H-3/H-3_ing-Soluble.inp
@@ -14,8 +14,8 @@ H-3 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -44,10 +44,10 @@ H-3 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
@@ -22,6 +22,8 @@ H-3 Inhalation:Type-F_Gas
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -40,8 +42,6 @@ H-3 Inhalation:Type-F_Gas
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -101,6 +101,9 @@ H-3 Inhalation:Type-F_Gas
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -112,6 +115,3 @@ H-3 Inhalation:Type-F_Gas
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
@@ -14,8 +14,8 @@ H-3 Inhalation:Type-F_Gas
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -73,7 +73,7 @@ H-3 Inhalation:Type-F_Gas
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
 
   ALV-F                   Blood                 $sr
@@ -88,10 +88,10 @@ H-3 Inhalation:Type-F_Gas
   LNTH-F                  Blood                 $sr
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Gas.inp
@@ -13,6 +13,17 @@ H-3 Inhalation:Type-F_Gas
 #-----+---------------------+---------------
   inp   input                 ---
 
+  acc   ET2-F                 ET2-sur
+  acc   ETseq-F               ET2-seq
+  acc   LNET-F                LN-ET
+  acc   BB-F                  Bronchi
+  acc   BBseq-F               Bronchi-q
+  acc   bb-F                  Brchiole
+  acc   bbseq-F               Brchiole-q
+  acc   ALV-F                 ALV
+  acc   INT-F                 ALV
+  acc   LNTH-F                LN-Th
+
   acc   Oralcavity            O-cavity
   acc   Oesophagus-f          Oesophag-f
   acc   Oesophagus-s          Oesophag-s
@@ -24,17 +35,6 @@ H-3 Inhalation:Type-F_Gas
   exc   Faeces                ---
   acc   UB-con                UB-cont
   exc   Urine                 ---
-
-  acc   ET2-F                 ET2-sur
-  acc   ETseq-F               ET2-seq
-  acc   LNET-F                LN-ET
-  acc   BB-F                  Bronchi
-  acc   BBseq-F               Bronchi-q
-  acc   bb-F                  Brchiole
-  acc   bbseq-F               Brchiole-q
-  acc   ALV-F                 ALV
-  acc   INT-F                 ALV
-  acc   LNTH-F                LN-Th
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
@@ -13,18 +13,6 @@ H-3 Inhalation:Type-F_Organic
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ H-3 Inhalation:Type-F_Organic
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   mix   mix-Blood             ---
   acc   Blood                 Blood

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
@@ -14,8 +14,8 @@ H-3 Inhalation:Type-F_Organic
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -99,7 +99,7 @@ H-3 Inhalation:Type-F_Organic
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -111,7 +111,7 @@ H-3 Inhalation:Type-F_Organic
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -139,10 +139,10 @@ H-3 Inhalation:Type-F_Organic
   LNTH-S                  mix-Blood             $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Organic.inp
@@ -22,6 +22,8 @@ H-3 Inhalation:Type-F_Organic
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -54,8 +56,6 @@ H-3 Inhalation:Type-F_Organic
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -152,6 +152,9 @@ H-3 Inhalation:Type-F_Organic
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  mix-Blood             $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.37 Para.76
 # ICRP Publ.134 p.38 Fig.2.4
   mix-Blood               Blood                    50.0%
@@ -168,6 +171,3 @@ H-3 Inhalation:Type-F_Organic
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
@@ -14,8 +14,8 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -98,7 +98,7 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -110,7 +110,7 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -138,10 +138,10 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
@@ -22,6 +22,8 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -53,8 +55,6 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -151,6 +151,9 @@ H-3 Inhalation:Type-F_LaNiAlTritide
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -162,6 +165,3 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeF-Tritide.inp
@@ -13,18 +13,6 @@ H-3 Inhalation:Type-F_LaNiAlTritide
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ H-3 Inhalation:Type-F_LaNiAlTritide
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other

--- a/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
@@ -22,6 +22,8 @@ H-3 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -53,8 +55,6 @@ H-3 Inhalation:Type-M
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -151,6 +151,9 @@ H-3 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -162,6 +165,3 @@ H-3 Inhalation:Type-M
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
@@ -13,18 +13,6 @@ H-3 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ H-3 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other

--- a/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeM.inp
@@ -14,8 +14,8 @@ H-3 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -98,7 +98,7 @@ H-3 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -110,7 +110,7 @@ H-3 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -138,10 +138,10 @@ H-3 Inhalation:Type-M
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
@@ -13,18 +13,6 @@ H-3 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ H-3 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ExtravasHTO           Other

--- a/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
@@ -22,6 +22,8 @@ H-3 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -53,8 +55,6 @@ H-3 Inhalation:Type-S
   acc   OBT2                  Other
   exc   Breath(discharge)     ---
   exc   Skin(discharge)       ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [H-3:transfer]
 #-----------------------+---------------------+--------------
@@ -151,6 +151,9 @@ H-3 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.35 Table 2.5 & footnote†
   Blood                   ExtravasHTO             400
   ExtravasHTO             OBT1                      0.0006
@@ -162,6 +165,3 @@ H-3 Inhalation:Type-S
   ExtravasHTO             Blood                    44
   OBT1                    ExtravasHTO               0.01733
   OBT2                    ExtravasHTO               0.0019
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
+++ b/resources/inp/OIR/H-3/H-3_inh-TypeS.inp
@@ -14,8 +14,8 @@ H-3 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -98,7 +98,7 @@ H-3 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -110,7 +110,7 @@ H-3 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -138,10 +138,10 @@ H-3 Inhalation:Type-S
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/I-129/I-129_ing.inp
+++ b/resources/inp/OIR/I-129/I-129_ing.inp
@@ -27,6 +27,8 @@ I-129 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ I-129 Ingestion
   acc   Other2                Other
   acc   Other3                Other
   acc   Other4                Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [I-129:transfer]
 #-----------------------+---------------------+--------------
@@ -79,6 +79,9 @@ I-129 Ingestion
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.108 Table 5.4
   Blood1                  Thyroid1                  7.26
   Blood1                  UB-con                   11.84
@@ -110,6 +113,3 @@ I-129 Ingestion
   Liver2                  Blood2                   21
   Liver2                  Blood1                    0.14
   Liver2                  RC-con                    0.08
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
@@ -13,23 +13,6 @@ I-129 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -53,6 +36,23 @@ I-129 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeF.inp
@@ -27,6 +27,8 @@ I-129 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -65,8 +67,6 @@ I-129 Inhalation:Type-F
   acc   Other2                Other
   acc   Other3                Other
   acc   Other4                Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [I-129:transfer]
 #-----------------------+---------------------+--------------
@@ -173,6 +173,9 @@ I-129 Inhalation:Type-F
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.108 Table 5.4
   Blood1                  Thyroid1                  7.26
   Blood1                  UB-con                   11.84
@@ -204,6 +207,3 @@ I-129 Inhalation:Type-F
   Liver2                  Blood2                   21
   Liver2                  Blood1                    0.14
   Liver2                  RC-con                    0.08
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
@@ -27,6 +27,8 @@ I-129 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -65,8 +67,6 @@ I-129 Inhalation:Type-M
   acc   Other2                Other
   acc   Other3                Other
   acc   Other4                Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [I-129:transfer]
 #-----------------------+---------------------+--------------
@@ -173,6 +173,9 @@ I-129 Inhalation:Type-M
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.108 Table 5.4
   Blood1                  Thyroid1                  7.26
   Blood1                  UB-con                   11.84
@@ -204,6 +207,3 @@ I-129 Inhalation:Type-M
   Liver2                  Blood2                   21
   Liver2                  Blood1                    0.14
   Liver2                  RC-con                    0.08
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeM.inp
@@ -13,23 +13,6 @@ I-129 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -53,6 +36,23 @@ I-129 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
@@ -13,23 +13,6 @@ I-129 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -53,6 +36,23 @@ I-129 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
+++ b/resources/inp/OIR/I-129/I-129_inh-TypeS.inp
@@ -27,6 +27,8 @@ I-129 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -65,8 +67,6 @@ I-129 Inhalation:Type-S
   acc   Other2                Other
   acc   Other3                Other
   acc   Other4                Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [I-129:transfer]
 #-----------------------+---------------------+--------------
@@ -173,6 +173,9 @@ I-129 Inhalation:Type-S
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.108 Table 5.4
   Blood1                  Thyroid1                  7.26
   Blood1                  UB-con                   11.84
@@ -204,6 +207,3 @@ I-129 Inhalation:Type-S
   Liver2                  Blood2                   21
   Liver2                  Blood1                    0.14
   Liver2                  RC-con                    0.08
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
@@ -55,11 +55,11 @@ Mo-93 Ingestion:Other
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.310 Table 14.3
   Blood1                  Blood2                   12.5
@@ -89,7 +89,6 @@ Mo-93 Ingestion:Other
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -154,7 +153,6 @@ Mo-93 Ingestion:Other
   Mo-93/LC-con            LC-con                    ---
   Mo-93/RS-con            RS-con                    ---
   Mo-93/Faeces            Faeces                    ---
-
   Mo-93/UB-con            UB-con                    ---
   Mo-93/Urine             Urine                     ---
 
@@ -204,12 +202,12 @@ Mo-93 Ingestion:Other
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.294 Table 13.3
   Blood1                  Blood2                    3.2

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Other.inp
@@ -15,8 +15,8 @@ Mo-93 Ingestion:Other
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -45,10 +45,10 @@ Mo-93 Ingestion:Other
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -80,8 +80,8 @@ Mo-93 Ingestion:Other
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -145,8 +145,8 @@ Mo-93 Ingestion:Other
 
 # from parent to progeny
   Mo-93/Oralcavity        Oralcavity                ---
-  Mo-93/Oesophagus-F      Oesophagus-F              ---
-  Mo-93/Oesophagus-S      Oesophagus-S              ---
+  Mo-93/Oesophagus-f      Oesophagus-f              ---
+  Mo-93/Oesophagus-s      Oesophagus-s              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
   Mo-93/RC-con            RC-con                    ---
@@ -191,10 +191,10 @@ Mo-93 Ingestion:Other
   decay-OtherTissue       Blood1                    1.39
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
@@ -55,11 +55,11 @@ Mo-93 Ingestion:Sulphide
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.310 Table 14.3
   Blood1                  Blood2                   12.5
@@ -89,7 +89,6 @@ Mo-93 Ingestion:Sulphide
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -154,7 +153,6 @@ Mo-93 Ingestion:Sulphide
   Mo-93/LC-con            LC-con                    ---
   Mo-93/RS-con            RS-con                    ---
   Mo-93/Faeces            Faeces                    ---
-
   Mo-93/UB-con            UB-con                    ---
   Mo-93/Urine             Urine                     ---
 
@@ -204,12 +202,12 @@ Mo-93 Ingestion:Sulphide
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.294 Table 13.3
   Blood1                  Blood2                    3.2

--- a/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_ing-Sulphide.inp
@@ -15,8 +15,8 @@ Mo-93 Ingestion:Sulphide
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -45,10 +45,10 @@ Mo-93 Ingestion:Sulphide
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -80,8 +80,8 @@ Mo-93 Ingestion:Sulphide
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -145,8 +145,8 @@ Mo-93 Ingestion:Sulphide
 
 # from parent to progeny
   Mo-93/Oralcavity        Oralcavity                ---
-  Mo-93/Oesophagus-F      Oesophagus-F              ---
-  Mo-93/Oesophagus-S      Oesophagus-S              ---
+  Mo-93/Oesophagus-f      Oesophagus-f              ---
+  Mo-93/Oesophagus-s      Oesophagus-s              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
   Mo-93/RC-con            RC-con                    ---
@@ -191,10 +191,10 @@ Mo-93 Ingestion:Sulphide
   decay-OtherTissue       Blood1                    1.39
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
@@ -156,11 +156,11 @@ Mo-93 Inhalation:Type-F
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.310 Table 14.3
   Blood1                  Blood2                   12.5
@@ -214,7 +214,6 @@ Mo-93 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -305,7 +304,6 @@ Mo-93 Inhalation:Type-F
   Mo-93/LC-con            LC-con                    ---
   Mo-93/RS-con            RS-con                    ---
   Mo-93/Faeces            Faeces                    ---
-
   Mo-93/UB-con            UB-con                    ---
   Mo-93/Urine             Urine                     ---
 
@@ -403,12 +401,12 @@ Mo-93 Inhalation:Type-F
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.294 Table 13.3
   Blood1                  Blood2                    3.2

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeF.inp
@@ -39,8 +39,8 @@ Mo-93 Inhalation:Type-F
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Mo-93 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Mo-93 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Mo-93 Inhalation:Type-F
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -205,8 +205,8 @@ Mo-93 Inhalation:Type-F
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -296,8 +296,8 @@ Mo-93 Inhalation:Type-F
   Mo-93/Environment       Environment               ---
 
   Mo-93/Oralcavity        Oralcavity                ---
-  Mo-93/Oesophagus-F      Oesophagus-F              ---
-  Mo-93/Oesophagus-S      Oesophagus-S              ---
+  Mo-93/Oesophagus-f      Oesophagus-f              ---
+  Mo-93/Oesophagus-s      Oesophagus-s              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
   Mo-93/RC-con            RC-con                    ---
@@ -350,7 +350,7 @@ Mo-93 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -362,7 +362,7 @@ Mo-93 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -390,10 +390,10 @@ Mo-93 Inhalation:Type-F
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
@@ -156,11 +156,11 @@ Mo-93 Inhalation:Type-M
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.310 Table 14.3
   Blood1                  Blood2                   12.5
@@ -214,7 +214,6 @@ Mo-93 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -305,7 +304,6 @@ Mo-93 Inhalation:Type-M
   Mo-93/LC-con            LC-con                    ---
   Mo-93/RS-con            RS-con                    ---
   Mo-93/Faeces            Faeces                    ---
-
   Mo-93/UB-con            UB-con                    ---
   Mo-93/Urine             Urine                     ---
 
@@ -403,12 +401,12 @@ Mo-93 Inhalation:Type-M
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.294 Table 13.3
   Blood1                  Blood2                    3.2

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeM.inp
@@ -39,8 +39,8 @@ Mo-93 Inhalation:Type-M
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Mo-93 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Mo-93 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Mo-93 Inhalation:Type-M
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -205,8 +205,8 @@ Mo-93 Inhalation:Type-M
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -296,8 +296,8 @@ Mo-93 Inhalation:Type-M
   Mo-93/Environment       Environment               ---
 
   Mo-93/Oralcavity        Oralcavity                ---
-  Mo-93/Oesophagus-F      Oesophagus-F              ---
-  Mo-93/Oesophagus-S      Oesophagus-S              ---
+  Mo-93/Oesophagus-f      Oesophagus-f              ---
+  Mo-93/Oesophagus-s      Oesophagus-s              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
   Mo-93/RC-con            RC-con                    ---
@@ -350,7 +350,7 @@ Mo-93 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -362,7 +362,7 @@ Mo-93 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -390,10 +390,10 @@ Mo-93 Inhalation:Type-M
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
@@ -39,8 +39,8 @@ Mo-93 Inhalation:Type-S
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Mo-93 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Mo-93 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Mo-93 Inhalation:Type-S
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -205,8 +205,8 @@ Mo-93 Inhalation:Type-S
   exc   Environment           ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -296,8 +296,8 @@ Mo-93 Inhalation:Type-S
   Mo-93/Environment       Environment               ---
 
   Mo-93/Oralcavity        Oralcavity                ---
-  Mo-93/Oesophagus-F      Oesophagus-F              ---
-  Mo-93/Oesophagus-S      Oesophagus-S              ---
+  Mo-93/Oesophagus-f      Oesophagus-f              ---
+  Mo-93/Oesophagus-s      Oesophagus-s              ---
   Mo-93/St-con            St-con                    ---
   Mo-93/SI-con            SI-con                    ---
   Mo-93/RC-con            RC-con                    ---
@@ -350,7 +350,7 @@ Mo-93 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -362,7 +362,7 @@ Mo-93 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -390,10 +390,10 @@ Mo-93 Inhalation:Type-S
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
+++ b/resources/inp/OIR/Mo-93/Mo-93_inh-TypeS.inp
@@ -156,11 +156,11 @@ Mo-93 Inhalation:Type-S
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.310 Table 14.3
   Blood1                  Blood2                   12.5
@@ -214,7 +214,6 @@ Mo-93 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
-
   acc   UB-con                UB-cont
   exc   Urine                 ---
 
@@ -305,7 +304,6 @@ Mo-93 Inhalation:Type-S
   Mo-93/LC-con            LC-con                    ---
   Mo-93/RS-con            RS-con                    ---
   Mo-93/Faeces            Faeces                    ---
-
   Mo-93/UB-con            UB-con                    ---
   Mo-93/Urine             Urine                     ---
 
@@ -403,12 +401,12 @@ Mo-93 Inhalation:Type-S
   LC-con                  RS-con                    2
   RS-con                  Faeces                    2
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.294 Table 13.3
   Blood1                  Blood2                    3.2

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
@@ -22,6 +22,8 @@ Pu-238 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-238 Ingestion:Insoluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-238:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-238 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-238 Ingestion:Insoluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Pu-238 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-238 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
@@ -22,6 +22,8 @@ Pu-238 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-238 Ingestion:Soluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-238:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-238 Ingestion:Soluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-238 Ingestion:Soluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_ing-Soluble.inp
@@ -14,8 +14,8 @@ Pu-238 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-238 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
@@ -13,18 +13,6 @@ Pu-238 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-238 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
@@ -14,8 +14,8 @@ Pu-238 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-238 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-238 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-238 Inhalation:Type-F
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeF.inp
@@ -22,6 +22,8 @@ Pu-238 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-238 Inhalation:Type-F
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-238:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-238 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-238 Inhalation:Type-F
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
@@ -22,6 +22,8 @@ Pu-238 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-238 Inhalation:Type-M
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-238:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-238 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-238 Inhalation:Type-M
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
@@ -14,8 +14,8 @@ Pu-238 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-238 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-238 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-238 Inhalation:Type-M
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeM.inp
@@ -13,18 +13,6 @@ Pu-238 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-238 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
@@ -22,6 +22,8 @@ Pu-238 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-238 Inhalation:Type-S
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-238:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-238 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-238 Inhalation:Type-S
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
@@ -14,8 +14,8 @@ Pu-238 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-238 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-238 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-238 Inhalation:Type-S
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-238/Pu-238_inh-TypeS.inp
@@ -13,18 +13,6 @@ Pu-238 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-238 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Pu-239 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-239 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Insoluble.inp
@@ -22,6 +22,8 @@ Pu-239 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-239 Ingestion:Insoluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-239 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-239 Ingestion:Insoluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
@@ -22,6 +22,8 @@ Pu-239 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-239 Ingestion:Soluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-239 Ingestion:Soluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-239 Ingestion:Soluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_ing-Soluble.inp
@@ -14,8 +14,8 @@ Pu-239 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-239 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
@@ -14,8 +14,8 @@ Pu-239 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-239 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-239 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-239 Inhalation:Type-F
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
@@ -22,6 +22,8 @@ Pu-239 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-239 Inhalation:Type-F
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-239 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-239 Inhalation:Type-F
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeF.inp
@@ -13,18 +13,6 @@ Pu-239 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-239 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
@@ -22,6 +22,8 @@ Pu-239 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-239 Inhalation:Type-M
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-239 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-239 Inhalation:Type-M
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
@@ -14,8 +14,8 @@ Pu-239 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-239 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-239 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-239 Inhalation:Type-M
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeM.inp
@@ -13,18 +13,6 @@ Pu-239 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-239 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
@@ -22,6 +22,8 @@ Pu-239 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-239 Inhalation:Type-S
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-239 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-239 Inhalation:Type-S
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
@@ -13,18 +13,6 @@ Pu-239 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-239 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inh-TypeS.inp
@@ -14,8 +14,8 @@ Pu-239 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-239 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-239 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-239 Inhalation:Type-S
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_inj.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inj.inp
@@ -14,8 +14,8 @@ Pu-239 Injection
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-239 Injection
   input                   Blood0                  100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-239/Pu-239_inj.inp
+++ b/resources/inp/OIR/Pu-239/Pu-239_inj.inp
@@ -22,6 +22,8 @@ Pu-239 Injection
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood0                Blood
   acc   Blood1                Blood
@@ -42,8 +44,6 @@ Pu-239 Injection
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-239:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-239 Injection
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood0                  ST0                       3.0000E+2
@@ -108,6 +111,3 @@ Pu-239 Injection
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
@@ -22,6 +22,8 @@ Pu-240 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-240 Ingestion:Insoluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-240:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-240 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-240 Ingestion:Insoluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Pu-240 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-240 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
@@ -14,8 +14,8 @@ Pu-240 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-240 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_ing-Soluble.inp
@@ -22,6 +22,8 @@ Pu-240 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-240 Ingestion:Soluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-240:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-240 Ingestion:Soluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-240 Ingestion:Soluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
@@ -13,18 +13,6 @@ Pu-240 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-240 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
@@ -14,8 +14,8 @@ Pu-240 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-240 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-240 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-240 Inhalation:Type-F
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeF.inp
@@ -22,6 +22,8 @@ Pu-240 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-240 Inhalation:Type-F
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-240:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-240 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-240 Inhalation:Type-F
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
@@ -14,8 +14,8 @@ Pu-240 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-240 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-240 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-240 Inhalation:Type-M
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
@@ -13,18 +13,6 @@ Pu-240 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-240 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeM.inp
@@ -22,6 +22,8 @@ Pu-240 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-240 Inhalation:Type-M
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-240:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-240 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-240 Inhalation:Type-M
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
@@ -13,18 +13,6 @@ Pu-240 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-240 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
@@ -14,8 +14,8 @@ Pu-240 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-240 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-240 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-240 Inhalation:Type-S
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-240/Pu-240_inh-TypeS.inp
@@ -22,6 +22,8 @@ Pu-240 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-240 Inhalation:Type-S
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-240:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-240 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-240 Inhalation:Type-S
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
@@ -22,6 +22,8 @@ Pu-241 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-241 Ingestion:Insoluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-241:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-241 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-241 Ingestion:Insoluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Insolube.inp
@@ -14,8 +14,8 @@ Pu-241 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-241 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
@@ -22,6 +22,8 @@ Pu-241 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-241 Ingestion:Soluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-241:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-241 Ingestion:Soluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-241 Ingestion:Soluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_ing-Soluble.inp
@@ -14,8 +14,8 @@ Pu-241 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-241 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
@@ -14,8 +14,8 @@ Pu-241 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-241 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-241 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-241 Inhalation:Type-F
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
@@ -13,18 +13,6 @@ Pu-241 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-241 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeF.inp
@@ -22,6 +22,8 @@ Pu-241 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-241 Inhalation:Type-F
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-241:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-241 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-241 Inhalation:Type-F
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
@@ -14,8 +14,8 @@ Pu-241 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-241 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-241 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-241 Inhalation:Type-M
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
@@ -13,18 +13,6 @@ Pu-241 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-241 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeM.inp
@@ -22,6 +22,8 @@ Pu-241 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-241 Inhalation:Type-M
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-241:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-241 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-241 Inhalation:Type-M
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
@@ -22,6 +22,8 @@ Pu-241 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-241 Inhalation:Type-S
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-241:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-241 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-241 Inhalation:Type-S
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
@@ -14,8 +14,8 @@ Pu-241 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-241 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-241 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-241 Inhalation:Type-S
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-241/Pu-241_inh-TypeS.inp
@@ -13,18 +13,6 @@ Pu-241 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-241 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
@@ -22,6 +22,8 @@ Pu-242 Ingestion:Insoluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-242 Ingestion:Insoluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-242:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-242 Ingestion:Insoluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-242 Ingestion:Insoluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Insoluble.inp
@@ -14,8 +14,8 @@ Pu-242 Ingestion:Insoluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-242 Ingestion:Insoluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
@@ -14,8 +14,8 @@ Pu-242 Ingestion:Soluble
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -56,10 +56,10 @@ Pu-242 Ingestion:Soluble
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_ing-Soluble.inp
@@ -22,6 +22,8 @@ Pu-242 Ingestion:Soluble
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -41,8 +43,6 @@ Pu-242 Ingestion:Soluble
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-242:transfer]
 #-----------------------+---------------------+--------------
@@ -68,6 +68,9 @@ Pu-242 Ingestion:Soluble
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
@@ -106,6 +109,3 @@ Pu-242 Ingestion:Soluble
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
@@ -14,8 +14,8 @@ Pu-242 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-242 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-242 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-242 Inhalation:Type-F
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
@@ -22,6 +22,8 @@ Pu-242 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-242 Inhalation:Type-F
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-242:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-242 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-242 Inhalation:Type-F
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeF.inp
@@ -13,18 +13,6 @@ Pu-242 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-242 Inhalation:Type-F
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
@@ -13,18 +13,6 @@ Pu-242 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-242 Inhalation:Type-M
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
@@ -22,6 +22,8 @@ Pu-242 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-242 Inhalation:Type-M
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-242:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-242 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-242 Inhalation:Type-M
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeM.inp
@@ -14,8 +14,8 @@ Pu-242 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-242 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-242 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-242 Inhalation:Type-M
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
@@ -13,18 +13,6 @@ Pu-242 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -58,6 +46,18 @@ Pu-242 Inhalation:Type-S
   acc   INT-B                 ALV
   acc   LNTH-B                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
@@ -14,8 +14,8 @@ Pu-242 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -122,7 +122,7 @@ Pu-242 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -134,7 +134,7 @@ Pu-242 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -197,10 +197,10 @@ Pu-242 Inhalation:Type-S
   LNTH-B                  Blood1                $sb
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
+++ b/resources/inp/OIR/Pu-242/Pu-242_inh-TypeS.inp
@@ -22,6 +22,8 @@ Pu-242 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -75,8 +77,6 @@ Pu-242 Inhalation:Type-S
   acc   Ovaries               Ovaries
   acc   Testes                Testes
   acc   Renal-tubules         Ureters
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Pu-242:transfer]
 #-----------------------+---------------------+--------------
@@ -210,6 +210,9 @@ Pu-242 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.141 p.225 Table 18.6
   Blood1                  Liver0                    4.6200E-1
   Blood1                  C-bone-S                  8.7780E-2
@@ -247,6 +250,3 @@ Pu-242 Inhalation:Type-S
   T-bone-V                T-marrow                  4.9300E-4
   C-marrow                Blood2                    7.6000E-3
   T-marrow                Blood2                    7.6000E-3
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
@@ -13,18 +13,6 @@ Ra-223 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ra-223 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
@@ -14,8 +14,8 @@ Ra-223 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Ra-223 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Ra-223 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Ra-223 Inhalation:Type-F
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-223/Ra-223_inh-TypeF.inp
@@ -22,6 +22,8 @@ Ra-223 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -61,8 +63,6 @@ Ra-223 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ra-223:transfer]
 #-----------------------+---------------------+--------------
@@ -159,6 +159,9 @@ Ra-223 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.332 Table 13.3
   Blood                   UB-con                    0.606
   Blood                   RC-con                   21.79
@@ -188,6 +191,3 @@ Ra-223 Inhalation:Type-F
   Exch-C-bone-V           Noch-C-bone-V             0.0046
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ra-226/Ra-226_ing.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_ing.inp
@@ -22,6 +22,8 @@ Ra-226 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other
@@ -37,8 +39,6 @@ Ra-226 Ingestion
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ra-226:transfer]
 #-----------------------+---------------------+--------------
@@ -64,6 +64,9 @@ Ra-226 Ingestion
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.137 p.332 Table 13.3
   Blood                   UB-con                    0.606
@@ -94,6 +97,3 @@ Ra-226 Ingestion
   Exch-C-bone-V           Noch-C-bone-V             0.0046
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ra-226/Ra-226_ing.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_ing.inp
@@ -14,8 +14,8 @@ Ra-226 Ingestion
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -52,10 +52,10 @@ Ra-226 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
@@ -13,18 +13,6 @@ Ra-226 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ra-226 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
@@ -22,6 +22,8 @@ Ra-226 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -61,8 +63,6 @@ Ra-226 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ra-226:transfer]
 #-----------------------+---------------------+--------------
@@ -159,6 +159,9 @@ Ra-226 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.332 Table 13.3
   Blood                   UB-con                    0.606
   Blood                   RC-con                   21.79
@@ -188,6 +191,3 @@ Ra-226 Inhalation:Type-F
   Exch-C-bone-V           Noch-C-bone-V             0.0046
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeF.inp
@@ -14,8 +14,8 @@ Ra-226 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Ra-226 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Ra-226 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Ra-226 Inhalation:Type-F
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
@@ -22,6 +22,8 @@ Ra-226 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -61,8 +63,6 @@ Ra-226 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ra-226:transfer]
 #-----------------------+---------------------+--------------
@@ -159,6 +159,9 @@ Ra-226 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.332 Table 13.3
   Blood                   UB-con                    0.606
   Blood                   RC-con                   21.79
@@ -188,6 +191,3 @@ Ra-226 Inhalation:Type-M
   Exch-C-bone-V           Noch-C-bone-V             0.0046
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
@@ -13,18 +13,6 @@ Ra-226 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ra-226 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeM.inp
@@ -14,8 +14,8 @@ Ra-226 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Ra-226 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Ra-226 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Ra-226 Inhalation:Type-M
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
@@ -13,18 +13,6 @@ Ra-226 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -48,6 +36,18 @@ Ra-226 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
@@ -14,8 +14,8 @@ Ra-226 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -106,7 +106,7 @@ Ra-226 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -118,7 +118,7 @@ Ra-226 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -146,10 +146,10 @@ Ra-226 Inhalation:Type-S
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
+++ b/resources/inp/OIR/Ra-226/Ra-226_inh-TypeS.inp
@@ -22,6 +22,8 @@ Ra-226 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -61,8 +63,6 @@ Ra-226 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Ra-226:transfer]
 #-----------------------+---------------------+--------------
@@ -159,6 +159,9 @@ Ra-226 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.137 p.332 Table 13.3
   Blood                   UB-con                    0.606
   Blood                   RC-con                   21.79
@@ -188,6 +191,3 @@ Ra-226 Inhalation:Type-S
   Exch-C-bone-V           Noch-C-bone-V             0.0046
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Sr-90/Sr-90_ing-Other.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_ing-Other.inp
@@ -23,6 +23,8 @@ Sr-90 Ingestion:Other
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   ST0                   Other
@@ -34,8 +36,6 @@ Sr-90 Ingestion:Other
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Sr-90:transfer]
 #-----------------------+---------------------+--------------
@@ -62,6 +62,9 @@ Sr-90 Ingestion:Other
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.220 Table 10.3
   Blood1                  UB-con                    1.73
   Blood1                  RC-con                    0.525
@@ -84,9 +87,6 @@ Sr-90 Ingestion:Other
   Noch-C-bone-V           Blood1                    0.0000821
   Noch-T-bone-V           Blood1                    0.000493
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Y-90:compartment]
 #-----+---------------------| S-Coefficient
@@ -101,6 +101,8 @@ Sr-90 Ingestion:Other
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -113,8 +115,6 @@ Sr-90 Ingestion:Other
   acc   C-bone-V              C-bone-V
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Y-90:transfer]
 #-----------------------+---------------------+--------------
@@ -134,6 +134,8 @@ Sr-90 Ingestion:Other
   Sr-90/LC-con            LC-con                    ---
   Sr-90/RS-con            RS-con                    ---
   Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/Blood1            Blood1                    ---
   Sr-90/ST0               ST0                       ---
@@ -145,8 +147,6 @@ Sr-90 Ingestion:Other
   Sr-90/T-bone-S          T-bone-S                  ---
   Sr-90/Exch-T-bone-V     T-bone-V                  ---
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-F           6480
@@ -161,6 +161,9 @@ Sr-90 Ingestion:Other
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.252 Table 11.3
   Blood1                  Blood2                    0.498
@@ -186,6 +189,3 @@ Sr-90 Ingestion:Other
   C-bone-S                Blood1                    0.0000821
   C-bone-S                C-bone-V                  0.0000411
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Sr-90/Sr-90_ing-Other.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_ing-Other.inp
@@ -15,8 +15,8 @@ Sr-90 Ingestion:Other
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -49,10 +49,10 @@ Sr-90 Ingestion:Other
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -93,8 +93,8 @@ Sr-90 Ingestion:Other
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -126,8 +126,8 @@ Sr-90 Ingestion:Other
 
 # from parent to progeny
   Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-F      Oesophagus-F              ---
-  Sr-90/Oesophagus-S      Oesophagus-S              ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
   Sr-90/St-con            St-con                    ---
   Sr-90/SI-con            SI-con                    ---
   Sr-90/RC-con            RC-con                    ---
@@ -149,10 +149,10 @@ Sr-90 Ingestion:Other
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Sr-90/Sr-90_ing-Titanate.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_ing-Titanate.inp
@@ -23,6 +23,8 @@ Sr-90 Ingestion:StrontiumTitanate
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   ST0                   Other
@@ -34,8 +36,6 @@ Sr-90 Ingestion:StrontiumTitanate
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Sr-90:transfer]
 #-----------------------+---------------------+--------------
@@ -62,6 +62,9 @@ Sr-90 Ingestion:StrontiumTitanate
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.220 Table 10.3
   Blood1                  UB-con                    1.73
   Blood1                  RC-con                    0.525
@@ -84,9 +87,6 @@ Sr-90 Ingestion:StrontiumTitanate
   Noch-C-bone-V           Blood1                    0.0000821
   Noch-T-bone-V           Blood1                    0.000493
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Y-90:compartment]
 #-----+---------------------| S-Coefficient
@@ -101,6 +101,8 @@ Sr-90 Ingestion:StrontiumTitanate
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -113,8 +115,6 @@ Sr-90 Ingestion:StrontiumTitanate
   acc   C-bone-V              C-bone-V
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Y-90:transfer]
 #-----------------------+---------------------+--------------
@@ -134,6 +134,8 @@ Sr-90 Ingestion:StrontiumTitanate
   Sr-90/LC-con            LC-con                    ---
   Sr-90/RS-con            RS-con                    ---
   Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/Blood1            Blood1                    ---
   Sr-90/ST0               ST0                       ---
@@ -145,8 +147,6 @@ Sr-90 Ingestion:StrontiumTitanate
   Sr-90/T-bone-S          T-bone-S                  ---
   Sr-90/Exch-T-bone-V     T-bone-V                  ---
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-F           6480
@@ -161,6 +161,9 @@ Sr-90 Ingestion:StrontiumTitanate
 
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.252 Table 11.3
   Blood1                  Blood2                    0.498
@@ -186,6 +189,3 @@ Sr-90 Ingestion:StrontiumTitanate
   C-bone-S                Blood1                    0.0000821
   C-bone-S                C-bone-V                  0.0000411
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Sr-90/Sr-90_ing-Titanate.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_ing-Titanate.inp
@@ -15,8 +15,8 @@ Sr-90 Ingestion:StrontiumTitanate
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -49,10 +49,10 @@ Sr-90 Ingestion:StrontiumTitanate
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -93,8 +93,8 @@ Sr-90 Ingestion:StrontiumTitanate
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -126,8 +126,8 @@ Sr-90 Ingestion:StrontiumTitanate
 
 # from parent to progeny
   Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-F      Oesophagus-F              ---
-  Sr-90/Oesophagus-S      Oesophagus-S              ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
   Sr-90/St-con            St-con                    ---
   Sr-90/SI-con            SI-con                    ---
   Sr-90/RC-con            RC-con                    ---
@@ -149,10 +149,10 @@ Sr-90 Ingestion:StrontiumTitanate
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
@@ -14,18 +14,6 @@ Sr-90 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +37,18 @@ Sr-90 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   ST0                   Other
@@ -186,18 +186,6 @@ Sr-90 Inhalation:Type-F
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -222,6 +210,18 @@ Sr-90 Inhalation:Type-F
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -245,18 +245,6 @@ Sr-90 Inhalation:Type-F
   $fA = 1E-4
 
 # from parent to progeny
-  Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-f      Oesophagus-f              ---
-  Sr-90/Oesophagus-s      Oesophagus-s              ---
-  Sr-90/St-con            St-con                    ---
-  Sr-90/SI-con            SI-con                    ---
-  Sr-90/RC-con            RC-con                    ---
-  Sr-90/LC-con            LC-con                    ---
-  Sr-90/RS-con            RS-con                    ---
-  Sr-90/Faeces            Faeces                    ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
-
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
   Sr-90/ETseq-F           ETseq-F                   ---
@@ -280,6 +268,18 @@ Sr-90 Inhalation:Type-F
   Sr-90/INT-S             INT-S                     ---
   Sr-90/LNTH-S            LNTH-S                    ---
   Sr-90/Environment       Environment               ---
+
+  Sr-90/Oralcavity        Oralcavity                ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
+  Sr-90/St-con            St-con                    ---
+  Sr-90/SI-con            SI-con                    ---
+  Sr-90/RC-con            RC-con                    ---
+  Sr-90/LC-con            LC-con                    ---
+  Sr-90/RS-con            RS-con                    ---
+  Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/Blood1            Blood1                    ---
   Sr-90/ST0               ST0                       ---

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
@@ -15,8 +15,8 @@ Sr-90 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -103,7 +103,7 @@ Sr-90 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -115,7 +115,7 @@ Sr-90 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -143,10 +143,10 @@ Sr-90 Inhalation:Type-F
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -187,8 +187,8 @@ Sr-90 Inhalation:Type-F
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -246,8 +246,8 @@ Sr-90 Inhalation:Type-F
 
 # from parent to progeny
   Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-F      Oesophagus-F              ---
-  Sr-90/Oesophagus-S      Oesophagus-S              ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
   Sr-90/St-con            St-con                    ---
   Sr-90/SI-con            SI-con                    ---
   Sr-90/RC-con            RC-con                    ---
@@ -301,7 +301,7 @@ Sr-90 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -313,7 +313,7 @@ Sr-90 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -341,10 +341,10 @@ Sr-90 Inhalation:Type-F
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeF.inp
@@ -23,6 +23,8 @@ Sr-90 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -58,8 +60,6 @@ Sr-90 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Sr-90:transfer]
 #-----------------------+---------------------+--------------
@@ -156,6 +156,9 @@ Sr-90 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.220 Table 10.3
   Blood1                  UB-con                    1.73
   Blood1                  RC-con                    0.525
@@ -178,9 +181,6 @@ Sr-90 Inhalation:Type-F
   Noch-C-bone-V           Blood1                    0.0000821
   Noch-T-bone-V           Blood1                    0.000493
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Y-90:compartment]
 #-----+---------------------| S-Coefficient
@@ -195,6 +195,8 @@ Sr-90 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -231,8 +233,6 @@ Sr-90 Inhalation:Type-F
   acc   C-bone-V              C-bone-V
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Y-90:transfer]
 #-----------------------+---------------------+--------------
@@ -254,6 +254,8 @@ Sr-90 Inhalation:Type-F
   Sr-90/LC-con            LC-con                    ---
   Sr-90/RS-con            RS-con                    ---
   Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
@@ -289,8 +291,6 @@ Sr-90 Inhalation:Type-F
   Sr-90/T-bone-S          T-bone-S                  ---
   Sr-90/Exch-T-bone-V     T-bone-V                  ---
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -354,6 +354,9 @@ Sr-90 Inhalation:Type-F
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.252 Table 11.3
   Blood1                  Blood2                    0.498
   Blood1                  Liver0                    1.66
@@ -378,6 +381,3 @@ Sr-90 Inhalation:Type-F
   C-bone-S                Blood1                    0.0000821
   C-bone-S                C-bone-V                  0.0000411
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
@@ -15,8 +15,8 @@ Sr-90 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -103,7 +103,7 @@ Sr-90 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -115,7 +115,7 @@ Sr-90 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -143,10 +143,10 @@ Sr-90 Inhalation:Type-M
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -187,8 +187,8 @@ Sr-90 Inhalation:Type-M
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -246,8 +246,8 @@ Sr-90 Inhalation:Type-M
 
 # from parent to progeny
   Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-F      Oesophagus-F              ---
-  Sr-90/Oesophagus-S      Oesophagus-S              ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
   Sr-90/St-con            St-con                    ---
   Sr-90/SI-con            SI-con                    ---
   Sr-90/RC-con            RC-con                    ---
@@ -301,7 +301,7 @@ Sr-90 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -313,7 +313,7 @@ Sr-90 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -341,10 +341,10 @@ Sr-90 Inhalation:Type-M
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
@@ -23,6 +23,8 @@ Sr-90 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -58,8 +60,6 @@ Sr-90 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Sr-90:transfer]
 #-----------------------+---------------------+--------------
@@ -156,6 +156,9 @@ Sr-90 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.220 Table 10.3
   Blood                   UB-con                    1.73
   Blood                   RC-con                    0.525
@@ -178,9 +181,6 @@ Sr-90 Inhalation:Type-M
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Y-90:compartment]
 #-----+---------------------| S-Coefficient
@@ -195,6 +195,8 @@ Sr-90 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -231,8 +233,6 @@ Sr-90 Inhalation:Type-M
   acc   C-bone-V              C-bone-V
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Y-90:transfer]
 #-----------------------+---------------------+--------------
@@ -254,6 +254,8 @@ Sr-90 Inhalation:Type-M
   Sr-90/LC-con            LC-con                    ---
   Sr-90/RS-con            RS-con                    ---
   Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
@@ -289,8 +291,6 @@ Sr-90 Inhalation:Type-M
   Sr-90/T-bone-S          T-bone-S                  ---
   Sr-90/Exch-T-bone-V     T-bone-V                  ---
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -354,6 +354,9 @@ Sr-90 Inhalation:Type-M
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood1                $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.252 Table 11.3
   Blood1                  Blood2                    0.498
   Blood1                  Liver0                    1.66
@@ -378,6 +381,3 @@ Sr-90 Inhalation:Type-M
   C-bone-S                Blood1                    0.0000821
   C-bone-S                C-bone-V                  0.0000411
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeM.inp
@@ -14,18 +14,6 @@ Sr-90 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +37,18 @@ Sr-90 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other
@@ -186,18 +186,6 @@ Sr-90 Inhalation:Type-M
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -222,6 +210,18 @@ Sr-90 Inhalation:Type-M
   acc   LNTH-S                LN-Th
   exc   Environment           ---
 
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
+
   acc   Blood1                Blood
   acc   Blood2                Blood
   acc   ST0                   Other
@@ -245,18 +245,6 @@ Sr-90 Inhalation:Type-M
   $fA = 2E-5
 
 # from parent to progeny
-  Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-f      Oesophagus-f              ---
-  Sr-90/Oesophagus-s      Oesophagus-s              ---
-  Sr-90/St-con            St-con                    ---
-  Sr-90/SI-con            SI-con                    ---
-  Sr-90/RC-con            RC-con                    ---
-  Sr-90/LC-con            LC-con                    ---
-  Sr-90/RS-con            RS-con                    ---
-  Sr-90/Faeces            Faeces                    ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
-
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
   Sr-90/ETseq-F           ETseq-F                   ---
@@ -280,6 +268,18 @@ Sr-90 Inhalation:Type-M
   Sr-90/INT-S             INT-S                     ---
   Sr-90/LNTH-S            LNTH-S                    ---
   Sr-90/Environment       Environment               ---
+
+  Sr-90/Oralcavity        Oralcavity                ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
+  Sr-90/St-con            St-con                    ---
+  Sr-90/SI-con            SI-con                    ---
+  Sr-90/RC-con            RC-con                    ---
+  Sr-90/LC-con            LC-con                    ---
+  Sr-90/RS-con            RS-con                    ---
+  Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/Blood             Blood1                    ---
   Sr-90/ST0               ST0                       ---

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
@@ -15,8 +15,8 @@ Sr-90 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   RC-con                RC-cont
@@ -103,7 +103,7 @@ Sr-90 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -115,7 +115,7 @@ Sr-90 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -143,10 +143,10 @@ Sr-90 Inhalation:Type-S
   LNTH-S                  Blood                 $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2
@@ -187,8 +187,8 @@ Sr-90 Inhalation:Type-S
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
 
@@ -288,8 +288,8 @@ Sr-90 Inhalation:Type-S
 
 # from parent to progeny
   Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-F      Oesophagus-F              ---
-  Sr-90/Oesophagus-S      Oesophagus-S              ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
   Sr-90/St-con            St-con                    ---
   Sr-90/SI-con            SI-con                    ---
   Sr-90/RC-con            RC-con                    ---
@@ -351,7 +351,7 @@ Sr-90 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -363,7 +363,7 @@ Sr-90 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -391,10 +391,10 @@ Sr-90 Inhalation:Type-S
   LNTH-S                  Blood1                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   SI-conRe                RC-con                    6

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
@@ -14,18 +14,6 @@ Sr-90 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +37,18 @@ Sr-90 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   ST0                   Other
@@ -186,22 +186,6 @@ Sr-90 Inhalation:Type-S
 #-----+---------------------| S-Coefficient
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-
-# ICRP Publ.134 p.252 Table 11.3
-  acc   SI-conRe              SI-cont   # SI-con Re-Absorption
-
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -225,6 +209,22 @@ Sr-90 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+
+# ICRP Publ.134 p.252 Table 11.3
+  acc   SI-conRe              SI-cont   # SI-con Re-Absorption
+
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood1                Blood
   acc   Blood2                Blood
@@ -287,18 +287,6 @@ Sr-90 Inhalation:Type-S
   $fA_Re =      fA_MaxValueOfIng
 
 # from parent to progeny
-  Sr-90/Oralcavity        Oralcavity                ---
-  Sr-90/Oesophagus-f      Oesophagus-f              ---
-  Sr-90/Oesophagus-s      Oesophagus-s              ---
-  Sr-90/St-con            St-con                    ---
-  Sr-90/SI-con            SI-con                    ---
-  Sr-90/RC-con            RC-con                    ---
-  Sr-90/LC-con            LC-con                    ---
-  Sr-90/RS-con            RS-con                    ---
-  Sr-90/Faeces            Faeces                    ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
-
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
   Sr-90/ETseq-F           ETseq-F                   ---
@@ -322,6 +310,18 @@ Sr-90 Inhalation:Type-S
   Sr-90/INT-S             INT-S                     ---
   Sr-90/LNTH-S            LNTH-S                    ---
   Sr-90/Environment       Environment               ---
+
+  Sr-90/Oralcavity        Oralcavity                ---
+  Sr-90/Oesophagus-f      Oesophagus-f              ---
+  Sr-90/Oesophagus-s      Oesophagus-s              ---
+  Sr-90/St-con            St-con                    ---
+  Sr-90/SI-con            SI-con                    ---
+  Sr-90/RC-con            RC-con                    ---
+  Sr-90/LC-con            LC-con                    ---
+  Sr-90/RS-con            RS-con                    ---
+  Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/Blood             Blood1                    ---
 

--- a/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
+++ b/resources/inp/OIR/Sr-90/Sr-90_inh-TypeS.inp
@@ -23,6 +23,8 @@ Sr-90 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -58,8 +60,6 @@ Sr-90 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   Exch-T-bone-V         T-bone-V
   acc   Noch-T-bone-V         T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Sr-90:transfer]
 #-----------------------+---------------------+------------------------
@@ -156,6 +156,9 @@ Sr-90 Inhalation:Type-S
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Blood                 $(fA * 6 / (1 - fA))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.220 Table 10.3
   Blood                   UB-con                    1.73
   Blood                   RC-con                    0.525
@@ -178,9 +181,6 @@ Sr-90 Inhalation:Type-S
   Noch-C-bone-V           Blood                     0.0000821
   Noch-T-bone-V           Blood                     0.000493
 
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12
-
 
 [Y-90:compartment]
 #-----+---------------------| S-Coefficient
@@ -199,6 +199,8 @@ Sr-90 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -244,8 +246,6 @@ Sr-90 Inhalation:Type-S
   acc   C-bone-V              C-bone-V
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Y-90:transfer]
 #-----------------------+---------------------+--------------
@@ -296,6 +296,8 @@ Sr-90 Inhalation:Type-S
   Sr-90/LC-con            LC-con                    ---
   Sr-90/RS-con            RS-con                    ---
   Sr-90/Faeces            Faeces                    ---
+  Sr-90/UB-con            UB-con                    ---
+  Sr-90/Urine             Urine                     ---
 
   Sr-90/ET1-F             ET1-F                     ---
   Sr-90/ET2-F             ET2-F                     ---
@@ -332,15 +334,13 @@ Sr-90 Inhalation:Type-S
   Sr-90/ST0               ST-decay                  ---
   Sr-90/ST1               ST-decay                  ---
   Sr-90/ST2               ST-decay                  ---
-#
+
   Sr-90/C-bone-S          C-bone-S                  ---
   Sr-90/Exch-C-bone-V     C-bone-V                  ---
   Sr-90/Noch-C-bone-V     C-bone-V                  ---
   Sr-90/T-bone-S          T-bone-S                  ---
   Sr-90/Exch-T-bone-V     T-bone-V                  ---
   Sr-90/Noch-T-bone-V     T-bone-V                  ---
-  Sr-90/UB-con            UB-con                    ---
-  Sr-90/Urine             Urine                     ---
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -406,6 +406,9 @@ Sr-90 Inhalation:Type-S
   SI-con                  Blood1                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood1                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.252 Table 11.3
   Blood1                  Blood2                    0.498
   Blood1                  Liver0                    1.66
@@ -439,6 +442,3 @@ Sr-90 Inhalation:Type-S
   C-bone-S                Blood1                    0.0000821
   C-bone-S                C-bone-V                  0.0000411
   C-bone-V                Blood1                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Tc-99/Tc-99_ing.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_ing.inp
@@ -27,6 +27,8 @@ Tc-99 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   Liver1                Liver
@@ -43,8 +45,6 @@ Tc-99 Ingestion
   acc   ST0                   Other
   acc   ST1                   Other
   acc   ST2                   Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Tc-99:transfer]
 #-----------------------+---------------------+--------------
@@ -81,6 +81,9 @@ Tc-99 Ingestion
   SI-con                  Blood                 $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood                 $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.334 Table 15.3
   Blood                   Thyroid1                  7.0
   Blood                   ST0                      71.88
@@ -115,6 +118,3 @@ Tc-99 Ingestion
   C-bone-S                C-bone-V                  0.00462
   T-bone-V                Blood                     0.000493
   C-bone-V                Blood                     0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Tc-99/Tc-99_ing.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_ing.inp
@@ -12,6 +12,7 @@ Tc-99 Ingestion
 # Func| Compartment         | Source Region
 #-----+---------------------+---------------
   inp   input                 ---
+
   acc   Oralcavity            O-cavity
   acc   OralcavityRe          O-cavity
   acc   Oesophagus-f          Oesophag-f

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
@@ -13,24 +13,6 @@ Tc-99 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -54,6 +36,24 @@ Tc-99 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   Liver1                Liver

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeF.inp
@@ -28,6 +28,8 @@ Tc-99 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -68,8 +70,6 @@ Tc-99 Inhalation:Type-F
   acc   ST0                   Other
   acc   ST1                   Other
   acc   ST2                   Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Tc-99:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Tc-99 Inhalation:Type-F
   SI-con                  Blood                 $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood                 $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.334 Table 15.3
   Blood                   Thyroid1                  7.0
   Blood                   ST0                      71.88
@@ -210,6 +213,3 @@ Tc-99 Inhalation:Type-F
   C-bone-S                C-bone-V                  0.00462
   T-bone-V                Blood                     0.000493
   C-bone-V                Blood                     0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
@@ -13,24 +13,6 @@ Tc-99 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -54,6 +36,24 @@ Tc-99 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   Liver1                Liver

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeM.inp
@@ -28,6 +28,8 @@ Tc-99 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -68,8 +70,6 @@ Tc-99 Inhalation:Type-M
   acc   ST0                   Other
   acc   ST1                   Other
   acc   ST2                   Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Tc-99:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Tc-99 Inhalation:Type-M
   SI-con                  Blood                 $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood                 $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.334 Table 15.3
   Blood                   Thyroid1                  7.0
   Blood                   ST0                      71.88
@@ -210,6 +213,3 @@ Tc-99 Inhalation:Type-M
   C-bone-S                C-bone-V                  0.00462
   T-bone-V                Blood                     0.000493
   C-bone-V                Blood                     0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
@@ -13,24 +13,6 @@ Tc-99 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   OralcavityRe          O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   Oesophagus-sRe        Oesophag-s
-  acc   St-wall               St-wall
-  acc   St-con                St-cont
-  acc   St-conRe              St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-wall               RC-wall
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -54,6 +36,24 @@ Tc-99 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   OralcavityRe          O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   Oesophagus-sRe        Oesophag-s
+  acc   St-wall               St-wall
+  acc   St-con                St-cont
+  acc   St-conRe              St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-wall               RC-wall
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Blood                 Blood
   acc   Liver1                Liver

--- a/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
+++ b/resources/inp/OIR/Tc-99/Tc-99_inh-TypeS.inp
@@ -28,6 +28,8 @@ Tc-99 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -68,8 +70,6 @@ Tc-99 Inhalation:Type-S
   acc   ST0                   Other
   acc   ST1                   Other
   acc   ST2                   Other
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Tc-99:transfer]
 #-----------------------+---------------------+--------------
@@ -176,6 +176,9 @@ Tc-99 Inhalation:Type-S
   SI-con                  Blood                 $(fA    * 6 / (1 - fA   ))
   SI-conRe                Blood                 $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.334 Table 15.3
   Blood                   Thyroid1                  7.0
   Blood                   ST0                      71.88
@@ -210,6 +213,3 @@ Tc-99 Inhalation:Type-S
   C-bone-S                C-bone-V                  0.00462
   T-bone-V                Blood                     0.000493
   C-bone-V                Blood                     0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Zn-65/Zn-65_ing.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_ing.inp
@@ -14,8 +14,8 @@ Zn-65 Ingestion
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -55,10 +55,10 @@ Zn-65 Ingestion
   input                   Oralcavity              100.0%
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Zn-65/Zn-65_ing.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_ing.inp
@@ -23,6 +23,8 @@ Zn-65 Ingestion
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other
@@ -39,8 +41,6 @@ Zn-65 Ingestion
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
   exc   Excreta               ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Zn-65:transfer]
 #-----------------------+---------------------+--------------
@@ -71,6 +71,9 @@ Zn-65 Ingestion
 # λ(SI->Blood) = fA * λ(SI->RC) / (1 - fA)
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
+
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
 
 # ICRP Publ.134 p.199 Table 9.4
   Plasma                  Liver1                   60
@@ -104,6 +107,3 @@ Zn-65 Ingestion
   C-bone-S                C-bone-V                  0.00053
   T-bone-V                Plasma                    0.000493
   C-bone-V                Plasma                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
@@ -23,6 +23,8 @@ Zn-65 Inhalation:Type-F
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -63,8 +65,6 @@ Zn-65 Inhalation:Type-F
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
   exc   Excreta               ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Zn-65:transfer]
 #-----------------------+---------------------+--------------
@@ -166,6 +166,9 @@ Zn-65 Inhalation:Type-F
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.199 Table 9.4
   Plasma                  Liver1                   60
   Plasma                  Kidneys                   4
@@ -198,6 +201,3 @@ Zn-65 Inhalation:Type-F
   C-bone-S                C-bone-V                  0.00053
   T-bone-V                Plasma                    0.000493
   C-bone-V                Plasma                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
@@ -13,19 +13,6 @@ Zn-65 Inhalation:Type-F
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Zn-65 Inhalation:Type-F
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeF.inp
@@ -14,8 +14,8 @@ Zn-65 Inhalation:Type-F
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -109,7 +109,7 @@ Zn-65 Inhalation:Type-F
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -121,7 +121,7 @@ Zn-65 Inhalation:Type-F
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -149,10 +149,10 @@ Zn-65 Inhalation:Type-F
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
@@ -23,6 +23,8 @@ Zn-65 Inhalation:Type-M
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -63,8 +65,6 @@ Zn-65 Inhalation:Type-M
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
   exc   Excreta               ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Zn-65:transfer]
 #-----------------------+---------------------+--------------
@@ -166,6 +166,9 @@ Zn-65 Inhalation:Type-M
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.199 Table 9.4
   Plasma                  Liver1                   60
   Plasma                  Kidneys                   4
@@ -198,6 +201,3 @@ Zn-65 Inhalation:Type-M
   C-bone-S                C-bone-V                  0.00053
   T-bone-V                Plasma                    0.000493
   C-bone-V                Plasma                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
@@ -14,8 +14,8 @@ Zn-65 Inhalation:Type-M
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -109,7 +109,7 @@ Zn-65 Inhalation:Type-M
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -121,7 +121,7 @@ Zn-65 Inhalation:Type-M
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -149,10 +149,10 @@ Zn-65 Inhalation:Type-M
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeM.inp
@@ -13,19 +13,6 @@ Zn-65 Inhalation:Type-M
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Zn-65 Inhalation:Type-M
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
@@ -23,6 +23,8 @@ Zn-65 Inhalation:Type-S
   acc   LC-con                LC-cont
   acc   RS-con                RS-cont
   exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
@@ -63,8 +65,6 @@ Zn-65 Inhalation:Type-S
   acc   T-bone-S              T-bone-S
   acc   T-bone-V              T-bone-V
   exc   Excreta               ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
 
 [Zn-65:transfer]
 #-----------------------+---------------------+--------------
@@ -166,6 +166,9 @@ Zn-65 Inhalation:Type-S
   SI-con                  Plasma                $(fA    * 6 / (1 - fA   ))
   SI-conRe                Plasma                $(fA_Re * 6 / (1 - fA_Re))
 
+# ICRP Publ.130 p.85 Para.172
+  UB-con                  Urine                    12
+
 # ICRP Publ.134 p.199 Table 9.4
   Plasma                  Liver1                   60
   Plasma                  Kidneys                   4
@@ -198,6 +201,3 @@ Zn-65 Inhalation:Type-S
   C-bone-S                C-bone-V                  0.00053
   T-bone-V                Plasma                    0.000493
   C-bone-V                Plasma                    0.0000821
-
-# ICRP Publ.130 p.85 Para.172
-  UB-con                  Urine                    12

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
@@ -13,19 +13,6 @@ Zn-65 Inhalation:Type-S
 #-----+---------------------+---------------
   inp   input                 ---
 
-  acc   Oralcavity            O-cavity
-  acc   Oesophagus-f          Oesophag-f
-  acc   Oesophagus-s          Oesophag-s
-  acc   St-con                St-cont
-  acc   SI-con                SI-cont
-  acc   SI-conRe              SI-cont
-  acc   RC-con                RC-cont
-  acc   LC-con                LC-cont
-  acc   RS-con                RS-cont
-  exc   Faeces                ---
-  acc   UB-con                UB-cont
-  exc   Urine                 ---
-
   acc   ET1-F                 ET1-sur
   acc   ET2-F                 ET2-sur
   acc   ETseq-F               ET2-seq
@@ -49,6 +36,19 @@ Zn-65 Inhalation:Type-S
   acc   INT-S                 ALV
   acc   LNTH-S                LN-Th
   exc   Environment           ---
+
+  acc   Oralcavity            O-cavity
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
+  acc   St-con                St-cont
+  acc   SI-con                SI-cont
+  acc   SI-conRe              SI-cont
+  acc   RC-con                RC-cont
+  acc   LC-con                LC-cont
+  acc   RS-con                RS-cont
+  exc   Faeces                ---
+  acc   UB-con                UB-cont
+  exc   Urine                 ---
 
   acc   Plasma                Blood
   acc   ST0                   Other

--- a/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
+++ b/resources/inp/OIR/Zn-65/Zn-65_inh-TypeS.inp
@@ -14,8 +14,8 @@ Zn-65 Inhalation:Type-S
   inp   input                 ---
 
   acc   Oralcavity            O-cavity
-  acc   Oesophagus-F          Oesophag-f
-  acc   Oesophagus-S          Oesophag-s
+  acc   Oesophagus-f          Oesophag-f
+  acc   Oesophagus-s          Oesophag-s
   acc   St-con                St-cont
   acc   SI-con                SI-cont
   acc   SI-conRe              SI-cont
@@ -109,7 +109,7 @@ Zn-65 Inhalation:Type-S
   bbseq-F                 LNTH-F                    0.001
   BB-F                    ET2-F                    10
   BBseq-F                 LNTH-F                    0.001
-  ET2-F                   Oesophagus-S            100
+  ET2-F                   Oesophagus-s            100
   ETseq-F                 LNET-F                    0.001
   ET1-F                   Environment               0.6
   ET1-F                   ET2-F                     1.5
@@ -121,7 +121,7 @@ Zn-65 Inhalation:Type-S
   bbseq-S                 LNTH-S                    0.001
   BB-S                    ET2-S                    10
   BBseq-S                 LNTH-S                    0.001
-  ET2-S                   Oesophagus-S            100
+  ET2-S                   Oesophagus-s            100
   ETseq-S                 LNET-S                    0.001
   ET1-S                   Environment               0.6
   ET1-S                   ET2-S                     1.5
@@ -149,10 +149,10 @@ Zn-65 Inhalation:Type-S
   LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
-  Oralcavity              Oesophagus-F           6480
-  Oralcavity              Oesophagus-S            720
-  Oesophagus-F            St-con                12343
-  Oesophagus-S            St-con                 2160
+  Oralcavity              Oesophagus-f           6480
+  Oralcavity              Oesophagus-s            720
+  Oesophagus-f            St-con                12343
+  Oesophagus-s            St-con                 2160
   St-con                  SI-con                   20.57
   SI-con                  RC-con                    6
   RC-con                  LC-con                    2


### PR DESCRIPTION
HRTM, HATM, 尿路の記述順序について、インプット間で同等となるよう調整する。