### PR TITLE
ResultCheckerの出力するサマリーファイルにおけるカラースケールの下限側の色を青強めに変更

### DIFF
--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -163,7 +163,7 @@ namespace ResultChecker
 
             condition.LowValue.Type = eExcelConditionalFormattingValueObjectType.Num;
             condition.LowValue.Value = 0.5;
-            condition.LowValue.Color = Color.LightBlue;
+            condition.LowValue.Color = Color.DeepSkyBlue;
             condition.MiddleValue.Type = eExcelConditionalFormattingValueObjectType.Num;
             condition.MiddleValue.Value = 1.0;
             condition.MiddleValue.Color = Color.LightGreen;


### PR DESCRIPTION
従来のカラースケールは上限側に対して下限側が淡い色で差異が分かりにくかったため、視認性の向上を目的とする。

変更前
![image](https://github.com/user-attachments/assets/d54c4211-3273-4041-85b6-ca33280dcf49)

変更後
![image](https://github.com/user-attachments/assets/c7f1c6ea-9b59-4284-923f-e85efba030f7)
