### PR TITLE
計算のアウトプットを個別にOFFにする機能を追加

### DIFF
--- a/FlexID.Calc.Tests/InputErrorTests.cs
+++ b/FlexID.Calc.Tests/InputErrorTests.cs
@@ -1050,7 +1050,7 @@ namespace FlexID.Calc.Tests
 
             var stream = new MemoryStream(inputFileBytes);
             var reader = new StreamReader(stream);
-            return new InputDataReader(reader, calcProgeny: true);
+            return new InputDataReader(reader);
         }
     }
 }

--- a/FlexID.Calc.Tests/InputReadTests.cs
+++ b/FlexID.Calc.Tests/InputReadTests.cs
@@ -102,8 +102,7 @@ namespace FlexID.Calc.Tests
             var nuclide = target.Split('_')[0];
             var inputPath = Path.Combine("inp", "OIR", nuclide, target + ".inp");
 
-            var calcProgeny = true;
-            var data = new InputDataReader(inputPath, calcProgeny).Read_OIR();
+            var data = new InputDataReader(inputPath).Read_OIR();
             Assert.IsNotNull(data);
         }
 
@@ -114,8 +113,7 @@ namespace FlexID.Calc.Tests
             var nuclide = target.Split('_')[0];
             var inputPath = Path.Combine("inp", "EIR", nuclide, target + ".inp");
 
-            var calcProgeny = true;
-            var data = new InputDataReader(inputPath, calcProgeny).Read_EIR();
+            var data = new InputDataReader(inputPath).Read_EIR();
             Assert.IsNotNull(data);
         }
     }

--- a/FlexID.Calc.Tests/TestCalc.cs
+++ b/FlexID.Calc.Tests/TestCalc.cs
@@ -18,28 +18,29 @@ namespace FlexID.Calc.Tests
 
             Directory.CreateDirectory(ResultDir);
 
+            var data = new InputDataReader(Path.Combine(TargetDir, target), calcProgeny: false).Read_OIR();
+
             var main = new MainRoutine_OIR();
-            main.InputPath = Path.Combine(TargetDir, target);
-            main.OutputPath = Path.Combine(ResultDir, TargetName);
-            main.CalcTimeMeshPath = Path.Combine(TargetDir, "time-per-1d.dat");
-            main.OutTimeMeshPath = Path.Combine(TargetDir, "time-per-1d.dat");
-            main.CommitmentPeriod = @"5days";
-            main.CalcProgeny = false;
+            main.OutputPath       /**/= Path.Combine(ResultDir, TargetName);
+            main.CalcTimeMeshPath /**/= Path.Combine(TargetDir, "time-per-1d.dat");
+            main.OutTimeMeshPath  /**/= Path.Combine(TargetDir, "time-per-1d.dat");
+            main.CommitmentPeriod /**/= @"5days";
 
-            main.Main();
+            main.Main(data);
 
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Cumulative.out")),
-                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Cumulative.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Dose.out")),
                 File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Dose.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_DoseRate.out")),
                 File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_DoseRate.out")));
+
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Retention.out")),
                 File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Retention.out")));
+            CollectionAssert.AreEqual(
+                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Cumulative.out")),
+                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Cumulative.out")));
         }
     }
 }

--- a/FlexID.Calc.Tests/TestCalc.cs
+++ b/FlexID.Calc.Tests/TestCalc.cs
@@ -18,7 +18,7 @@ namespace FlexID.Calc.Tests
 
             Directory.CreateDirectory(ResultDir);
 
-            var data = new InputDataReader(Path.Combine(TargetDir, target), calcProgeny: false).Read_OIR();
+            var data = new InputDataReader(Path.Combine(TargetDir, target)).Read_OIR();
 
             var main = new MainRoutine_OIR();
             main.OutputPath       /**/= Path.Combine(ResultDir, TargetName);

