### PR TITLE
ログ出力処理の開始タイミングを高速化

### DIFF
--- a/FlexID.Calc/InputDataReader_EIR.cs
+++ b/FlexID.Calc/InputDataReader_EIR.cs
@@ -16,7 +16,7 @@ namespace FlexID.Calc
         /// <param name="inputPath">インプットファイルのパス文字列。</param>
         /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は <see langword="true"/>。</param>
         public InputDataReader_EIR(string inputPath, bool calcProgeny = true)
-            : base(new StreamReader(new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read)), calcProgeny)
+            : this(new StreamReader(File.OpenRead(inputPath)), calcProgeny)
         {
         }
 

--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -46,7 +46,7 @@ namespace FlexID.Calc
         /// <param name="inputPath">インプットファイルのパス文字列。</param>
         /// <param name="calcProgeny">子孫核種を計算する＝読み込む場合は <see langword="true"/>。</param>
         public InputDataReader_OIR(string inputPath, bool calcProgeny = true)
-            : this(new StreamReader(new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read)), calcProgeny)
+            : this(new StreamReader(File.OpenRead(inputPath)), calcProgeny)
         {
         }
 

--- a/FlexID.Calc/MainRoutine_OIR.cs
+++ b/FlexID.Calc/MainRoutine_OIR.cs
@@ -71,66 +71,9 @@ namespace FlexID.Calc
             {
                 WriteOutNuclides(data, writer);
 
-                writer.WriteLine();
-                writer.WriteLine($"Zero inflow organs:");
+                WriteOutZeroInflows(data, writer);
 
-                foreach (var nuclide in data.Nuclides)
-                {
-                    foreach (var organ in data.Organs.Where(o => o.Nuclide == nuclide))
-                    {
-                        if (organ.IsDecayCompartment)
-                            continue;
-                        if (organ.IsZeroInflow && organ.Func != OrganFunc.inp)
-                            writer.WriteLine($"  {nuclide.Name} / {organ.Name}");
-                    }
-                }
-
-                var printScoeff = data.TryGetBooleanParameter("PrintScoefficients", false);
-
-                var sourceRegions = data.SourceRegions.Select(s => s.Name).ToArray();
-                var otherSourceRegion = "Other";
-
-                foreach (var nuclide in data.Nuclides)
-                {
-                    var indexN = data.Nuclides.IndexOf(nuclide);
-                    var scoeffTableM = data.SCoeffTablesM[indexN];
-                    var scoeffTableF = data.SCoeffTablesF[indexN];
-
-                    writer.WriteLine();
-                    writer.WriteLine($"Nuclide: {nuclide.Name}");
-
-                    if (printScoeff)
-                    {
-                        writer.WriteLine();
-                        writer.WriteLine($"S-Coefficients (Adult Male):");
-                        foreach (var line in CalcScoeff.GenerateScoeffFileContent(scoeffTableM, sourceRegions, data.TargetRegions))
-                            writer.WriteLine(line);
-
-                        writer.WriteLine();
-                        writer.WriteLine($"S-Coefficients (Adult Female):");
-                        foreach (var line in CalcScoeff.GenerateScoeffFileContent(scoeffTableF, sourceRegions, data.TargetRegions))
-                            writer.WriteLine(line);
-                    }
-
-                    writer.WriteLine();
-                    writer.WriteLine($"Source regions those are part of '{otherSourceRegion}':");
-                    writer.WriteLine(string.Join(",", nuclide.OtherSourceRegions));
-                    writer.WriteLine();
-                    writer.WriteLine($"S-Coefficient values from '{otherSourceRegion}' to each target regions:");
-                    writer.WriteLine($"{"  T/S",-10} {otherSourceRegion + "(Male)",-14} {otherSourceRegion + "(Female)",-14}");
-
-                    var scoeffOtherM = scoeffTableM[otherSourceRegion];
-                    var scoeffOtherF = scoeffTableF[otherSourceRegion];
-
-                    foreach (var targetRegion in data.TargetRegions)
-                    {
-                        var indexT = Array.IndexOf(data.TargetRegions, targetRegion);
-                        var scoeffM = scoeffOtherM[indexT];
-                        var scoeffF = scoeffOtherF[indexT];
-
-                        writer.WriteLine($"{targetRegion,-10} {scoeffM:0.00000000E+00} {scoeffF:0.00000000E+00}");
-                    }
-                }
+                WriteOutScoefficients(data, writer);
             }
         }
 
@@ -208,6 +151,73 @@ namespace FlexID.Calc
                 }
 
                 WriteLine();
