### PR TITLE
時間メッシュの不整合を報告するメッセージを改良する

### DIFF
--- a/FlexID.Calc/TimeMesh.cs
+++ b/FlexID.Calc/TimeMesh.cs
@@ -141,6 +141,7 @@ namespace FlexID.Calc
                 ReadLine();
 
                 var prevEnd = 0L;
+                var prevEndStr = "";
                 while (true)
                 {
                     var ln = ReadLine();
@@ -159,10 +160,11 @@ namespace FlexID.Calc
                     if (interval < currStep)
                         throw new FormatException("Mesh interval is less than step value.");
                     if (interval % currStep != 0)
-                        throw new FormatException("Mesh interval should be equal to multiple of step value.");
+                        throw new FormatException($"Mesh interval ({columns[0]} - {prevEndStr}) should be equal to multiple of step value {columns[1]}.");
 
                     boundaries.Add(new TimeMeshBoundary(currEnd, currStep));
                     prevEnd = currEnd;
+                    prevEndStr = columns[0];
                 }
                 if (boundaries.Count < 1)
                     throw new FormatException("At least one mesh boundary is required.");


### PR DESCRIPTION
どの時間メッシュ間隔がStepの整数倍と整合していないかがわかるよう、メッシュの開始と終了時刻を追加で出力する。