--- a/FlexID.Calc.Tests/TestCalc.cs
+++ b/FlexID.Calc.Tests/TestCalc.cs
@@ -6,41 +6,76 @@ namespace FlexID.Calc.Tests
     [TestClass]
     public class TestCalc
     {
-        // 試計算
+        /// <summary>
+        /// テスト用計算ケースを使った計算処理の実行を確認する。
+        /// アウトプットファイルの出力切り替え機能についても同時にテストしている。
+        /// </summary>
         [TestMethod]
-        [DataRow("test_ing.inp")]
-        public void Test(string target)
+        [DataRow("test_ing.inp", true,  /**/true,  /**/true,  /**/true  /**/)]
+        [DataRow("test_ing.inp", true,  /**/true,  /**/true,  /**/false /**/)]
+        [DataRow("test_ing.inp", true,  /**/true,  /**/false, /**/true  /**/)]
+        [DataRow("test_ing.inp", true,  /**/true,  /**/false, /**/false /**/)]
+        [DataRow("test_ing.inp", true,  /**/false, /**/true,  /**/true  /**/)]
+        [DataRow("test_ing.inp", true,  /**/false, /**/true,  /**/false /**/)]
+        [DataRow("test_ing.inp", true,  /**/false, /**/false, /**/true  /**/)]
+        [DataRow("test_ing.inp", true,  /**/false, /**/false, /**/false /**/)]
+        [DataRow("test_ing.inp", false, /**/true,  /**/true,  /**/true  /**/)]
+        [DataRow("test_ing.inp", false, /**/true,  /**/true,  /**/false /**/)]
+        [DataRow("test_ing.inp", false, /**/true,  /**/false, /**/true  /**/)]
+        [DataRow("test_ing.inp", false, /**/true,  /**/false, /**/false /**/)]
+        [DataRow("test_ing.inp", false, /**/false, /**/true,  /**/true  /**/)]
+        [DataRow("test_ing.inp", false, /**/false, /**/true,  /**/false /**/)]
+        [DataRow("test_ing.inp", false, /**/false, /**/false, /**/true  /**/)]
+        [DataRow("test_ing.inp", false, /**/false, /**/false, /**/false /**/)]
+        public void TestOutput(string target, bool outDose, bool outDoseRate, bool outActRete, bool outActCumu)
         {
-            var TargetDir = TestFiles.Combine("TestCalc");
-            var ExpectDir = Path.Combine(TargetDir, "Expect");
-            var ResultDir = Path.Combine(TargetDir, "Result~");
-            var TargetName = Path.GetFileNameWithoutExtension(target);
+            var targetDir = TestFiles.Combine("TestCalc");
+            var targetName = Path.GetFileNameWithoutExtension(target);
 
-            Directory.CreateDirectory(ResultDir);
+            var flagsD = $"_dose({(outDose ? "D" : "")}{(outDoseRate ? "R" : "")})";
+            var flagsA = $"_act({(outActRete ? "R" : "")}{(outActCumu ? "C" : "")})";
 
-            var data = new InputDataReader(Path.Combine(TargetDir, target)).Read_OIR();
+            var expectDir = Path.Combine(targetDir, "Expect");
+            var resultDir = Path.Combine(targetDir, $"Result~/output{flagsD}{flagsA}");
+
+            // 結果を出力する空のフォルダを準備する。
+            Directory.CreateDirectory(resultDir);
+            foreach (var previousOutFile in Directory.EnumerateFiles(resultDir))
+                File.Delete(previousOutFile);
+
+            // インプットファイルを読み込む。
+            var data = new InputDataReader(Path.Combine(targetDir, target)).Read_OIR();
+
+            // アウトプットファイル書き出しの有無を設定する。
+            data.OutputDose = outDose;
+            data.OutputDoseRate = outDoseRate;
+            data.OutputRetention = outActRete;
+            data.OutputCumulative = outActCumu;
 
             var main = new MainRoutine_OIR();
-            main.OutputPath       /**/= Path.Combine(ResultDir, TargetName);
-            main.CalcTimeMeshPath /**/= Path.Combine(TargetDir, "time-per-1d.dat");
-            main.OutTimeMeshPath  /**/= Path.Combine(TargetDir, "time-per-1d.dat");
+            main.OutputPath       /**/= Path.Combine(resultDir, targetName);
+            main.CalcTimeMeshPath /**/= Path.Combine(targetDir, "time-per-1d.dat");
+            main.OutTimeMeshPath  /**/= Path.Combine(targetDir, "time-per-1d.dat");
             main.CommitmentPeriod /**/= @"5days";
 
+            // 計算を実行する。
             main.Main(data);
 
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Dose.out")),
-                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Dose.out")));
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_DoseRate.out")),
-                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_DoseRate.out")));
+            // アウトプットファイルの出力有無と、出力されている場合はその内容確認を行う。
+            CheckOutputFile(targetName + "_Dose.out", outDose);
+            CheckOutputFile(targetName + "_DoseRate.out", outDoseRate);
+            CheckOutputFile(targetName + "_Retention.out", outActRete);
+            CheckOutputFile(targetName + "_Cumulative.out", outActCumu);
 
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Retention.out")),
-                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Retention.out")));
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(ExpectDir, TargetName + "_Cumulative.out")),
-                File.ReadAllLines(Path.Combine(ResultDir, TargetName + "_Cumulative.out")));
+            void CheckOutputFile(string fileName, bool outputFlag)
+            {
+                var expectFilePath = Path.Combine(expectDir, fileName);
+                var actualFilePath = Path.Combine(resultDir, fileName);
+                if (outputFlag)
+                    CollectionAssert.AreEqual(File.ReadAllLines(expectFilePath), File.ReadAllLines(actualFilePath));
+                else
+                    Assert.IsFalse(File.Exists(actualFilePath));
+            }
         }
     }
 }

