### PR TITLE
FlexID GUIの起動が極端に遅くなっていた問題を修正

### DIFF
--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -42,6 +42,8 @@ namespace FlexID.Calc
             if (!calcTimeMesh.Cover(outTimeMesh))
                 throw Program.Error("Calculation time mesh does not cover all boundaries of output time mesh.");
 
+            InputDataReader_OIR.SetSCoefficients(data);
+
             using (CalcOut = new CalcOut(data, OutputPath))
             {
                 // ログファイルを出力する。


### PR DESCRIPTION
FlexID GUIでは評価実行可能な核種とインプットのタイトルを取得するため、inpフォルダ配下にあるすべてのインプットをいったん読み込むことでこれを実施しているが、S係数データをインプット毎に自動計算するように変更した際、これがGUI起動時のすべてのインプット読み込み処理に乗ってしまい、GUI起動が非常に遅くなる問題が生じていた。

S係数データの読み込みと各コンパートメントへの設定処理を、インプットの読み込み中から計算の開始直前に移動することで当該問題を解消する。