### PR TITLE
Fe-59のインプットにおいて3種類の骨髄コンパートメントに線源領域としてR-marrowを設定する

### DIFF
--- a/resources/inp/OIR/Fe-59/Fe-59_ing.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_ing.inp
@@ -30,9 +30,9 @@ Fe-59 Ingestion:Unspecified
   acc   Liver1(Hepato)        Liver
   acc   Liver2(RE)            Liver
   acc   Spleen                Spleen
-  acc   MarrowSynthe          Other
-  acc   MarrowTransit         Other
-  acc   MarrowStorage         Other
+  acc   MarrowSynthe          R-marrow
+  acc   MarrowTransit         R-marrow
+  acc   MarrowStorage         R-marrow
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeF.inp
@@ -54,9 +54,9 @@ Fe-59 Inhalation:Type-F
   acc   Liver1(Hepato)        Liver
   acc   Liver2(RE)            Liver
   acc   Spleen                Spleen
-  acc   MarrowSynthe          Other
-  acc   MarrowTransit         Other
-  acc   MarrowStorage         Other
+  acc   MarrowSynthe          R-marrow
+  acc   MarrowTransit         R-marrow
+  acc   MarrowStorage         R-marrow
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeM.inp
@@ -54,9 +54,9 @@ Fe-59 Inhalation:Type-M
   acc   Liver1(Hepato)        Liver
   acc   Liver2(RE)            Liver
   acc   Spleen                Spleen
-  acc   MarrowSynthe          Other
-  acc   MarrowTransit         Other
-  acc   MarrowStorage         Other
+  acc   MarrowSynthe          R-marrow
+  acc   MarrowTransit         R-marrow
+  acc   MarrowStorage         R-marrow
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other

--- a/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
+++ b/resources/inp/OIR/Fe-59/Fe-59_inh-TypeS.inp
@@ -54,9 +54,9 @@ Fe-59 Inhalation:Type-S
   acc   Liver1(Hepato)        Liver
   acc   Liver2(RE)            Liver
   acc   Spleen                Spleen
-  acc   MarrowSynthe          Other
-  acc   MarrowTransit         Other
-  acc   MarrowStorage         Other
+  acc   MarrowSynthe          R-marrow
+  acc   MarrowTransit         R-marrow
+  acc   MarrowStorage         R-marrow
   acc   Other1(Trans)         Other
   acc   Other2(Parenc)        Other
   acc   Other3(RE)            Other


### PR DESCRIPTION
Close #128.

Fe-59のインプットについて骨格集合コンパートメントの残留を計算し、これがOIRによく合うことを確認した。
変更の根拠については https://github.com/9rnsr/FlexID/issues/128#issuecomment-2809610297 を参照。