### PR TITLE
[nuclide]セクションで未指定の核種をコンパートメントや移行経路の定義セクションで指定した場合のエラー報告処理を追加

### DIFF
--- a/FlexID.Calc.Tests/InputErrorTests.cs
+++ b/FlexID.Calc.Tests/InputErrorTests.cs
@@ -154,6 +154,25 @@ namespace FlexID.Calc.Tests
         }
 
         [TestMethod]
+        public void SectionCompartmentNuclideUndefined()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[nuclide]",
+                "  Sr-90",
+                "",
+                "[Pu-249:compartment]",
+                "  inp    input     ---",
+            });
+
+            var e = Assert.ThrowsException<ApplicationException>(() => reader.Read());
+            Assert.AreEqual("Undefined nuclide 'Pu-249' is used to define compartments.", e.Message);
+        }
+
+        [TestMethod]
         public void SectionCompartmentDuplicated()
         {
             var reader = CreateReader(new[]
@@ -220,6 +239,25 @@ namespace FlexID.Calc.Tests
 
             var e = Assert.ThrowsException<ApplicationException>(() => reader.Read());
             Assert.AreEqual("None of compartments defined for nuclide 'Sr-90'.", e.Message);
+        }
+
+        [TestMethod]
+        public void SectionTransferNuclideUndefined()
+        {
+            var reader = CreateReader(new[]
+            {
+                "[title]",
+                "dummy",
+                "",
+                "[nuclide]",
+                "  Sr-90",
+                "",
+                "[Pu-249:transfer]",
+                "  xxx    yyy    100",
+            });
+
+            var e = Assert.ThrowsException<ApplicationException>(() => reader.Read());
+            Assert.AreEqual("Undefined nuclide 'Pu-249' is used to define transfers.", e.Message);
         }
 
         [TestMethod]

--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -159,6 +159,12 @@ namespace FlexID.Calc
             if (!nuclides.Any())
                 throw Program.Error($"None of nuclides defined.");
 
+            foreach (var undefinedNuc in nuclideOrgans.Keys.Except(nuclides.Select(n => n.Name)))
+                throw Program.Error($"Undefined nuclide '{undefinedNuc}' is used to define compartments.");
+
+            foreach (var undefinedNuc in nuclideTransfers.Keys.Except(nuclides.Select(n => n.Name)))
+                throw Program.Error($"Undefined nuclide '{undefinedNuc}' is used to define transfers.");
+
             // 全てのコンパートメントを定義する。
             DefineCompartments(data);
 

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -426,7 +426,7 @@ namespace ResultChecker
         {
             var nuclide = target.Nuclide;
             var filePath = target.ExpectDosePath
-                ?? throw new FileNotFoundException("expect retention file", $"{nuclide}.dat");
+                ?? throw new FileNotFoundException("expect dose file", $"{nuclide}.dat");
 
             var (routeOfIntake, _, _) = DecomposeMaterial(mat);
 


### PR DESCRIPTION
[nuclide]セクションに記述がない子孫核種の体内動態モデルがインプットとして記述されている状態で計算が通ってしまったことから問題に気付いた。
