### PR TITLE
残留放射能の期待値データで提示されている核種が集合コンパートメント毎に異なる場合を処理可能とする

### DIFF
--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -252,11 +252,14 @@ namespace ResultChecker
         /// <summary>
         /// 計算および比較の結果。
         /// </summary>
-        struct Result
+        class Result
         {
             public Target Target;
 
             public bool HasErrors;
+
+            public IReadOnlyList<Retention> ExpectActs;
+            public IReadOnlyList<Retention> ActualActs;
 
             public Dose ExpectDose;
             public Dose ActualDose;
@@ -314,8 +317,8 @@ namespace ResultChecker
         {
             var result = new Result() { Target = target };
 
-            var expectActs = GetExpectRetentions(target);
-            var actualActs = GetResultRetentions(target);
+            result.ExpectActs = GetExpectRetentions(target);
+            result.ActualActs = GetResultRetentions(target);
 
             // 50年の預託期間における、各出力時間メッシュにおける数値の比較。
             // 要約として、期待値に対する下振れ率と上振れ率の最大値を算出する。
@@ -328,7 +331,8 @@ namespace ResultChecker
             var fractionsLiver     /**/= (min: double.PositiveInfinity, max: double.NegativeInfinity);
             var fractionsThyroid   /**/= (min: double.PositiveInfinity, max: double.NegativeInfinity);
 
-            foreach (var (actualAct, expectAct) in actualActs.Zip(expectActs, (a, e) => (a, e)))
+            var activities = result.ActualActs.Zip(result.ExpectActs, (a, e) => (a, e));
+            foreach (var (actualAct, expectAct) in activities)
             {
                 //Console.WriteLine(
                 //    $"{expectAct.EndTime,8}," +
@@ -618,7 +622,7 @@ namespace ResultChecker
         /// *_Retention.outから、Whole Bodyの数値列を読み込む。
         /// </summary>
         /// <param name="target"></param>
-        /// <returns></returns>
+        /// <returns>時間メッシュ毎の残留放射能データ。</returns>
         static List<Retention> GetResultRetentions(Target target)
         {
             var nuclide = target.Nuclide;
@@ -691,7 +695,7 @@ namespace ResultChecker
         /// 全身の残留放射能の数値を取得する。
         /// </summary>
         /// <param name="target"></param>
-        /// <returns></returns>
+        /// <returns>時間メッシュ毎の残留放射能データ。</returns>
         /// <exception cref="InvalidDataException"></exception>
         static List<Retention> GetExpectRetentions(Target target)
         {

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -236,6 +236,8 @@ namespace ResultChecker
             public string ChemicalForm;
             public string ParticleSize;
 
+            public string NuclideWholeBody;
+
             public string TargetPath;
 
             public string ExpectDosePath;
@@ -312,8 +314,8 @@ namespace ResultChecker
         {
             var result = new Result() { Target = target };
 
-            var expectActs = GetExpectRetentions(target, out var retentionNuc);
-            var actualActs = GetResultRetentions(target, retentionNuc);
+            var expectActs = GetExpectRetentions(target);
+            var actualActs = GetResultRetentions(target);
 
             // 50年の預託期間における、各出力時間メッシュにおける数値の比較。
             // 要約として、期待値に対する下振れ率と上振れ率の最大値を算出する。
@@ -616,11 +618,11 @@ namespace ResultChecker
         /// *_Retention.outから、Whole Bodyの数値列を読み込む。
         /// </summary>
         /// <param name="target"></param>
-        /// <param name="resultNuc"></param>
         /// <returns></returns>
-        static List<Retention> GetResultRetentions(Target target, string resultNuc)
+        static List<Retention> GetResultRetentions(Target target)
         {
             var nuclide = target.Nuclide;
+            var resultNuc = target.NuclideWholeBody;
             var filePath = target.ResultRetentionPath;
 
             var retentions = new List<Retention>();
@@ -689,10 +691,9 @@ namespace ResultChecker
         /// 全身の残留放射能の数値を取得する。
         /// </summary>
         /// <param name="target"></param>
-        /// <param name="retentionNuc">残留放射能データが対応する核種名</param>
         /// <returns></returns>
         /// <exception cref="InvalidDataException"></exception>
-        static List<Retention> GetExpectRetentions(Target target, out string retentionNuc)
+        static List<Retention> GetExpectRetentions(Target target)
         {
             var nuclide = target.Nuclide;
             var filePath = target.ExpectRetentionPath
@@ -740,9 +741,9 @@ namespace ResultChecker
                 var headerWholeBody = columns[indexWholeBody];
                 var m = Regex.Match(headerWholeBody, @"Whole Body *\((?<nuc>[^ ]+)\)");
                 if (m.Success)
-                    retentionNuc = m.Groups["nuc"].Value;
+                    target.NuclideWholeBody = m.Groups["nuc"].Value;
                 else
-                    retentionNuc = nuclide;
+                    target.NuclideWholeBody = nuclide;
 
                 var startTime = 0.0;
 

--- a/ResultChecker/Program_Taregts.cs
+++ b/ResultChecker/Program_Taregts.cs
@@ -2,30 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace ResultChecker
 {
     internal partial class Program
     {
-        static Regex patternMaterial = new Regex(
-           @"^(?<RouteOfIntake>Injection|Ingestion|Inhalation), (?<Material>.+?)(?:, (?<ParticleSize>[\d\.]+) µm)?$");
-
-        static (string routeOfIntake, string material, string particleSize) DecomposeMaterial(string mat)
-        {
-            var m = patternMaterial.Match(mat);
-            if (!m.Success)
-                throw new InvalidDataException();
-
-            var routeOfIntake = m.Groups["RouteOfIntake"].Value;
-            var particleSize = m.Groups["ParticleSize"].Value;
-            var material = m.Groups["Material"].Value;
-            if (particleSize.Length == 0)
-                particleSize = "-";
-
-            return (routeOfIntake, material, particleSize);
-        }
-
         /// <summary>
         /// FlexIDに整備されているインプットとそれに対応する期待値データを列挙する。
         /// </summary>

--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -377,10 +377,12 @@ namespace ResultChecker
         /// <param name="result"></param>
         static void WriteResultSheet(ExcelWorksheet sheet, Result result)
         {
+            var target = result.Target;
+
             var expectActs = result.ExpectActs;
             var actualActs = result.ActualActs;
 
-            sheet.Cells[1, 1].Value = result.Target.Name;
+            sheet.Cells[1, 1].Value = target.Name;
 
             const int rowH = 4;
             const int rowT = rowH + 1;
@@ -390,6 +392,22 @@ namespace ResultChecker
             const int colC = 1;
 
             sheet.Cells[rowH - 1, colE + 0].Value = "OIR";
+            sheet.Cells[rowH - 1, colA + 0].Value = "FlexID";
+            sheet.Cells[rowH - 1, colD + 0].Value = "Diff";
+
+            string GetCompartmentNuclide(string nuclide) =>
+                nuclide is null ? "-" : nuclide == target.Nuclide ? "" : $"({nuclide})";
+            sheet.Cells[rowH - 1, colD + 1].Value = GetCompartmentNuclide(target.NuclideWholeBody);
+            sheet.Cells[rowH - 1, colD + 2].Value = GetCompartmentNuclide(target.NuclideUrine);
+            sheet.Cells[rowH - 1, colD + 3].Value = GetCompartmentNuclide(target.NuclideFaeces);
+            sheet.Cells[rowH - 1, colD + 4].Value = GetCompartmentNuclide(target.NuclideAtract);
+            sheet.Cells[rowH - 1, colD + 5].Value = GetCompartmentNuclide(target.NuclideLungs);
+            sheet.Cells[rowH - 1, colD + 6].Value = GetCompartmentNuclide(target.NuclideSkeleton);
+            sheet.Cells[rowH - 1, colD + 7].Value = GetCompartmentNuclide(target.NuclideLiver);
+            sheet.Cells[rowH - 1, colD + 8].Value = GetCompartmentNuclide(target.NuclideThyroid);
+            sheet.Cells[rowH - 1, colD + 1, rowH - 1, colD + 8].Style.ShrinkToFit = true;
+            sheet.Cells[rowH - 1, colD + 1, rowH - 1, colD + 8].Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
+
             sheet.Cells[rowH, colE + 0].Value = "Time, days";
             sheet.Cells[rowH, colE + 1].Value = "Whole Body";
             sheet.Cells[rowH, colE + 2].Value = "Urine\n(24-hour sample)";
@@ -403,7 +421,6 @@ namespace ResultChecker
             sheet.Cells[rowH, colE + 0, rowH, colE + 8].Style.VerticalAlignment = ExcelVerticalAlignment.Center;
             sheet.Cells[rowH, colE + 0, rowH, colE + 8].Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
 
-            sheet.Cells[rowH - 1, colA + 0].Value = "FlexID";
             sheet.Cells[rowH, colA + 0].Value = "Time, days";
             sheet.Cells[rowH, colA + 1].Value = "Whole Body";
             sheet.Cells[rowH, colA + 2].Value = "Urine\n(24-hour)";
@@ -417,7 +434,6 @@ namespace ResultChecker
             sheet.Cells[rowH, colA + 0, rowH, colA + 8].Style.VerticalAlignment = ExcelVerticalAlignment.Center;
             sheet.Cells[rowH, colA + 0, rowH, colA + 8].Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
 
-            sheet.Cells[rowH - 1, colD + 0].Value = "Difference";
             sheet.Cells[rowH, colD + 0].Value = "Time, days";
             sheet.Cells[rowH, colD + 1].Value = "Whole Body";
             sheet.Cells[rowH, colD + 2].Value = "Urine";

--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -377,8 +377,8 @@ namespace ResultChecker
         /// <param name="result"></param>
         static void WriteResultSheet(ExcelWorksheet sheet, Result result)
         {
-            var expectActs = GetExpectRetentions(result.Target);
-            var actualActs = GetResultRetentions(result.Target);
+            var expectActs = result.ExpectActs;
+            var actualActs = result.ActualActs;
 
             sheet.Cells[1, 1].Value = result.Target.Name;
 

--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -377,7 +377,7 @@ namespace ResultChecker
         /// <param name="result"></param>
         static void WriteResultSheet(ExcelWorksheet sheet, Result result)
         {
-            var expectActs = GetExpectRetentions(result.Target, out _, out var retentionNuc);
+            var expectActs = GetExpectRetentions(result.Target, out var retentionNuc);
             var actualActs = GetResultRetentions(result.Target, retentionNuc);
 
             sheet.Cells[1, 1].Value = result.Target.Name;

--- a/ResultChecker/Program_WriteResult.cs
+++ b/ResultChecker/Program_WriteResult.cs
@@ -377,8 +377,8 @@ namespace ResultChecker
         /// <param name="result"></param>
         static void WriteResultSheet(ExcelWorksheet sheet, Result result)
         {
-            var expectActs = GetExpectRetentions(result.Target, out var retentionNuc);
-            var actualActs = GetResultRetentions(result.Target, retentionNuc);
+            var expectActs = GetExpectRetentions(result.Target);
+            var actualActs = GetResultRetentions(result.Target);
 
             sheet.Cells[1, 1].Value = result.Target.Name;
 


### PR DESCRIPTION
これまでOIR Data Viewerから取得した残留放射能の期待値データについては、全ての集合コンパートメントについて親または子孫のある1核種のデータが提示されていると仮定していたが、Th-232の期待値データでは、UrineとFaecesは親核種であるTh-232の数値を、それ以外のWhole Bodyを含む集合コンパートメントについては子孫核種であるAc-228の数値を提示しており、上記の仮定が成り立たないことが判明した。

このような期待値データを持つ核種についても正しい比較ができるよう、処理を改良する。

これに合わせて、summary.xlsxに出力する残留放射能の詳細比較シートに集合コンパートメントのデータとして提示されている核種を追加出力する機能を追加した。以下に出力イメージを示す。

![image](https://github.com/user-attachments/assets/0d84a9fa-693e-4615-b709-8a7e8353dfb0)

![image](https://github.com/user-attachments/assets/5dcd4f8e-67c1-4a70-9e90-782ce7ed0219)

![image](https://github.com/user-attachments/assets/4cc118ff-7128-4146-8b53-9ab787f66dbb)