--- a/FlexID.Calc.Tests/TrialCalcTests.cs
+++ b/FlexID.Calc.Tests/TrialCalcTests.cs
@@ -36,7 +36,7 @@ namespace FlexID.Calc.Tests
 
             var commitmentPeriod = "50years";
 
-            var data = new InputDataReader(inputPath, calcProgeny: true).Read_OIR();
+            var data = new InputDataReader(inputPath).Read_OIR();
 
             var main = new MainRoutine_OIR();
             main.OutputPath       /**/= outputPath;
@@ -91,7 +91,7 @@ namespace FlexID.Calc.Tests
                 exposureAge == "Adult"       /**/? "50years" :   // 75years - 25years
                 throw new NotSupportedException();
 
-            var dataList = new InputDataReader(inputPath, calcProgeny: true).Read_EIR();
+            var dataList = new InputDataReader(inputPath).Read_EIR();
 
             var main = new MainRoutine_EIR();
             main.OutputPath       /**/= outputPath;

--- a/FlexID.Calc.Tests/TrialCalcTests.cs
+++ b/FlexID.Calc.Tests/TrialCalcTests.cs
@@ -36,28 +36,29 @@ namespace FlexID.Calc.Tests
 
             var commitmentPeriod = "50years";
 
+            var data = new InputDataReader(inputPath, calcProgeny: true).Read_OIR();
+
             var main = new MainRoutine_OIR();
-            main.InputPath        /**/= inputPath;
             main.OutputPath       /**/= outputPath;
             main.CalcTimeMeshPath /**/= cTimeMeshFile;
             main.OutTimeMeshPath  /**/= oTimeMeshFile;
             main.CommitmentPeriod /**/= commitmentPeriod;
-            main.CalcProgeny      /**/= true;
 
