### PR TITLE
ResultChecker実行時のアウトプットを必要なものだけに削減する

### DIFF
--- a/FlexID.Calc/InputDataReader.cs
+++ b/FlexID.Calc/InputDataReader.cs
@@ -972,7 +972,7 @@ namespace FlexID.Calc
             input.IsZeroInflow = true;
 
             bool CheckOutput(string name) =>
-                data.Parameters.TryGetValue(name, out var str) && bool.TryParse(str, out var value) && value;
+                data.Parameters.TryGetValue(name, out var str) && bool.TryParse(str, out var value) ? value : true;
 
             // 出力ファイルの設定。
             data.OutputDose = CheckOutput("OutputDose");

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -335,12 +335,8 @@ namespace FlexID.Calc
                 }
             }
 
-            this.WholeBodyEffectiveDose = wholeBodyNow;
-
             // 計算完了の出力を行う。
             CalcOut.FinishOut();
         }
-
-        public double WholeBodyEffectiveDose { get; private set; }
     }
 }

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -211,7 +211,7 @@ namespace ResultChecker
             result.FractionsThyroid   /**/= fractionsThyroid;
 
             // 50年預託実行線量の比較。
-            var actualDose = main.WholeBodyEffectiveDose;
+            var actualDose = GetResultEffectiveDose(target);
             var expectDose = ReadDosePerIntake(target, mat);
             result.ActualEffectiveDose = $"{actualDose:0.000000E+00}";
             result.ExpectEffectiveDose = expectDose;
@@ -446,6 +446,30 @@ namespace ResultChecker
             }
 
             return retentions;
+        }
+
+        /// <summary>
+        /// FlexIDが出力した各出力時間メッシュにおける線量の出力ファイル
+        /// *_Dose.outから、Whole Bodyの数値列の最終値を読み込む。
+        /// </summary>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        static double GetResultEffectiveDose(string target)
+        {
+            var nuclide = target.Split('_')[0];
+            var filePath = $"out/{target}_Dose.out";
+
+            using (var reader = new OutputDataReader(filePath))
+            {
+                var data = reader.Read();
+                var result = data.Nuclides[0];
+
+                var resultWholeBody = result.Compartments.FirstOrDefault(c => c.Name == "WholeBody");
+                if (resultWholeBody is null)
+                    throw new InvalidDataException();
+
+                return resultWholeBody.Values.Last();
+            }
         }
     }
 

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -111,6 +111,10 @@ namespace ResultChecker
             var commitmentPeriod = "50years";
 
             var data = new InputDataReader(inputPath).Read_OIR();
+            data.OutputDose = true;
+            data.OutputDoseRate = false;
+            data.OutputRetention = true;
+            data.OutputCumulative = false;
 
             var main = new MainRoutine_OIR();
             main.OutputPath       /**/= outputPath;


### PR DESCRIPTION
#152 で追加した機能を使用してDose.outとRetention.outのみを使用し、残り2つのアウトプットファイルについては出力しないようにする。