### PR TITLE
移行係数がない壊変経路の定義は、直接の娘核種でない場合も許可する

### DIFF
--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -853,7 +853,7 @@ namespace FlexID.Calc
                     if (isDecayPath)
                     {
                         // 分岐比が不明な壊変経路は定義できない。
-                        if (!toNuclide.DecayRates.Any(b => b.Parent == fromNuclide.Name))
+                        if (!decayNuclides[fromNuclide].Contains(toNuclide))
                             throw Program.Error($"Line {lineNum}: There is no decay path from {fromNuclide.Name} to {toNuclide.Name}.");
 
                         var paths = decayPaths.Where(path => path.from == organFrom);


### PR DESCRIPTION
PR #169 では崩壊系列を経た孫移行の核種への壊変経路について移行速度ありとなしのものを混在可能としたが、後者について従来の娘への移行経路のみを許可するためのエラー確認処理が残ったままだった。

インプットの確認処理によって不必要にエラーとしていたのを修正。