-            main.Main();
+            main.Main(data);
 
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(expectDir, target + "_Cumulative.out")),
-                File.ReadAllLines(Path.Combine(resultDir, target + "_Cumulative.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_Dose.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_Dose.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_DoseRate.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_DoseRate.out")));
+
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_Retention.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_Retention.out")));
+            CollectionAssert.AreEqual(
+                File.ReadAllLines(Path.Combine(expectDir, target + "_Cumulative.out")),
+                File.ReadAllLines(Path.Combine(resultDir, target + "_Cumulative.out")));
         }
 
         [TestMethod]
@@ -90,29 +91,30 @@ namespace FlexID.Calc.Tests
                 exposureAge == "Adult"       /**/? "50years" :   // 75years - 25years
                 throw new NotSupportedException();
 
+            var dataList = new InputDataReader(inputPath, calcProgeny: true).Read_EIR();
+
             var main = new MainRoutine_EIR();
-            main.InputPath        /**/= inputPath;
             main.OutputPath       /**/= outputPath;
             main.CalcTimeMeshPath /**/= cTimeMeshFile;
             main.OutTimeMeshPath  /**/= oTimeMeshFile;
             main.CommitmentPeriod /**/= commitmentPeriod;
-            main.CalcProgeny      /**/= true;
             main.ExposureAge      /**/= exposureAge;
 
-            main.Main();
+            main.Main(dataList);
 
-            CollectionAssert.AreEqual(
-                File.ReadAllLines(Path.Combine(expectDir, target + "_Cumulative.out")),
-                File.ReadAllLines(Path.Combine(resultDir, target + "_Cumulative.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_Dose.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_Dose.out")));
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_DoseRate.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_DoseRate.out")));
+
             CollectionAssert.AreEqual(
                 File.ReadAllLines(Path.Combine(expectDir, target + "_Retention.out")),
                 File.ReadAllLines(Path.Combine(resultDir, target + "_Retention.out")));
+            CollectionAssert.AreEqual(
+                File.ReadAllLines(Path.Combine(expectDir, target + "_Cumulative.out")),
+                File.ReadAllLines(Path.Combine(resultDir, target + "_Cumulative.out")));
         }
     }
 }

--- a/FlexID.Calc/InputDataReader.cs
+++ b/FlexID.Calc/InputDataReader.cs
@@ -281,8 +281,8 @@ namespace FlexID.Calc
         /// コンストラクタ。
         /// </summary>
         /// <param name="inputPath">インプットファイルのパス文字列。</param>
-        /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は<c>true</c>。</param>
-        public InputDataReader(string inputPath, bool calcProgeny)
+        /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は <see langword="true"/>。</param>
+        public InputDataReader(string inputPath, bool calcProgeny = true)
         {
             var stream = new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             var reader = new StreamReader(stream);
@@ -295,8 +295,8 @@ namespace FlexID.Calc
         /// コンストラクタ。
         /// </summary>
         /// <param name="reader">インプットの読み込み元。</param>
-        /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は<c>true</c>。</param>
-        public InputDataReader(StreamReader reader, bool calcProgeny)
+        /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は <see langword="true"/>。</param>
+        public InputDataReader(StreamReader reader, bool calcProgeny = true)
         {
             this.reader = reader;
             this.calcProgeny = calcProgeny;

--- a/FlexID.Calc/InputDataReader.cs
+++ b/FlexID.Calc/InputDataReader.cs
@@ -253,8 +253,32 @@ namespace FlexID.Calc
         public static readonly string[] ParameterNames = new[]
         {
             "ExcludeOtherSourceRegions",
-            "IncludeOtherSourceRegions"
+            "IncludeOtherSourceRegions",
+            "OutputDose",
+            "OutputDoseRate",
+            "OutputRetention",
+            "OutputCumulative",
         };
+
+        /// <summary>
+        /// 線量の計算結果をファイルに出力する場合は <see langword="true"/>。
+        /// </summary>
+        public bool OutputDose { get; set; } = true;
+
+        /// <summary>
+        /// 線量率の計算結果をファイルに出力する場合は <see langword="true"/>。
+        /// </summary>
+        public bool OutputDoseRate { get; set; } = true;
+
+        /// <summary>
+        /// 残留放射能の計算結果をファイルに出力する場合は <see langword="true"/>。
+        /// </summary>
+        public bool OutputRetention { get; set; } = true;
+
+        /// <summary>
+        /// 積算放射能の計算結果をファイルに出力する場合は <see langword="true"/>。
+        /// </summary>
+        public bool OutputCumulative { get; set; } = true;
     }
 
     /// <summary>
@@ -946,6 +970,15 @@ namespace FlexID.Calc
             }
             // 初期配分を終えた後は流入なし。
             input.IsZeroInflow = true;
