### PR TITLE
ResultCheckerの計算進捗表示について改良する

### DIFF
--- a/ResultChecker/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/ResultChecker/LimitedConcurrencyLevelTaskScheduler.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ResultChecker
+{
+    // https://learn.microsoft.com/ja-jp/dotnet/api/system.threading.tasks.taskscheduler
+
+    // Provides a task scheduler that ensures a maximum concurrency level while
+    // running on top of the thread pool.
+    public class LimitedConcurrencyLevelTaskScheduler : TaskScheduler
+    {
+        // Indicates whether the current thread is processing work items.
+        [ThreadStatic]
+        private static bool _currentThreadIsProcessingItems;
+
+        // The list of tasks to be executed
+        private readonly LinkedList<Task> _tasks = new LinkedList<Task>(); // protected by lock(_tasks)
+
+        // The maximum concurrency level allowed by this scheduler.
+        private readonly int _maxDegreeOfParallelism;
+
+        // Indicates whether the scheduler is currently processing work items.
+        private int _delegatesQueuedOrRunning = 0;
+
+        // Creates a new instance with the specified degree of parallelism.
+        public LimitedConcurrencyLevelTaskScheduler(int maxDegreeOfParallelism)
+        {
+            if (maxDegreeOfParallelism < 1)
+                throw new ArgumentOutOfRangeException("maxDegreeOfParallelism");
+
+            _maxDegreeOfParallelism = maxDegreeOfParallelism;
+        }
+
+        // Gets the maximum concurrency level supported by this scheduler.
+        public sealed override int MaximumConcurrencyLevel => _maxDegreeOfParallelism;
+
+        // Queues a task to the scheduler.
+        protected sealed override void QueueTask(Task task)
+        {
+            // Add the task to the list of tasks to be processed.  If there aren't enough
+            // delegates currently queued or running to process tasks, schedule another.
+            lock (_tasks)
+            {
+                _tasks.AddLast(task);
+                if (_delegatesQueuedOrRunning < _maxDegreeOfParallelism)
+                {
+                    ++_delegatesQueuedOrRunning;
+                    NotifyThreadPoolOfPendingWork();
+                }
+            }
+        }
+
+        // Inform the ThreadPool that there's work to be executed for this scheduler.
+        private void NotifyThreadPoolOfPendingWork()
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(_ =>
+            {
+                // Note that the current thread is now processing work items.
+                // This is necessary to enable inlining of tasks into this thread.
+                _currentThreadIsProcessingItems = true;
+                try
+                {
+                    // Process all available items in the queue.
+                    while (true)
+                    {
+                        Task item;
+                        lock (_tasks)
+                        {
+                            // When there are no more items to be processed,
+                            // note that we're done processing, and get out.
+                            if (_tasks.Count == 0)
+                            {
+                                --_delegatesQueuedOrRunning;
+                                break;
+                            }
+
+                            // Get the next item from the queue
+                            item = _tasks.First.Value;
+                            _tasks.RemoveFirst();
+                        }
+
+                        // Execute the task we pulled out of the queue
+                        base.TryExecuteTask(item);
+                    }
+                }
+                // We're done processing items on the current thread
+                finally
+                {
+                    _currentThreadIsProcessingItems = false;
+                }
+            }, null);
+        }
+
+        // Attempts to execute the specified task on the current thread.
+        protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            // If this thread isn't already processing a task, we don't support inlining
+            if (!_currentThreadIsProcessingItems)
+                return false;
+
+            // If the task was previously queued, remove it from the queue
+            if (taskWasPreviouslyQueued)
+            {
+                // Try to run the task.
+                if (TryDequeue(task))
+                    return base.TryExecuteTask(task);
+                else
+                    return false;
+            }
+            else
+                return base.TryExecuteTask(task);
+        }
+
+        // Attempt to remove a previously scheduled task from the scheduler.
+        protected sealed override bool TryDequeue(Task task)
+        {
+            lock (_tasks)
+                return _tasks.Remove(task);
+        }
+
+        // Gets an enumerable of the tasks currently scheduled on this scheduler.
+        protected sealed override IEnumerable<Task> GetScheduledTasks()
+        {
+            bool lockTaken = false;
+            try
+            {
+                Monitor.TryEnter(_tasks, ref lockTaken);
+                if (lockTaken)
+                    return _tasks;
+                else
+                    throw new NotSupportedException();
+            }
+            finally
+            {
+                if (lockTaken)
+                    Monitor.Exit(_tasks);
+            }
+        }
+    }
+}