+            }
+        }
+
+        private static void WriteOutZeroInflows(InputData data, TextWriter writer)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"Zero inflow organs:");
+
+            foreach (var nuclide in data.Nuclides)
+            {
+                foreach (var organ in data.Organs.Where(o => o.Nuclide == nuclide))
+                {
+                    if (organ.IsDecayCompartment)
+                        continue;
+                    if (organ.IsZeroInflow && organ.Func != OrganFunc.inp)
+                        writer.WriteLine($"  {nuclide.Name} / {organ.Name}");
+                }
+            }
+        }
+
+        private static void WriteOutScoefficients(InputData data, TextWriter writer)
+        {
+            var printScoeff = data.TryGetBooleanParameter("PrintScoefficients", false);
+
+            var sourceRegions = data.SourceRegions.Select(s => s.Name).ToArray();
+            var otherSourceRegion = "Other";
+
+            foreach (var nuclide in data.Nuclides)
+            {
+                var indexN = data.Nuclides.IndexOf(nuclide);
+                var scoeffTableM = data.SCoeffTablesM[indexN];
+                var scoeffTableF = data.SCoeffTablesF[indexN];
+
+                writer.WriteLine();
+                writer.WriteLine($"Nuclide: {nuclide.Name}");
+
+                if (printScoeff)
+                {
+                    writer.WriteLine();
+                    writer.WriteLine($"S-Coefficients (Adult Male):");
+                    foreach (var line in CalcScoeff.GenerateScoeffFileContent(scoeffTableM, sourceRegions, data.TargetRegions))
+                        writer.WriteLine(line);
+
+                    writer.WriteLine();
+                    writer.WriteLine($"S-Coefficients (Adult Female):");
+                    foreach (var line in CalcScoeff.GenerateScoeffFileContent(scoeffTableF, sourceRegions, data.TargetRegions))
+                        writer.WriteLine(line);
+                }
+
+                writer.WriteLine();
+                writer.WriteLine($"Source regions those are part of '{otherSourceRegion}':");
+                writer.WriteLine(string.Join(",", nuclide.OtherSourceRegions));
+                writer.WriteLine();
+                writer.WriteLine($"S-Coefficient values from '{otherSourceRegion}' to each target regions:");
+                writer.WriteLine($"{"  T/S",-10} {otherSourceRegion + "(Male)",-14} {otherSourceRegion + "(Female)",-14}");
+
+                var scoeffOtherM = scoeffTableM[otherSourceRegion];
+                var scoeffOtherF = scoeffTableF[otherSourceRegion];
+
+                foreach (var targetRegion in data.TargetRegions)
+                {
+                    var indexT = Array.IndexOf(data.TargetRegions, targetRegion);
+                    var scoeffM = scoeffOtherM[indexT];
+                    var scoeffF = scoeffOtherF[indexT];
+
+                    writer.WriteLine($"{targetRegion,-10} {scoeffM:0.00000000E+00} {scoeffF:0.00000000E+00}");
+                }
             }
         }
 

--- a/FlexID.Calc/OutputDataReader.cs
+++ b/FlexID.Calc/OutputDataReader.cs
@@ -91,11 +91,8 @@ namespace FlexID.Calc
         /// </summary>
         /// <param name="outputPath">アウトプットファイルのパス文字列。</param>
         public OutputDataReader(string outputPath)
+            : this(new StreamReader(File.OpenRead(outputPath)))
         {
-            var stream = new FileStream(outputPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var reader = new StreamReader(stream);
-
-            this.reader = reader;
         }
 
         /// <summary>

--- a/ResultChecker/Program.cs
+++ b/ResultChecker/Program.cs
@@ -455,8 +455,7 @@ namespace ResultChecker
             if (target.ParticleSize != "-")
                 mat += $", {target.ParticleSize} µm";
 
-            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var reader = new StreamReader(stream, Encoding.UTF8))
+            using (var reader = new StreamReader(File.OpenRead(filePath), Encoding.UTF8))
             {
                 string[] columns;
 
@@ -707,8 +706,7 @@ namespace ResultChecker
 
             var retentions = new List<Retention>();
 
-            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var reader = new StreamReader(stream, Encoding.UTF8))
+            using (var reader = new StreamReader(File.OpenRead(filePath), Encoding.UTF8))
             {
                 string[] columns;
 


### PR DESCRIPTION
S係数の計算には多少の時間が必要であり、これを待ってからのログファイル作成は計算処理の開始を遅く感じさせてしまうため、待ちを生じさせないようにログファイルの出力タイミングについて調整した。