+
+            bool CheckOutput(string name) =>
+                data.Parameters.TryGetValue(name, out var str) && bool.TryParse(str, out var value) && value;
+
+            // 出力ファイルの設定。
+            data.OutputDose = CheckOutput("OutputDose");
+            data.OutputDoseRate = CheckOutput("OutputDoseRate");
+            data.OutputRetention = CheckOutput("OutputRetention");
+            data.OutputCumulative = CheckOutput("OutputCumulative");
 
             return data;
         }

--- a/FlexID.Calc/MainRoutine_EIR.cs
+++ b/FlexID.Calc/MainRoutine_EIR.cs
@@ -16,11 +16,6 @@ namespace FlexID.Calc
         public string OutputPath { get; set; }
 
         /// <summary>
-        /// 核種情報ファイルパス。
-        /// </summary>
-        public string InputPath { get; set; }
-
-        /// <summary>
         /// 計算時間メッシュファイルパス。
         /// </summary>
         public string CalcTimeMeshPath { get; set; }
@@ -34,11 +29,6 @@ namespace FlexID.Calc
         /// 預託期間。
         /// </summary>
         public string CommitmentPeriod { get; set; }
-
-        /// <summary>
-        /// 子孫核種の計算を行うかどうか。
-        /// </summary>
-        public bool CalcProgeny { get; set; }
 
         /// <summary>
         /// 被ばく時の年齢。
@@ -57,14 +47,12 @@ namespace FlexID.Calc
         public const int Age15year = 15 * 365;
         public const int AgeAdult = 25 * 365;   // TODO: 現在はSrしか計算しないため25歳で決め打ち
 