--- a/ResultChecker/ProgressPresenter.cs
+++ b/ResultChecker/ProgressPresenter.cs
@@ -1,3 +1,5 @@
+#define DEBUG_ParallelRunningCount
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,6 +45,9 @@ namespace ResultChecker
         private int totalCount;
         private int finishCount;
         private const int DumpCount = 10;
+#if DEBUG_ParallelRunningCount
+        private int runningCount;
+#endif
 
         /// <summary>
         /// コンストラクタ。
@@ -93,6 +98,9 @@ namespace ResultChecker
                 var item = new ItemData(name);
                 items.Add(item);
                 PrintOut(item, overwriteLine: true);
+#if DEBUG_ParallelRunningCount
+                //System.Diagnostics.Debug.WriteLine($"START {name} : ThreadID = {Thread.CurrentThread.ManagedThreadId}");
+#endif
             }
             finally
             {
@@ -117,6 +125,9 @@ namespace ResultChecker
 
                 var target = items[i];
                 target.SetStatus(status, message);
+#if DEBUG_ParallelRunningCount
+                System.Diagnostics.Debug.WriteLine($"END   {name} : ThreadID = {Thread.CurrentThread.ManagedThreadId}");
+#endif
             }
             finally
             {
@@ -162,6 +173,14 @@ namespace ResultChecker
                 // 実行中の項目を出力。
                 foreach (var item in items)
                     PrintOut(item, overwriteLine);
+
+#if DEBUG_ParallelRunningCount
+                if (items.Count != runningCount)
+                {
+                    runningCount = items.Count;
+                    System.Diagnostics.Debug.WriteLine($"runningCount = {runningCount}");
+                }
+#endif
             }
             finally
             {
@@ -214,6 +233,9 @@ namespace ResultChecker
         {
             Console.Write("\x1B[K");
             Console.WriteLine($"=== {finishCount} / {totalCount} done ===");
+#if DEBUG_ParallelRunningCount
+            System.Diagnostics.Debug.WriteLine($"=== {finishCount} / {totalCount} done ===");
+#endif
         }
 
         public async Task WaitForExit()

--- a/ResultChecker/ProgressPresenter.cs
+++ b/ResultChecker/ProgressPresenter.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ResultChecker
+{
+    class ProgressPresenter
+    {
+        private class ItemData
+        {
+            public string Name { get; }
+
+            public string Status { get; private set; }
+
+            public string Message { get; private set; }
+
+            public bool IsFinished { get; private set; }
+
+            public ItemData(string name)
+            {
+                Name = name;
+            }
+
+            public void SetStatus(string status, string message)
+            {
+                Status = status;
+                Message = message;
+                IsFinished = true;
+            }
+        }
+
+        private readonly Task task;
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        private readonly List<ItemData> items = new List<ItemData>();
+        private readonly ReaderWriterLockSlim locker = new ReaderWriterLockSlim();
+
+        private string windmill = "/";
+        private readonly TimeSpan wait = TimeSpan.FromMilliseconds(100);
+
+        private int totalCount;
+        private int finishCount;
+        private const int DumpCount = 10;
+
+        /// <summary>
+        /// コンストラクタ。
+        /// </summary>
+        /// <param name="totalCount">項目の総数。</param>
+        public ProgressPresenter(int totalCount)
+        {
+            this.totalCount = totalCount;
+            this.finishCount = 0;
+
+            var cancellationToken = cancellationTokenSource.Token;
+
+            // 一定間隔ごとに画面を更新するためのタスク。
+            task = new Task(async () =>
+            {
+                DumpOut();
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    Update();
+                    try
+                    {
+                        await Task.Delay(wait, cancellationToken);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        break;
+                    }
+                }
+                Update();
+
+                if (totalCount % DumpCount != 0)
+                    DumpOut();
+            }, TaskCreationOptions.LongRunning);
+
+            task.Start();
+        }
+
+        /// <summary>
+        /// 実行開始した新しい項目を追加する。
+        /// </summary>
+        /// <param name="name">項目名。</param>
+        public void Start(string name)
+        {
+            locker.EnterWriteLock();
+            try
+            {
+                var item = new ItemData(name);
+                items.Add(item);
+                PrintOut(item, overwriteLine: true);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// 項目を実行終了したうえで最終状態を設定する。
+        /// </summary>
+        /// <param name="name">項目名。</param>
+        /// <param name="status">最終状態。</param>
+        /// <param name="message">付加的なメッセージ。</param>
+        public void Stop(string name, string status, string message = null)
+        {
+            locker.EnterReadLock();
+            try
+            {
+                var i = items.IndexOf(item => item.Name == name);
+                if (i == -1)
+                    return;
+
+                var target = items[i];
+                target.SetStatus(status, message);
+            }
+            finally
+            {
+                locker.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// 画面の更新処理。
+        /// </summary>
+        private void Update()
+        {
+            switch (windmill)
+            {
+                case @"/": windmill = @"-"; break;
+                case @"-": windmill = @"\"; break;
+                case @"\": windmill = @"|"; break;
+                case @"|": windmill = @"/"; break;
+            }
+
+            locker.EnterWriteLock();
+            try
+            {
+                if (items.Count == 0)
+                    return;
+
+                // カーソルをitems.Count行上の先頭に移動。
+                Console.Write($"\x1B[{items.Count}F");
+
+                var overwriteLine = false;
+                // 終了した項目を出力。
+                foreach (var item in items.Where(item => item.IsFinished))
+                {
+                    overwriteLine = true;
+                    PrintOut(item, overwriteLine);
+                    if ((++finishCount % DumpCount) == 0)
+                        DumpOut();
+                }
+
+                // 終了した項目を除去。
+                items.RemoveAll(item => item.IsFinished);
+
+                // 実行中の項目を出力。
+                foreach (var item in items)
+                    PrintOut(item, overwriteLine);
+            }
+            finally
+            {
+                locker.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// 項目情報の出力処理。
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="overwriteLine">行全体を書き換える場合は<see langword="true"/>。</param>
+        void PrintOut(ItemData item, bool overwriteLine)
+        {
+            if (item.IsFinished)
+                overwriteLine = true;
+
+            if (!overwriteLine)
+            {
+                // 風車部分のみ更新。
+                Console.WriteLine($"\x1B[1C\x1B[33m{windmill}\x1B[0m");
+                return;
+            }
+
+            // 行末まで消去。
+            Console.Write("\x1B[K");
+
+            // 終了状態または風車を出力。
+            Console.Write("[");
+            if (item.IsFinished)
+                Console.Write(item.Status);
+            else
+                Console.Write($"\x1B[33m{windmill}\x1B[0m");
+            Console.Write("] ");
+
+            // 項目名を出力。
+            Console.Write(item.Name);
+
+            // メッセージがある場合はこれを追加出力。
+            if (item.IsFinished && item.Message != null)
+                Console.WriteLine($" : \x1B[33m{item.Message}\u001b[0m");
+            else
+                Console.WriteLine();
+        }
+
+        /// <summary>
+        /// ダンプ情報の出力処理。
+        /// </summary>
+        private void DumpOut()
+        {
+            Console.Write("\x1B[K");
+            Console.WriteLine($"=== {finishCount} / {totalCount} done ===");
+        }
+
+        public async Task WaitForExit()
+        {
+            cancellationTokenSource.Cancel();
+
+            await task;
+        }
+    }
+}


### PR DESCRIPTION
現在のResultCheckerはコンソールに計算完了したインプットの名前を出力するが、現在実行中の計算についてはわからない問題がある。また対象となったインプット総数に対していくつまで処理完了したかなどの情報も出力されないため、進捗状況が分かりづらい。

これらを改善するため、エスケープシーケンスを使った色付きのコンソール出力と、実行中の計算ケースをアニメーション付きで表示する仕組みを追加する。

改良後の画面イメージを以下に示す。
![image](https://github.com/user-attachments/assets/2bb4bc9e-a336-4dbd-a68c-8dc7447f1d61)

計算実行中のインプットに対しては、`[/]`→`[-]`→`[\]`→`[|]`→`[/]`というアニメーションで回転する風車が表示される。

さらに、従来使用していた`Paralle.ForEach`には計算実施したインプット数が多くなるにつれて並列計算される数が減っていくという問題があったため、これについても併せて対策を実施した。