-        public void Main()
+        public void Main(List<InputData> dataList)
         {
             var calcTimeMesh = new TimeMesh(CalcTimeMeshPath);
             var outTimeMesh = new TimeMesh(OutTimeMeshPath);
             if (!calcTimeMesh.Cover(outTimeMesh))
                 throw Program.Error("Calculation time mesh does not cover all boundaries of output time mesh.");
-
-            var dataList = new InputDataReader(InputPath, CalcProgeny).Read_EIR();
 
             using (CalcOut = new CalcOut(dataList[0], OutputPath))
             {

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -17,11 +17,6 @@ namespace FlexID.Calc
         public string OutputPath { get; set; }
 
         /// <summary>
-        /// 核種情報ファイルパス。
-        /// </summary>
-        public string InputPath { get; set; }
-
-        /// <summary>
         /// 計算時間メッシュファイルパス。
         /// </summary>
         public string CalcTimeMeshPath { get; set; }
@@ -36,23 +31,16 @@ namespace FlexID.Calc
         /// </summary>
         public string CommitmentPeriod { get; set; }
 
-        /// <summary>
-        /// 子孫核種の計算を行うかどうか。
-        /// </summary>
-        public bool CalcProgeny { get; set; }
-
         public Activity Act { get; } = new Activity();
 
         private CalcOut CalcOut { get; set; }
 
-        public void Main()
+        public void Main(InputData data)
         {
             var calcTimeMesh = new TimeMesh(CalcTimeMeshPath);
             var outTimeMesh = new TimeMesh(OutTimeMeshPath);
             if (!calcTimeMesh.Cover(outTimeMesh))
                 throw Program.Error("Calculation time mesh does not cover all boundaries of output time mesh.");
-
-            var data = new InputDataReader(InputPath, CalcProgeny).Read_OIR();
 
             using (CalcOut = new CalcOut(data, OutputPath))
             {

--- a/FlexID.Calc/Program.cs
+++ b/FlexID.Calc/Program.cs
@@ -68,14 +68,14 @@ namespace FlexID.Calc
                 var FileLines = File.ReadAllLines(args[0]);
                 var param = GetParam(FileLines);
 
-                main.OutputPath = param.Output;
-                main.InputPath = param.Input;
-                main.CalcTimeMeshPath = param.CalcTimeMesh;
-                main.OutTimeMeshPath = param.OutTimeMesh;
-                main.CommitmentPeriod = param.CommitmentPeriod;
-                main.CalcProgeny = true;
+                var data = new InputDataReader(param.Input, calcProgeny: true).Read_OIR();
 
-                main.Main();
+                main.OutputPath       /**/= param.Output;
+                main.CalcTimeMeshPath /**/= param.CalcTimeMesh;
+                main.OutTimeMeshPath  /**/= param.OutTimeMesh;
+                main.CommitmentPeriod /**/= param.CommitmentPeriod;
+
+                main.Main(data);
 
                 return 0;
             }

--- a/FlexID.Calc/Program.cs
+++ b/FlexID.Calc/Program.cs
@@ -68,7 +68,7 @@ namespace FlexID.Calc
                 var FileLines = File.ReadAllLines(args[0]);
                 var param = GetParam(FileLines);
 
-                var data = new InputDataReader(param.Input, calcProgeny: true).Read_OIR();
+                var data = new InputDataReader(param.Input).Read_OIR();
 
                 main.OutputPath       /**/= param.Output;
                 main.CalcTimeMeshPath /**/= param.CalcTimeMesh;

--- a/FlexID/ViewModels/InputData.cs
+++ b/FlexID/ViewModels/InputData.cs
@@ -96,7 +96,7 @@ namespace FlexID.ViewModels
                 Calc.InputData data;
                 try
                 {
-                    var reader = new InputDataReader(inputFile, calcProgeny: true);
+                    var reader = new InputDataReader(inputFile);
                     data = reader.Read_OIR();
                 }
                 catch
@@ -140,7 +140,7 @@ namespace FlexID.ViewModels
                 Calc.InputData data;
                 try
                 {
-                    var reader = new InputDataReader(inputFile, calcProgeny: true);
+                    var reader = new InputDataReader(inputFile);
                     data = reader.Read_EIR().FirstOrDefault();
                 }
                 catch

--- a/FlexID/ViewModels/InputEIRViewModel.cs
+++ b/FlexID/ViewModels/InputEIRViewModel.cs
@@ -170,16 +170,16 @@ namespace FlexID.ViewModels
         {
             // FlexID.Calcアセンブリがない場合はこのメソッドに入った直後に例外が発生する。
 
-            var main = new MainRoutine_EIR();
-            main.OutputPath = OutputFilePath.Value;
-            main.InputPath = selectedInput.FilePath;
-            main.CalcTimeMeshPath = CalcTimeMeshFilePath.Value;
-            main.OutTimeMeshPath = OutTimeMeshFilePath.Value;
-            main.CommitmentPeriod = CommitmentPeriod.Value + SelectedCommitmentPeriodUnit.Value;
-            main.CalcProgeny = CalcProgeny.Value;
-            main.ExposureAge = SelectedIntakeAge.Value;
+            var dataList = new InputDataReader(selectedInput.FilePath, CalcProgeny.Value).Read_EIR();
 
-            await Task.Run(() => main.Main());
+            var main = new MainRoutine_EIR();
+            main.OutputPath       /**/= OutputFilePath.Value;
+            main.CalcTimeMeshPath /**/= CalcTimeMeshFilePath.Value;
+            main.OutTimeMeshPath  /**/= OutTimeMeshFilePath.Value;
+            main.CommitmentPeriod /**/= CommitmentPeriod.Value + SelectedCommitmentPeriodUnit.Value;
+            main.ExposureAge      /**/= SelectedIntakeAge.Value;
+
+            await Task.Run(() => main.Main(dataList));
 
             // ファイルパスを引数にして出力GUI実行
             var p = Process.Start("FlexID.Viewer.exe", main.OutputPath + "_Retention.out");

--- a/FlexID/ViewModels/InputOIRViewModel.cs
+++ b/FlexID/ViewModels/InputOIRViewModel.cs
@@ -156,15 +156,15 @@ namespace FlexID.ViewModels
         {
             // FlexID.Calcアセンブリがない場合はこのメソッドに入った直後に例外が発生する。
 
-            var main = new MainRoutine_OIR();
-            main.OutputPath = OutputFilePath.Value;
-            main.InputPath = selectedInput.FilePath;
-            main.CalcTimeMeshPath = CalcTimeMeshFilePath.Value;
-            main.OutTimeMeshPath = OutTimeMeshFilePath.Value;
-            main.CommitmentPeriod = CommitmentPeriod.Value + SelectedCommitmentPeriodUnit.Value;
-            main.CalcProgeny = CalcProgeny.Value;
+            var data = new InputDataReader(selectedInput.FilePath, CalcProgeny.Value).Read_OIR();
 
-            await Task.Run(() => main.Main());
+            var main = new MainRoutine_OIR();
+            main.OutputPath       /**/= OutputFilePath.Value;
+            main.CalcTimeMeshPath /**/= CalcTimeMeshFilePath.Value;
+            main.OutTimeMeshPath  /**/= OutTimeMeshFilePath.Value;
+            main.CommitmentPeriod /**/= CommitmentPeriod.Value + SelectedCommitmentPeriodUnit.Value;
+
+            await Task.Run(() => main.Main(data));
 
             // ファイルパスを引数にして出力GUI実行
             var p = Process.Start("FlexID.Viewer.exe", main.OutputPath + "_Retention.out");

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -110,7 +110,7 @@ namespace ResultChecker
 
             var commitmentPeriod = "50years";
 
-            var data = new InputDataReader(inputPath, calcProgeny: true).Read_OIR();
+            var data = new InputDataReader(inputPath).Read_OIR();
 
             var main = new MainRoutine_OIR();
             main.OutputPath       /**/= outputPath;

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -110,15 +110,15 @@ namespace ResultChecker
 
             var commitmentPeriod = "50years";
 
+            var data = new InputDataReader(inputPath, calcProgeny: true).Read_OIR();
+
             var main = new MainRoutine_OIR();
-            main.InputPath        /**/= inputPath;
             main.OutputPath       /**/= outputPath;
             main.CalcTimeMeshPath /**/= cTimeMeshFile;
             main.OutTimeMeshPath  /**/= oTimeMeshFile;
             main.CommitmentPeriod /**/= commitmentPeriod;
-            main.CalcProgeny      /**/= true;
 
-            main.Main();
+            main.Main(data);
 
             var result = new Result() { Target = target };
 


### PR DESCRIPTION
現在は1つの計算結果について残留放射能、積算放射能、線量、線量率の4つのファイルを出力するが、一部の計算（ResultCheckerや解析解との比較など）ではこれらの全てを必要としない場合がある。そのため、これらについて個別に出力のON/OFFを選択できる機能を追加する。

設定は`[parameter]`セクションにて以下のように行う。4つのオプションは既定値として`true`が設定される。
```
[parameter]
OutputRetention = true
OutputCumulative = false
OutputDose = true
OutputDoseRate = false
```