### PR TITLE
合流を伴う壊変経路を正しく取り扱えるよう改修

### DIFF
--- a/FlexID.Calc.Tests/DecaySetTests.cs
+++ b/FlexID.Calc.Tests/DecaySetTests.cs
@@ -1,0 +1,1570 @@
+namespace FlexID.Calc.Tests;
+
+using static InputErrorTestHelpers;
+
+[TestClass]
+public class DecaySetTests
+{
+    // N1 --> N2 --> N3 --> N4 --> (stable)
+    [TestClass]
+    public class StraightDecayChain
+    {
+        const int LineNum = 1;
+        const int Line1 = LineNum + 0;
+        const int Line2 = LineNum + 1;
+        const int Line3 = LineNum + 2;
+        const int Line4 = LineNum + 3;
+        const int Line5 = LineNum + 4;
+        const int Line6 = LineNum + 5;
+        const int Line7 = LineNum + 6;
+
+        readonly NuclideData N1; readonly Organ C11, C12, C13, C14;
+        readonly NuclideData N2; readonly Organ C21, C22;
+        readonly NuclideData N3; readonly Organ C31, C32;
+        readonly NuclideData N4; readonly Organ C41;
+
+        readonly DecaySet decaySet;
+        readonly InputErrors errors = new();
+
+        public StraightDecayChain()
+        {
+            N1 = new NuclideData { Index = 0, Name = "N1", };
+            N2 = new NuclideData { Index = 1, Name = "N2", IsProgeny = true, };
+            N3 = new NuclideData { Index = 2, Name = "N3", IsProgeny = true, };
+            N4 = new NuclideData { Index = 3, Name = "N4", IsProgeny = true, };
+            N1.Branches = [(Daughter: N2, Fraction: 1.0)];
+            N2.Branches = [(Daughter: N3, Fraction: 1.0)];
+            N3.Branches = [(Daughter: N4, Fraction: 1.0)];
+            N4.Branches = [];
+
+            C11 = new Organ { Nuclide = N1, Name = "C11", Func = OrganFunc.acc, };
+            C12 = new Organ { Nuclide = N1, Name = "C12", Func = OrganFunc.acc, };
+            C13 = new Organ { Nuclide = N1, Name = "C13", Func = OrganFunc.acc, };
+            C14 = new Organ { Nuclide = N1, Name = "C14", Func = OrganFunc.acc, };
+            C21 = new Organ { Nuclide = N2, Name = "C21", Func = OrganFunc.acc, };
+            C22 = new Organ { Nuclide = N2, Name = "C22", Func = OrganFunc.acc, };
+            C31 = new Organ { Nuclide = N3, Name = "C31", Func = OrganFunc.acc, };
+            C32 = new Organ { Nuclide = N3, Name = "C32", Func = OrganFunc.acc, };
+            C41 = new Organ { Nuclide = N4, Name = "C41", Func = OrganFunc.acc, };
+            C11.ToString().ShouldBe("N1/C11");
+            C12.ToString().ShouldBe("N1/C12");
+            C13.ToString().ShouldBe("N1/C13");
+            C14.ToString().ShouldBe("N1/C14");
+            C21.ToString().ShouldBe("N2/C21");
+            C22.ToString().ShouldBe("N2/C22");
+            C31.ToString().ShouldBe("N3/C31");
+            C32.ToString().ShouldBe("N3/C32");
+            C41.ToString().ShouldBe("N4/C41");
+
+            decaySet = new DecaySet([N1, N2, N3, N4], errors);
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // =========================
+        //         N1/C11 --> N2/C21
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow(1.23)]
+        public void SinglePath(double? coeff)
+        {
+            var organDecay = decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            if (coeff is null)
+            {
+                chain1[N1].ShouldBe((Line1, C11));
+                chain1[N2].ShouldBe((Line1, C21));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+            }
+            else
+            {
+                chain1[N1].ShouldBe((Line1, C11));
+                chain1[N2].ShouldBe((Line1, organDecay));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[organDecay].ShouldBe([chain1]);
+            }
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // [Line2] N1/C12 --> N2/C22
+        // =========================
+        //         N1/C11 --> N2/C21
+        //         N1/C12 --> N2/C22
+        [TestMethod]
+        public void ParallelPaths()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C22, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C22));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C22].ShouldBe([chain2]);
+        }
+
+        // [Line1] N1/C11 ----------> N2/C21
+        // [Line2] N1/C12 -(coeff.)-> N2/C21
+        // ===============================
+        //         N1/C11 ----------> N2/C21
+        //                              ↑
+        //                            (coeff.)
+        //                              ↑
+        //         N1/C12 ----------> N2/d21
+        [TestMethod]
+        public void ParallelPaths2()
+        {
+            // 2つの経路設定は、終端側がC21で合流しているように見えるが
+            // 2つ目の経路は移行速度付きのため実際はN2位置で壊変コンパートメントが自動作成され、
+            // 従ってこれらは独立した2つの壊変経路を作成する。
+            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);   // 壊変経路1
+            var d21 = decaySet.AddDecayPath(Line2, C12, C21, 123m);   // 壊変経路2: 経路1とは関係ない
+            errors.GetErrorLines().ShouldBe([]);
+            d11.ShouldBeNull();
+            d21.ShouldNotBeNull();
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, d21));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[d21].ShouldBe([chain2]);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C12 -----> N2/C21
+        // =========================
+        //         N1/C11 ---+-> N2/C21
+        //                  /
+        //         N1/C12 -+
+        [TestMethod]
+        public void JoinPathsAtN2()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C21));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C12 -----> N2/C21
+        // [Line3]               N2/C21 --> N3/C31
+        // =======================================
+        //         N1/C11 ---+-> N2/C21 --> N3/C31
+        //                  /
+        //         N1/C12 -+
+        [TestMethod]
+        public void JoinPathsAtN2_AndShareN3_Order1()
+        {
+            // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
+            // 自動的に合流した2つの系列で共有される。
+            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);
+            var d21 = decaySet.AddDecayPath(Line2, C12, C21, null);
+            var d31 = decaySet.AddDecayPath(Line3, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+            d11.ShouldBeNull();
+            d21.ShouldBeNull();
+            d31.ShouldBeNull();
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line3, C31));
+
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line3, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line3]               N2/C21 --> N3/C31
+        // [Line2] N1/C12 -----> N2/C21
+        // =======================================
+        //         N1/C11 ---+-> N2/C21 --> N3/C31
+        //                  /
+        //         N1/C12 -+
+        [TestMethod]
+        public void JoinPathsAtN2_AndShareN3_Order2()
+        {
+            // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
+            // 自動的に合流した2つの系列で共有される。
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line3, C31));
+
+            // chain1に対してN2位置で合流するchain2を追加する。
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain2 = decaySet.DecayChains[1];
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line3, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -------> N2/C21
+        // [Line2] N1/C12 -------> N2/C21
+        // [Line3]                 N2/C21 -(coeff.)-> N3/C31
+        // ===============================================
+        //         N1/C11 -----+-> N2/C21 ----------> N3/d31
+        //                    /                         ↓
+        //                   /                        (coeff.)
+        //                  /                           ↓
+        //         N1/C12 -+                          N3/C31
+        [TestMethod]
+        public void JoinPathsAtN2_AndShareN3_WithCoeff()
+        {
+            // 合流が発生した核種N2の子孫核種N3の位置が壊変コンパートメントである場合も、
+            // 自動的に合流した2つの系列で共有される。
+            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);
+            var d21 = decaySet.AddDecayPath(Line2, C12, C21, null);
+            var d31 = decaySet.AddDecayPath(Line3, C21, C31, 123m);
+            errors.GetErrorLines().ShouldBe([]);
+            d11.ShouldBeNull();
+            d21.ShouldBeNull();
+            d31.ShouldNotBeNull();
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line3, d31));
+
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line3, d31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+        }
+
+        // [Line1] N1/C11 -------> N2/C21
+        // [Line2]                 N2/C21 --> N3/C31
+        // [Line3]                            N3/C31 --> N4/C41
+        // [Line4] N1/C12 -------> N2/C21
+        // ====================================================
+        //         N1/C11 -----+-> N2/C21 --> N3/C31 --> N4/C41
+        //                    /
+        //                   /
+        //                  /
+        //         N1/C12 -+
+        [TestMethod]
+        public void JoinPathsAtN2_AndShareN3N4()
+        {
+            // 核種N2で合流が発生した場合、その子孫核種であるN3,N4のコンパートメントは
+            // 自動的に合流した2つの系列で共有される。
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C21, C31, null);
+            decaySet.AddDecayPath(Line3, C31, C41, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line2, C31));
+            chain1[N4].ShouldBe((Line3, C41));
+
+            decaySet.AddDecayPath(Line4, C12, C21, null);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain2 = decaySet.DecayChains[1];
+            chain2[N1].ShouldBe((Line4, C12));
+            chain2[N2].ShouldBe((Line4, C21));
+            chain2[N3].ShouldBe((Line2, C31));
+            chain2[N4].ShouldBe((Line3, C41));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C41].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -------> N2/C21
+        // [Line2] N1/C12 -------> N2/C21
+        // [Line3]                 N2/C21 -------> N3/C31
+        // [Line4]                                 N3/C31 --> N4/C41
+        // [Line5] N1/C13 -------> N2/C22
+        // [Line6] N1/C14 -------> N2/C22
+        // [Line7]                 N2/C22 -------> N3/C31
+        // =========================================================
+        //         N1/C11 ---+---> N2/C21 -----+-> N3/C31 --> N4/C41
+        //                  /                 /
+        //         N1/C12 -+                 /
+        //                                  /
+        //         N1/C13 ---+---> N2/C22 -+
+        //                  /
+        //         N1/C14 -+
+        [TestMethod]
+        public void JoinPathsAtN2N3_AndShareN4()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
+            decaySet.AddDecayPath(Line4, C31, C41, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line3, C31));
+            chain1[N4].ShouldBe((Line4, C41));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line3, C31));
+            chain2[N4].ShouldBe((Line4, C41));
+
+            decaySet.AddDecayPath(Line5, C13, C22, null);
+            decaySet.AddDecayPath(Line6, C14, C22, null);
+
+            decaySet.DecayChains.Count.ShouldBe(4);
+            var chain3 = decaySet.DecayChains[2];
+            var chain4 = decaySet.DecayChains[3];
+            chain3[N1].ShouldBe((Line5, C13));
+            chain3[N2].ShouldBe((Line5, C22));
+            chain3[N3].ShouldBe(default);
+            chain3[N4].ShouldBe(default);
+            chain4[N1].ShouldBe((Line6, C14));
+            chain4[N2].ShouldBe((Line6, C22));
+            chain4[N3].ShouldBe(default);
+            chain4[N4].ShouldBe(default);
+
+            decaySet.AddDecayPath(Line7, C22, C31, null);
+
+            decaySet.DecayChains.Count.ShouldBe(4);
+            chain3[N3].ShouldBe((Line7, C31));
+            chain3[N4].ShouldBe((Line4, C41));
+            chain4[N3].ShouldBe((Line7, C31));
+            chain4[N4].ShouldBe((Line4, C41));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C13].ShouldBe([chain3]);
+            decaySet.JointChains[C14].ShouldBe([chain4]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+            decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C12 -----> N2/C21
+        // [Line3] N1/C13 -----> N2/C22
+        // [Line4] N1/C14 -----> N2/C22
+        // [Line5]               N2/C21 -------> N3/C31
+        // [Line6]               N2/C22 -------> N3/C31
+        // =========================
+        //         N1/C11 ---+-> N2/C21 -----+-> N3/C31
+        //                  /               /
+        //         N1/C12 -+               /
+        //                                /
+        //         N1/C13 ---+-> N2/C22 -+
+        //                  /
+        //         N1/C14 -+
+        [TestMethod]
+        public void JoinPathsAtN3_Order1()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C13, C22, null);
+            decaySet.AddDecayPath(Line4, C14, C22, null);
+
+            decaySet.DecayChains.Count.ShouldBe(4);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+            var chain3 = decaySet.DecayChains[2];
+            var chain4 = decaySet.DecayChains[3];
+            chain1[N1].ShouldBe((Line1, C11));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain3[N1].ShouldBe((Line3, C13));
+            chain4[N1].ShouldBe((Line4, C14));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain3[N2].ShouldBe((Line3, C22));
+            chain4[N2].ShouldBe((Line4, C22));
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+
+            decaySet.AddDecayPath(Line5, C21, C31, null);
+            decaySet.AddDecayPath(Line6, C22, C31, null);
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain3[N1].ShouldBe((Line3, C13));
+            chain4[N1].ShouldBe((Line4, C14));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain3[N2].ShouldBe((Line3, C22));
+            chain4[N2].ShouldBe((Line4, C22));
+            chain1[N3].ShouldBe((Line5, C31));
+            chain2[N3].ShouldBe((Line5, C31));
+            chain3[N3].ShouldBe((Line6, C31));
+            chain4[N3].ShouldBe((Line6, C31));
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C12 -----> N2/C21
+        // [Line3] N1/C13 -----> N2/C22
+        // [Line4] N1/C14 -----> N2/C22
+        // [Line5] N1/C11 ---------------------> N3/C31
+        // [Line6] N2/C14 ---------------------> N3/C31
+        // =========================
+        //         N1/C11 ---+-> N2/C21 -----+-> N3/C31
+        //                  /               /
+        //         N1/C12 -+               /
+        //                                /
+        //         N1/C13 ---+-> N2/C22 -+
+        //                  /
+        //         N1/C14 -+
+        [TestMethod]
+        public void JoinPathsAtN3_Order2()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C13, C22, null);
+            decaySet.AddDecayPath(Line4, C14, C22, null);
+
+            decaySet.DecayChains.Count.ShouldBe(4);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+            var chain3 = decaySet.DecayChains[2];
+            var chain4 = decaySet.DecayChains[3];
+            chain1[N1].ShouldBe((Line1, C11));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain3[N1].ShouldBe((Line3, C13));
+            chain4[N1].ShouldBe((Line4, C14));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain3[N2].ShouldBe((Line3, C22));
+            chain4[N2].ShouldBe((Line4, C22));
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+
+            decaySet.AddDecayPath(Line5, C11, C31, null);
+            decaySet.AddDecayPath(Line6, C14, C31, null);
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain2[N1].ShouldBe((Line2, C12));
+            chain3[N1].ShouldBe((Line3, C13));
+            chain4[N1].ShouldBe((Line4, C14));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain2[N2].ShouldBe((Line2, C21));
+            chain3[N2].ShouldBe((Line3, C22));
+            chain4[N2].ShouldBe((Line4, C22));
+            chain1[N3].ShouldBe((Line5, C31));
+            chain2[N3].ShouldBe((Line5, C31));
+            chain3[N3].ShouldBe((Line6, C31));
+            chain4[N3].ShouldBe((Line6, C31));
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C11 -----> N2/C22
+        // ============================
+        //         N1/C11 -+---> N2/C21
+        //                  \ 
+        //                   +-> N2/C22 (error)
+        [TestMethod]
+        [DataRow(null, null)]
+        [DataRow(1.23, null)]
+        [DataRow(null, 2.34)]
+        [DataRow(1.23, 2.34)]
+        public void DivergePathsOnTheToPoint1(double? coeff1, double? coeff2)
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff1);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.AddDecayPath(Line2, C11, C22, (decimal?)coeff2);
+            errors.GetErrorLines().ShouldBe(
+            [
+                $"Line {Line2}: Decay paths conflict each other:",
+                $"    the previous: '{C11}' --> '{C21}'" + (coeff1 is null ? "": $" (with coeff. {coeff1.Value})") + $" at Line {Line1}",
+                $"    and here    : '{C11}' --> '{C22}'" + (coeff2 is null ? "": $" (with coeff. {coeff2.Value})"),
+            ]);
+        }
+
+        // [Line1] N1/C11 -----> N2/C21
+        // [Line2] N1/C12 -----> N2/C21
+        // [Line3]               N2/C21 -----> N3/C31
+        // [Line4] N1/C12 -------------------> N3/C32
+        // ==========================================
+        //         N1/C11 ---+-> N2/C21 -+---> N3/C31
+        //                  /             \
+        //         N1/C12 -+               +-> N3/C32 (error)
+        [TestMethod]
+        public void DivergePathsOnTheToPoint2()
+        {
+            // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
+            // 自動的に合流した2つの系列で共有される。
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            {
+                chain1[N1].ShouldBe((Line1, C11));
+                chain1[N2].ShouldBe((Line1, C21));
+                chain1[N3].ShouldBe((Line3, C31));
+            }
+            var chain2 = decaySet.DecayChains[1];
+            {
+                chain2[N1].ShouldBe((Line2, C12));
+                chain2[N2].ShouldBe((Line2, C21));
+                chain2[N3].ShouldBe((Line3, C31));
+            }
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+
+            // 新しい経路の末端側の位置(核種N3)で壊変経路の分岐が生じる。
+            decaySet.AddDecayPath(Line4, C12, C32, null);
+            errors.GetErrorLines().ShouldBe(
+            [
+                $"Line {Line4}: Decay paths conflict each other:",
+                $"    the previous: '{C12}' --> '{C31}'" + $" at Line {Line3}",
+                $"    and here    : '{C12}' --> '{C32}'",
+            ]);
+        }
+
+        // [Line1] N1/C11 -------------------> N3/C31
+        // [Line2] N1/C12 -------------------> N3/C32
+        // [Line3] N1/C11 -----> N2/C21
+        // [Line4] N1/C12 -----> N2/C21
+        // ==========================================
+        //         N1/C11 ---+-> N2/C21 -+---> N3/C31
+        //                  /             \
+        //         N1/C12 -+               +-> N3/C32 (error)
+        [TestMethod]
+        public void DivergePathsOnTheProgenyOfToPoint()
+        {
+            decaySet.AddDecayPath(Line1, C11, C31, null);
+            decaySet.AddDecayPath(Line2, C12, C32, null);
+            decaySet.AddDecayPath(Line3, C11, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line3, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            chain2[N1].ShouldBe((Line2, C12));
+            chain2[N2].ShouldBe(default);
+            chain2[N3].ShouldBe((Line2, C32));
+
+            // 新しい経路の末端側(核種N2)より子孫の位置(核種N3)で壊変経路の分岐が生じる。
+            decaySet.AddDecayPath(Line4, C12, C21, null);
+            errors.GetErrorLines().ShouldBe(
+            [
+                $"Line 4: Decay paths conflict each other:",
+                $"    the previous: '{C21}' --> '{C31}' at Line {Line1}",
+                $"    and another : '{C21}' --> '{C32}' at Line {Line2}",
+            ]);
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // [Line2]            N2/C21 --> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order1a()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1]            N2/C21 --> N3/C31
+        // [Line2] N1/C11 --> N2/C21
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order1b()
+        {
+            decaySet.AddDecayPath(Line1, C21, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line2, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1] N1/C11 -------------> N3/C31
+        // [Line2]         N2/C21 -----> N3/C31
+        // ====================================
+        //         N1/C11 -----------+-> N3/C31
+        //                          /
+        //                 N2/C21 -+
+        [TestMethod]
+        public void FillChainPaths_Order2a()
+        {
+            decaySet.AddDecayPath(Line1, C11, C31, null);
+            decaySet.AddDecayPath(Line2, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe(default);
+            chain1[N3].ShouldBe((Line1, C31));
+
+            chain2[N1].ShouldBe(default);
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain2]);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1]         N2/C21 ---> N3/C31
+        // [Line2] N1/C11 -----------> N3/C31
+        // ==================================
+        //                 N2/C21 -+-> N3/C31
+        //                        /
+        //         N1/C11 -------+
+        [TestMethod]
+        public void FillChainPaths_Order2b()
+        {
+            decaySet.AddDecayPath(Line1, C21, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe(default);
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            chain2[N1].ShouldBe((Line2, C11));
+            chain2[N2].ShouldBe(default);
+            chain2[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -------------> N3/C31
+        // [Line2] N1/C11 --> N2/C21
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order3a()
+        {
+            decaySet.AddDecayPath(Line1, C11, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line2, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // [Line2] N1/C11 -------------> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order3b()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C11, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // [Line2]            N2/C21 --> N3/C31
+        // [Line3] N1/C11 -------------> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4a()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C21, C31, null);
+            decaySet.AddDecayPath(Line3, C11, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1]            N2/C21 --> N3/C31
+        // [Line2] N1/C11 --> N2/C21
+        // [Line3] N1/C11 -------------> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4b()
+        {
+            decaySet.AddDecayPath(Line1, C21, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C21, null);
+            decaySet.AddDecayPath(Line3, C11, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line2, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1] N1/C11 --> N2/C21
+        // [Line2] N1/C11 -------------> N3/C31
+        // [Line3]            N2/C21 --> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4c()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C11, C31, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1]            N2/C21 --> N3/C31
+        // [Line2] N1/C11 -------------> N3/C31
+        // [Line3] N1/C11 --> N2/C21
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4d()
+        {
+            decaySet.AddDecayPath(Line1, C21, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C31, null);
+            decaySet.AddDecayPath(Line3, C11, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe(default);
+            chain1[N2].ShouldBe((Line1, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            chain2[N1].ShouldBe((Line2, C11));
+            chain2[N2].ShouldBe((Line3, C21));
+            chain2[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain2]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+
+        // [Line1] N1/C11 -------------> N3/C31
+        // [Line2] N1/C11 --> N2/C21
+        // [Line3]            N2/C21 --> N3/C31
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4e()
+        {
+            decaySet.AddDecayPath(Line1, C11, C31, null);
+            decaySet.AddDecayPath(Line2, C11, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line2, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+        }
+
+        // [Line1] N1/C11 -------------> N3/C31
+        // [Line2]            N2/C21 --> N3/C31
+        // [Line3] N1/C11 --> N2/C21
+        // ====================================
+        //         N1/C11 --> N2/C21 --> N3/C31
+        [TestMethod]
+        public void FillChainPaths_Order4f()
+        {
+            decaySet.AddDecayPath(Line1, C11, C31, null);
+            decaySet.AddDecayPath(Line2, C21, C31, null);
+            decaySet.AddDecayPath(Line3, C11, C21, null);
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(2);
+            var chain1 = decaySet.DecayChains[0];
+            var chain2 = decaySet.DecayChains[1];
+
+            chain1[N1].ShouldBe((Line1, C11));
+            chain1[N2].ShouldBe((Line3, C21));
+            chain1[N3].ShouldBe((Line1, C31));
+
+            chain2[N1].ShouldBe(default);
+            chain2[N2].ShouldBe((Line2, C21));
+            chain2[N3].ShouldBe((Line2, C31));
+
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain2, chain1], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+        }
+    }
+
+    //        +--> N2 --+
+    //       /           \
+    // N1 --+             +-> N4
+    //       \           /
+    //        +--> N3 --+
+    [TestClass]
+    public class DiamondDecayChain
+    {
+        const int LineNum = 1;
+        const int Line1 = LineNum + 0;
+        const int Line2 = LineNum + 1;
+        const int Line3 = LineNum + 2;
+        const int Line4 = LineNum + 3;
+        const int Line5 = LineNum + 4;
+
+        readonly NuclideData N1; readonly Organ C11, C12, C13;
+        readonly NuclideData N2; readonly Organ C21;
+        readonly NuclideData N3; readonly Organ C31;
+        readonly NuclideData N4; readonly Organ C41;
+
+        readonly DecaySet decaySet;
+        readonly InputErrors errors = new();
+
+        public DiamondDecayChain()
+        {
+            N1 = new NuclideData { Index = 0, Name = "N1", };
+            N2 = new NuclideData { Index = 1, Name = "N2", IsProgeny = true, };
+            N3 = new NuclideData { Index = 2, Name = "N3", IsProgeny = true, };
+            N4 = new NuclideData { Index = 3, Name = "N4", IsProgeny = true, };
+            N1.Branches = [(Daughter: N2, Fraction: 0.5), (Daughter: N3, Fraction: 0.5)];
+            N2.Branches = [(Daughter: N4, Fraction: 1.0)];
+            N3.Branches = [(Daughter: N4, Fraction: 1.0)];
+            N4.Branches = [];
+
+            C11 = new Organ { Nuclide = N1, Name = "C11", Func = OrganFunc.acc, };
+            C12 = new Organ { Nuclide = N1, Name = "C12", Func = OrganFunc.acc, };
+            C13 = new Organ { Nuclide = N1, Name = "C13", Func = OrganFunc.acc, };
+            C21 = new Organ { Nuclide = N2, Name = "C21", Func = OrganFunc.acc, };
+            C31 = new Organ { Nuclide = N3, Name = "C31", Func = OrganFunc.acc, };
+            C41 = new Organ { Nuclide = N4, Name = "C41", Func = OrganFunc.acc, };
+            C11.ToString().ShouldBe("N1/C11");
+            C12.ToString().ShouldBe("N1/C12");
+            C13.ToString().ShouldBe("N1/C13");
+            C21.ToString().ShouldBe("N2/C21");
+            C31.ToString().ShouldBe("N3/C31");
+            C41.ToString().ShouldBe("N4/C41");
+
+            decaySet = new DecaySet([N1, N2, N3, N4], errors);
+        }
+
+        // [Line1] N1/C11 --------> N2/C21
+        // [Line2] N1/C11 ------------------> N3/C31
+        // [Line1] N1/C12 --------> N2/C21
+        // [Line2] N1/C13 ------------------> N3/C31
+        // [Line3] N1/C11 ---------------------------------> N4/C41
+        // =================================================
+        //         N1/C21 -----+--> N2/C21 ------------+
+        //                    /                         \
+        //         N1/C11 ---+                           +-> N4/C41
+        //                    \                         /
+        //                     +------------> N3/C31 --+
+        //                    /
+        //         N1/C13 ---+
+        [TestMethod]
+        public void JoinPathsAndShareGrandDaughter()
+        {
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C11, C31, null);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+            {
+                chain1[N1].ShouldBe((Line1, C11));
+                chain1[N2].ShouldBe((Line1, C21));
+                chain1[N3].ShouldBe((Line2, C31));
+            }
+            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C21].ShouldBe([chain1]);
+            decaySet.JointChains[C31].ShouldBe([chain1]);
+
+            decaySet.AddDecayPath(Line3, C12, C21, null);
+            decaySet.AddDecayPath(Line4, C13, C31, null);
+
+            decaySet.DecayChains.Count.ShouldBe(3);
+            var chain2 = decaySet.DecayChains[1];
+            {
+                chain2[N1].ShouldBe((Line3, C12));
+                chain2[N2].ShouldBe((Line3, C21));
+                chain2[N3].ShouldBe(default);
+            }
+            var chain3 = decaySet.DecayChains[2];
+            {
+                chain3[N1].ShouldBe((Line4, C13));
+                chain3[N2].ShouldBe(default);
+                chain3[N3].ShouldBe((Line4, C31));
+            }
+            decaySet.JointChains[C12].ShouldBe([chain2]);
+            decaySet.JointChains[C13].ShouldBe([chain3]);
+            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.JointChains[C31].ShouldBe([chain1, chain3], ignoreOrder: true);
+
+            // chain1の中でC41への経路を設定した時点で、chain1に加えて
+            // C21に合流している崩壊系列chain2とC31に合流している崩壊系列chain3も
+            // C41を共有する崩壊系列として判定される。
+            decaySet.AddDecayPath(Line5, C11, C41, null);
+
+            decaySet.DecayChains.Count.ShouldBe(3);
+            {
+                chain1[N4].ShouldBe((Line5, C41));
+                chain2[N4].ShouldBe((Line5, C41));
+                chain3[N4].ShouldBe((Line5, C41));
+            }
+            decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3], ignoreOrder: true);
+        }
+    }
+
+    /// <summary>
+    /// 直接的・間接的な壊変経路の設定を混合した場合でも、系列内の壊変経路が正しく接続されることを確認する。
+    /// </summary>
+    // N1 -+-> N2 -+-+-> N3 -+-> N4 --> (stable)
+    //      \       X       /
+    //       +-----+ +-----+
+    [TestClass]
+    public class ComplexDecayChain
+    {
+        readonly NuclideData N1; readonly Organ C1;
+        readonly NuclideData N2; readonly Organ C2;
+        readonly NuclideData N3; readonly Organ C3;
+        readonly NuclideData N4; readonly Organ C4;
+
+        readonly DecaySet decaySet;
+        readonly InputErrors errors = new();
+
+        public ComplexDecayChain()
+        {
+            N1 = new NuclideData { Index = 0, Name = "N1", };
+            N2 = new NuclideData { Index = 1, Name = "N2", IsProgeny = true, };
+            N3 = new NuclideData { Index = 2, Name = "N3", IsProgeny = true, };
+            N4 = new NuclideData { Index = 3, Name = "N4", IsProgeny = true, };
+            N1.Branches = [(Daughter: N2, Fraction: 0.5), (Daughter: N3, Fraction: 0.5)];
+            N2.Branches = [(Daughter: N3, Fraction: 0.5), (Daughter: N4, Fraction: 0.5)];
+            N3.Branches = [(Daughter: N4, Fraction: 0.5)];
+            N4.Branches = [];
+
+            C1 = new Organ { Nuclide = N1, Name = "C1", Func = OrganFunc.acc, };
+            C2 = new Organ { Nuclide = N2, Name = "C2", Func = OrganFunc.acc, };
+            C3 = new Organ { Nuclide = N3, Name = "C3", Func = OrganFunc.acc, };
+            C4 = new Organ { Nuclide = N4, Name = "C4", Func = OrganFunc.acc, };
+            C1.ToString().ShouldBe("N1/C1");
+            C2.ToString().ShouldBe("N2/C2");
+            C3.ToString().ShouldBe("N3/C3");
+            C4.ToString().ShouldBe("N4/C4");
+
+            decaySet = new DecaySet([N1, N2, N3, N4], errors);
+        }
+
+        /// <summary>
+        /// 直接的・間接的な壊変経路の設定を混合した場合でも、系列内の壊変経路が正しく接続されることを確認する。
+        /// </summary>
+        [TestMethod]
+        [DynamicData(nameof(MixingDecayPathSettings_Cases))]
+        public void MixingDecayPathSettings(params (string From, string To)[] paths)
+        {
+            IReadOnlyList<Organ> compartments = [C1, C2, C3, C4];
+
+            var line = 1;
+            foreach (var (from, to) in paths)
+            {
+                var organFrom = compartments.First(c => c.Name == from);
+                var organTo = compartments.First(c => c.Name == to);
+                decaySet.AddDecayPath(line++, organFrom, organTo, null);
+            }
+            errors.GetErrorLines().ShouldBe([]);
+
+            decaySet.DecayChains.Count.ShouldBe(1);
+            var chain1 = decaySet.DecayChains[0];
+
+            chain1[N1].Organ.ShouldBe(C1);
+            chain1[N2].Organ.ShouldBe(C2);
+            chain1[N3].Organ.ShouldBe(C3);
+            chain1[N4].Organ.ShouldBe(C4);
+
+            decaySet.JointChains[C1].ShouldBe([chain1]);
+            decaySet.JointChains[C2].ShouldBe([chain1]);
+            decaySet.JointChains[C3].ShouldBe([chain1]);
+            decaySet.JointChains[C4].ShouldBe([chain1]);
+        }
+
+        public static IEnumerable<object[]> MixingDecayPathSettings_Cases()
+        {
+            // 系列内で1つ以上の核種を暗黙に通過する、間接的な壊変経路の定義を使用する。
+            yield return new object[]
+            {
+                ("C1", "C2"),   // 親－娘の壊変経路を定義する。
+                ("C1", "C3"),   // 間接的な壊変経路を定義する。
+                ("C1", "C4"),   // 間接的な壊変経路を定義する。
+            };
+
+            // 親－娘の壊変経路だけを指定する。
+            yield return new object[]
+            {
+                ("C1", "C2"),   // 親－娘の壊変経路。
+                ("C1", "C3"),   // 親－娘の壊変経路。
+                ("C2", "C3"),   // 親－娘の壊変経路。
+                ("C2", "C4"),   // 親－娘の壊変経路。
+                ("C3", "C4"),   // 親－娘の壊変経路。
+            };
+
+            // 先に定義した間接的な経路の一部を、後から直接的な経路で明示する。
+            yield return new object[]
+            {
+                ("C1", "C2"),   // 親－娘の壊変経路。
+                ("C1", "C3"),   // 先に系列を作る。
+                ("C2", "C3"),   // 後で系列内の親－娘の壊変経路を明示している。
+                ("C1", "C4"),   // 先に系列を作る。
+                ("C2", "C4"),   // 後で系列内の親－娘の壊変経路を明示している。
+                ("C3", "C4"),   // 後で系列内の親－娘の壊変経路を明示している。
+            };
+
+            // 先に定義した直接的な経路を包含する間接的な経路を後から定義する。
+            yield return new object[]
+            {
+                ("C1", "C2"),   // 親－娘の壊変経路。
+                ("C2", "C3"),   // 先に系列内の親－娘の壊変経路を明示している。
+                ("C1", "C3"),   // 後で系列を作る。
+                ("C2", "C4"),   // 先に系列内の親－娘の壊変経路を明示している。
+                ("C3", "C4"),   // 先に系列内の親－娘の壊変経路を明示している。
+                ("C1", "C4"),   // 後で系列を作る。
+            };
+
+            // 先に定義した直接的な経路＋系列全体を包絡しない間接的な経路の組み合わせを設定する。
+            yield return new object[]
+            {
+                ("C1", "C2"),   // 親－娘の壊変経路。
+                ("C2", "C3"),   // 先に系列内の親－娘の壊変経路を明示している。
+                ("C1", "C3"),   // 後で系列を作る。
+                ("C2", "C4"),   // N1/C1から始まる系列全体を包絡しない間接的な経路。
+            };
+        }
+    }
+
+
+    [TestClass]
+    public class DecayChainTestsX
+    {
+        // Sb-129 -+-> Te-129m -+-+-> Te-129 -+-> I-129 --> (Xe-129)
+        //          \            X           /
+        //           +----------+ +---------+
+
+        private static string[] GetInflows(Organ organ) => [.. organ.Inflows.Select(i => i.Organ.ToString())];
+
+#if false
+        /// <summary>
+        /// 直接的・間接的な壊変経路の設定を混合した場合でも、系列内の壊変経路が正しく接続されることを確認する。
+        /// </summary>
+        /// <param name="reader"></param>
+        [TestMethod]
+        [DynamicData(nameof(MixingDecayPathSettings_Cases))]
+        public void MixingDecayPathSettings(InputDataReader_OIR reader)
+        {
+            var data = reader.Read();
+            var organs = data.Organs;
+
+            organs.Select(o => o.ToString()).ShouldBe(
+            [
+                "Sb-129/input",
+                "Sb-129/Blood",
+                "Te-129m/Blood",
+                "Te-129/Blood",
+                "I-129/Blood",
+            ]);
+
+            // DecayChain内の核種をインプットで定義したコンパートメントで網羅するよう設定したので、
+            // DecayCompartmentは定義されない。
+
+            GetInflows(organs[1]).ShouldBe(["Sb-129/input"]);
+            GetInflows(organs[2]).ShouldBe(["Sb-129/Blood"]);
+            GetInflows(organs[3]).ShouldBe(["Sb-129/Blood", "Te-129m/Blood"]);
+            GetInflows(organs[4]).ShouldBe(["Te-129m/Blood", "Te-129/Blood"]);
+        }
+
+        public static IEnumerable<object[]> MixingDecayPathSettings_Cases()
+        {
+            // 系列内で1つ以上の核種を暗黙に通過する、間接的な壊変経路の定義を使用する。
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input         Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood  Blood  ---",   // 親－娘の壊変経路を定義する。
+                    "[Te-129:transfer]",  "Sb-129/Blood  Blood  ---",   // 間接的な壊変経路を定義する。
+                    "[I-129:transfer]",   "Sb-129/Blood  Blood  ---",   // 間接的な壊変経路を定義する。
+                ]),
+            };
+
+            // 親－娘の壊変経路だけを指定する。
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",   // 親－娘の壊変経路。
+                    "[Te-129:transfer]",  "Sb-129/Blood   Blood  ---",   // 親－娘の壊変経路。
+                                          "Te-129m/Blood  Blood  ---",   // 親－娘の壊変経路。
+                    "[I-129:transfer]",   "Te-129m/Blood  Blood  ---",   // 親－娘の壊変経路。
+                                          "Te-129/Blood   Blood  ---",   // 親－娘の壊変経路。
+                ]),
+            };
+
+            // 先に定義した間接的な経路の一部を、後から直接的な経路で明示する。
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",  // 親－娘の壊変経路。
+                    "[Te-129:transfer]",  "Sb-129/Blood   Blood  ---",  // 先に系列を作る。
+                                          "Te-129m/Blood  Blood  ---",  // 後で系列内の親－娘の壊変経路を明示している。
+                    "[I-129:transfer]",   "Sb-129/Blood   Blood  ---",  // 先に系列を作る。
+                                          "Te-129m/Blood  Blood  ---",  // 後で系列内の親－娘の壊変経路を明示している。
+                                          "Te-129/Blood   Blood  ---",  // 後で系列内の親－娘の壊変経路を明示している。
+                ]),
+            };
+
+            // 先に定義した直接的な経路を包含する間接的な経路を後から定義する。
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",  // 親－娘の壊変経路。
+                    "[Te-129:transfer]",
+                                          "Te-129m/Blood  Blood  ---",  // 先に系列内の親－娘の壊変経路を明示している。
+                                          "Sb-129/Blood   Blood  ---",  // 後で系列を作る。
+                    "[I-129:transfer]",
+                                          "Te-129m/Blood  Blood  ---",  // 先に系列内の親－娘の壊変経路を明示している。
+                                          "Te-129/Blood   Blood  ---",  // 先に系列内の親－娘の壊変経路を明示している。
+                                          "Sb-129/Blood   Blood  ---",  // 後で系列を作る。
+                ]),
+            };
+
+            // 先に定義した直接的な経路＋系列全体を包絡しない間接的な経路の組み合わせを設定する。
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",  // 親－娘の壊変経路。
+                    "[Te-129:transfer]",
+                                          "Te-129m/Blood  Blood  ---",  // 先に系列内の親－娘の壊変経路を明示している。
+                                          "Sb-129/Blood   Blood  ---",  // 後で系列を作る。
+                    "[I-129:transfer]",
+                                          "Te-129m/Blood  Blood  ---",  // Sb-129から始まる系列全体を包絡しない間接的な経路。
+                ]),
+            };
+        }
+#endif
+
+        /// <summary>
+        /// 移行速度付き壊変経路を設定する際の開始核種によらず、系列内の壊変経路が正しく接続されることを確認する。
+        /// </summary>
+        /// <param name="reader"></param>
+        [TestMethod]
+        [DynamicData(nameof(AnywhereStartDecayPathWithCoeff_Cases))]
+        public void AnyStartDecayPathWithCoeff(InputDataReader_OIR reader)
+        {
+            var data = reader.Read();
+            var organs = data.Organs;
+
+            organs.Select(o => o.ToString()).ShouldBe(
+            [
+                "Sb-129/input",
+                "Sb-129/Blood",
+                "Te-129m/Blood",
+                "Te-129/Blood",
+                "I-129/Blood",
+                "I-129/<decay_from_Sb-129/Blood>",
+            ]);
+
+            // DecayCompartmentは同じDecayChainに属するよう生成される。
+            organs[5].IsDecayCompartment.ShouldBeTrue();
+
+            GetInflows(organs[1]).ShouldBe(["Sb-129/input"]);
+            GetInflows(organs[2]).ShouldBe(["Sb-129/Blood"]);
+            GetInflows(organs[3]).ShouldBe(["Sb-129/Blood", "Te-129m/Blood"]);
+            GetInflows(organs[4]).ShouldBe(["I-129/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[5]).ShouldBe(["Te-129m/Blood", "Te-129/Blood"]);
+        }
+
+        public static IEnumerable<object[]> AnywhereStartDecayPathWithCoeff_Cases()
+        {
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",  "inp  input  ---",
+                                             "acc  Blood  ---",
+                    "[Te-129m:compartment]", "acc  Blood  ---",
+                    "[Te-129:compartment]",  "acc  Blood  ---",
+                    "[I-129:compartment]",   "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input         Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood  Blood  ---",
+                    "[Te-129:transfer]",  "Sb-129/Blood  Blood  ---",
+                    "[I-129:transfer]",   "Sb-129/Blood  Blood  100",   // 移行速度付きの壊変経路を、系列先頭の核種Sb-129から設定。
+                ]),
+            };
+
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",   "inp  input  ---",
+                                              "acc  Blood  ---",
+                    "[Te-129m:compartment]",  "acc  Blood  ---",
+                    "[Te-129:compartment]",   "acc  Blood  ---",
+                    "[I-129:compartment]",    "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",
+                    "[Te-129:transfer]",  "Sb-129/Blood   Blood  ---",
+                    "[I-129:transfer]",   "Te-129m/Blood  Blood  100",   // 移行速度付きの壊変経路を、系列途中の核種Te-129mから設定。
+                ]),
+            };
+
+            yield return new object[]
+            {
+                CreateReader(
+                [
+                    "[title]", "dummy",
+                    "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                    "[Sb-129:compartment]",   "inp  input  ---",
+                                              "acc  Blood  ---",
+                    "[Te-129m:compartment]",  "acc  Blood  ---",
+                    "[Te-129:compartment]",   "acc  Blood  ---",
+                    "[I-129:compartment]",    "acc  Blood  ---",
+
+                    "[Sb-129:transfer]",  "input          Blood  100%",
+                    "[Te-129m:transfer]", "Sb-129/Blood   Blood  ---",
+                    "[Te-129:transfer]",  "Sb-129/Blood   Blood  ---",
+                    "[I-129:transfer]",   "Te-129/Blood   Blood  100",   // 移行速度付きの壊変経路を、系列途中の核種Te-129から設定。
+                ]),
+            };
+        }
+
+        /// <summary>
+        /// DecayChainで表現される壊変経路の系列が1つだけの場合において、
+        /// 暗黙に生成されるDecayCompartmentの作成処理をテストする。
+        /// </summary>
+        /// <param name="reader"></param>
+        [TestMethod]
+        public void OneDecayChainTest()
+        {
+            var reader = CreateReader(
+            [
+                "[title]", "dummy",
+                "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                "[Sb-129:compartment]",  "inp  input  ---",
+                                            "acc  Blood  ---",
+                "[Te-129m:compartment]", "acc  Blood  ---",
+                "[Te-129:compartment]",  "acc  Blood  ---",
+                "[I-129:compartment]",   "acc  Blood  ---",
+
+                "[Sb-129:transfer]",  "input         Blood   100%",
+                "[Te-129m:transfer]", "Sb-129/Blood  Blood    10",  // 系列の起点に同じSb-129/Bloodを設定。
+                "[Te-129:transfer]",  "Sb-129/Blood  Blood   100",  // 同上。
+                "[I-129:transfer]",   "Sb-129/Blood  Blood  1000",  // 同上。
+            ]);
+
+            var data = reader.Read();
+            var organs = data.Organs;
+
+            organs.Select(o => o.ToString()).ShouldBe(
+            [
+                "Sb-129/input",
+                "Sb-129/Blood",
+                "Te-129m/Blood",
+                "Te-129/Blood",
+                "I-129/Blood",
+                "Te-129m/<decay_from_Sb-129/Blood>",
+                "Te-129/<decay_from_Sb-129/Blood>",
+                "I-129/<decay_from_Sb-129/Blood>",
+            ]);
+
+            // DecayChainは、Sb-129/Bloodから始まる崩壊系列の1つが作成される。
+
+            // 移行速度付きの壊変経路で、移行後の核種を受けるambiguous compartmentとして先行生成されたもの。
+            organs[5].IsDecayCompartment.ShouldBeTrue();
+            organs[6].IsDecayCompartment.ShouldBeTrue();
+            organs[7].IsDecayCompartment.ShouldBeTrue();
+
+            // 崩壊系列を補完するambiguous compartmentとしてDefineDecayTransfersにおいて生成されたものは無い。
+
+            GetInflows(organs[1]).ShouldBe(["Sb-129/input"]);
+            GetInflows(organs[2]).ShouldBe(["Te-129m/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[3]).ShouldBe(["Te-129/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[4]).ShouldBe(["I-129/<decay_from_Sb-129/Blood>"]);
+
+            GetInflows(organs[5]).ShouldBe(["Sb-129/Blood",]);
+            GetInflows(organs[6]).ShouldBe(["Sb-129/Blood", "Te-129m/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[7]).ShouldBe(["Te-129m/<decay_from_Sb-129/Blood>", "Te-129/<decay_from_Sb-129/Blood>"]);
+        }
+
+        /// <summary>
+        /// DecayChainで表現される壊変経路の系列が2つある場合において、
+        /// 暗黙に生成されるDecayCompartmentの作成処理をテストする。
+        /// </summary>
+        /// <param name="reader"></param>
+        [TestMethod]
+        public void TwoDecayChainsTest()
+        {
+            var reader = CreateReader(
+            [
+                "[title]", "dummy",
+                "[nuclide]", "Sb-129  Te-129m  Te-129  I-129",
+
+                "[Sb-129:compartment]",  "inp  input  ---",
+                                         "acc  Blood  ---",
+                "[Te-129m:compartment]", "acc  Blood  ---",
+                "[Te-129:compartment]",  "acc  Blood  ---",
+                "[I-129:compartment]",   "acc  Blood  ---",
+
+                "[Sb-129:transfer]",  "input          Sb-129/Blood   100%",
+                "[Te-129m:transfer]", "Sb-129/Blood   Te-129m/Blood   10",  // 1つ目の系列の起点。
+                "[Te-129:transfer]",  "Te-129m/Blood  Te-129/Blood   100",  // 2つ目の系列の起点。
+                "[I-129:transfer]",   "Sb-129/Blood   I-129/Blood   1000",  // 1つ目の系列。
+            ]);
+
+            var data = reader.Read();
+            var organs = data.Organs;
+
+            organs.Select(o => o.ToString()).ShouldBe(
+            [
+                "Sb-129/input",
+                "Sb-129/Blood",
+                "Te-129m/Blood",
+                "Te-129/Blood",
+                "I-129/Blood",
+                "Te-129m/<decay_from_Sb-129/Blood>",
+                "Te-129/<decay_from_Te-129m/Blood>",
+                "I-129/<decay_from_Sb-129/Blood>",
+                "Te-129/<decay_from_Sb-129/Blood>",
+                "I-129/<decay_from_Te-129m/Blood>",
+            ]);
+
+            // DecayChainは、以下の2つが作成される。
+            // - Sb-129/Blood から始まる崩壊系列
+            // - Te-129m/Blood から始まる崩壊系列
+
+            // 移行速度付きの壊変経路で、移行後の核種を受けるambiguous compartmentとして先行して生成されたもの。
+            organs[5].IsDecayCompartment.ShouldBeTrue();
+            organs[6].IsDecayCompartment.ShouldBeTrue();
+            organs[7].IsDecayCompartment.ShouldBeTrue();
+
+            // 残りは、崩壊系列を補完するambiguous compartmentとしてDefineDecayTransfersにおいて生成されたもの。
+            organs[8].IsDecayCompartment.ShouldBeTrue();
+            organs[9].IsDecayCompartment.ShouldBeTrue();
+
+            GetInflows(organs[1]).ShouldBe(["Sb-129/input"]);
+            GetInflows(organs[2]).ShouldBe(["Te-129m/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[3]).ShouldBe(["Te-129/<decay_from_Te-129m/Blood>"]);
+            GetInflows(organs[4]).ShouldBe(["I-129/<decay_from_Sb-129/Blood>"]);
+
+            GetInflows(organs[5]).ShouldBe(["Sb-129/Blood",]);
+            GetInflows(organs[6]).ShouldBe(["Te-129m/Blood"]);
+            GetInflows(organs[7]).ShouldBe(["Te-129m/<decay_from_Sb-129/Blood>", "Te-129/<decay_from_Sb-129/Blood>"]);
+
+            GetInflows(organs[8]).ShouldBe(["Sb-129/Blood", "Te-129m/<decay_from_Sb-129/Blood>"]);
+            GetInflows(organs[9]).ShouldBe(["Te-129m/Blood", "Te-129/<decay_from_Te-129m/Blood>"]);
+        }
+    }
+}

--- a/FlexID.Calc.Tests/InputErrorTests.cs
+++ b/FlexID.Calc.Tests/InputErrorTests.cs
@@ -464,12 +464,15 @@ public class InputErrorTests
             "[Y-90:compartment]",
             "  acc    ST0        ---",
             "  acc    ST1        ---",
+            "  exc    Excreta    ---",
             "",
             "[Y-90:transfer]",
             "  Sr-90/input      ST0  ---",
             "  Sr-90/mix-Blood  ST0  ---",
             "  Sr-90/ST0        ST0  100%",
             "  ST0              ST1  100%",
+            "  Sr-90/Excreta    ST0  ---",
+            "  Sr-90/ST0    Excreta  ---",
         ]);
 
         var e = new Action(() => reader.Read()).ShouldThrow<InputErrorsException>();
@@ -479,10 +482,12 @@ public class InputErrorTests
             "Line 16: Require fraction of output activity [%] from mix 'mix-Blood'.",
             "Line 17: Cannot set input path to inp 'input'.",
             "Line 18: Cannot set output path from exc 'Excreta'.",
-            "Line 25: Cannot set decay path from inp 'Sr-90/input'.",
-            "Line 26: Cannot set decay path from mix 'Sr-90/mix-Blood'.",
-            "Line 27: Require transfer rate [/d] from acc 'Sr-90/ST0'.",
-            "Line 28: Require transfer rate [/d] from acc 'ST0'.",
+            "Line 26: Cannot set decay path from inp 'Sr-90/input'.",
+            "Line 27: Cannot set decay path from mix 'Sr-90/mix-Blood'.",
+            "Line 28: Require transfer rate [/d] from acc 'Sr-90/ST0'.",
+            "Line 29: Require transfer rate [/d] from acc 'ST0'.",
+            "Line 30: Cannot set decay path from exc 'Sr-90/Excreta' to non-exc 'ST0'.",
+            "Line 31: Cannot set decay path from acc 'Sr-90/ST0' to non-acc 'Excreta'.",
         ]);
     }
 

--- a/FlexID.Calc.Tests/InputErrorTests.cs
+++ b/FlexID.Calc.Tests/InputErrorTests.cs
@@ -578,7 +578,7 @@ public class InputErrorTests
     }
 }
 
-class InputErrorTestHelpers
+static class InputErrorTestHelpers
 {
     public static InputDataReader_OIR CreateReader(string[] inputLines)
     {
@@ -587,5 +587,12 @@ class InputErrorTestHelpers
         var stream = new MemoryStream(inputFileBytes);
         var reader = new StreamReader(stream);
         return new InputDataReader_OIR(reader);
+    }
+
+    public static IEnumerable<string> GetErrorLines(this InputErrors errors)
+    {
+        try { errors.RaiseIfAny(); }
+        catch (InputErrorsException e) { return e.ErrorLines; }
+        return Enumerable.Empty<string>();
     }
 }

--- a/FlexID.Calc/DecaySet.cs
+++ b/FlexID.Calc/DecaySet.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace FlexID.Calc;
 
 /// <summary>
@@ -17,29 +19,90 @@ internal class DecaySet
     /// </summary>
     public InputErrors Errors { get; }
 
-    public IList<Organ> Compartments { get; }
+    /// <summary>
+    /// 作成した崩壊系列のリスト。
+    /// </summary>
+    public List<DecayChain> DecayChains { get; } = [];
 
-    private readonly List<(Organ from, Organ to, bool hasCoeff)> decayPaths;
-    private readonly Dictionary<Organ, DecayChain> decayChains;
-    private readonly Dictionary<NuclideData, NuclideData[]> decayNuclides;
+    /// <summary>
+    /// 壊変経路のために作成したコンパートメントのリスト。
+    /// </summary>
+    public List<Organ> DecayCompartments { get; } = [];
+
+    /// <summary>
+    /// コンパートメントをキーとし、当該位置を共有する崩壊系列のリストを値とする辞書。
+    /// </summary>
+    public Dictionary<Organ, List<DecayChain>> JointChains { get; } = [];
+
+    /// <summary>
+    /// 移行速度付きの壊変経路が移行した先(organDecay)をキーとし、そこから同じ核種のまま移行した先とその係数を値とする辞書。
+    /// </summary>
+    private Dictionary<Organ, (Organ OrganTo, decimal? Coeff)> AfterDecayPath { get; } = [];
 
     /// <summary>
     /// コンストラクタ。
     /// </summary>
     /// <param name="nuclides"></param>
     /// <param name="errors"></param>
-    /// <param name="compartments"></param>
-    public DecaySet(IReadOnlyList<NuclideData> nuclides, InputErrors errors, IList<Organ> compartments)
+    public DecaySet(IReadOnlyList<NuclideData> nuclides, InputErrors errors)
     {
         Nuclides = nuclides;
         Errors = errors;
 
-        Compartments = compartments;
+        nuclideAncestors = Nuclides.Select(root =>
+        {
+            // 対象核種を末端とする崩壊系列を構成する祖先核種を列挙する。
+            var results = new List<NuclideData> { root };
 
-        decayPaths = [];
-        decayChains = [];
-        decayNuclides = Nuclides.ToDictionary(n => n, GetDecayNuclides);
+        Lagain:
+            var count = results.Count;
+            foreach (var nuclide in Nuclides.Except(results))
+            {
+                // 系列を構成する核種の親を追加する。
+                var daughters = nuclide.Branches.Select(b => b.Daughter);
+                if (daughters.Any(d => results.Contains(d)))
+                    results.Add(nuclide);
+            }
+            // 系列を構成する核種が増えなくなるまで繰り返す。
+            if (results.Count > count)
+                goto Lagain;
+
+            // rootを除いた、祖先核種のみの配列を返す。
+            results.RemoveAt(0);
+            return (IReadOnlyList<NuclideData>)results;
+        }).ToArray();
+
+        nuclideProgenies = Nuclides.Select(root =>
+        {
+            // 対象核種を始点とする崩壊系列を構成する子孫核種を列挙する。
+            var results = new List<NuclideData> { root };
+
+        Lagain:
+            var count = results.Count;
+            for (int i = 0; i < count; i++)
+            {
+                // 系列を構成する核種の娘を追加する。
+                var nuclide = results[i];
+                var daughters = nuclide.Branches.Select(b => b.Daughter);
+                results.AddRange(daughters.Where(d => !results.Contains(d)));
+            }
+            // 系列を構成する核種が増えなくなるまで繰り返す。
+            if (results.Count > count)
+                goto Lagain;
+
+            // rootを除いた、子孫核種のみの配列を返す。
+            results.RemoveAt(0);
+            return (IReadOnlyList<NuclideData>)results;
+        }).ToArray();
     }
+
+    private readonly IReadOnlyList<NuclideData>[] nuclideAncestors;
+
+    private readonly IReadOnlyList<NuclideData>[] nuclideProgenies;
+
+    private IReadOnlyList<NuclideData> GetAncestors(NuclideData nuclide) => nuclideAncestors[nuclide.Index];
+
+    private IReadOnlyList<NuclideData> GetProgenies(NuclideData nuclide) => nuclideProgenies[nuclide.Index];
 
     /// <summary>
     /// 対象コンパートメントの核種から始まる崩壊系列の情報を保持する。
@@ -49,41 +112,33 @@ internal class DecaySet
         /// <summary>
         /// コンストラクタ。
         /// </summary>
-        /// <param name="organRoot"></param>
-        /// <param name="decayNuclides">子孫核種の配列。</param>
-        public DecayChain(Organ organRoot, NuclideData[] decayNuclides)
+        /// <param name="nuclideCount">核種の総数。</param>
+        public DecayChain(int nuclideCount)
         {
-            RootCompartment = organRoot;
-            DecayNuclides = decayNuclides;
-            DecayCompartments = new Organ[decayNuclides.Length];
+            Compartments = new (int, Organ)[nuclideCount];
         }
 
-        public Organ RootCompartment;
-
-        public NuclideData[] DecayNuclides;
-
-        public Organ[] DecayCompartments;
+        /// <summary>
+        /// 崩壊系列において、これを構成する核種毎の位置を占めるコンパートメントを保持する。
+        /// </summary>
+        public (int LineNum, Organ Organ)[] Compartments;
 
         /// <summary>
-        /// 崩壊系列を構成する全ての移行経路を取得する。
+        /// 指定の子孫核種に対応する壊変コンパートメントを取得する。
         /// </summary>
+        /// <param name="progeny"></param>
         /// <returns></returns>
-        public IReadOnlyList<(NuclideData Parent, NuclideData Daughter)> GetDecayTransfers()
-        {
-            var nuclides = DecayNuclides.Prepend(RootCompartment.Nuclide);
+        public ref (int LineNum, Organ Organ) this[NuclideData progeny] => ref Compartments[progeny.Index];
 
-            var results = new List<(NuclideData Parent, NuclideData Daughter)>();
-            foreach (var parent in nuclides)
-            {
-                foreach (var daughter in DecayNuclides)
-                {
-                    if (parent == daughter)
-                        continue;
-                    if (parent.Branches.Any(b => b.Daughter == daughter))
-                        results.Add((parent, daughter));
-                }
-            }
-            return results;
+        public bool IsSubsetOf(DecayChain other)
+        {
+            return other.Compartments.Zip(this.Compartments)
+                        .All(x => x.Item1.Organ == x.Item2.Organ || x.Item2.Organ is null);
+        }
+
+        public override string ToString()
+        {
+            return string.Join(" ; ", Compartments.Select(c => c.Organ?.ToString() ?? "null"));
         }
     }
 
@@ -103,177 +158,380 @@ internal class DecaySet
         var hasCoeff = coeff is not null;
 
         // 分岐比が不明な壊変経路は定義できない。
-        if (!decayNuclides[nuclideFrom].Contains(nuclideTo))
+        if (!GetProgenies(nuclideFrom).Contains(nuclideTo))
+        {
             Errors.AddError(lineNum, $"There is no decay path from {nuclideFrom.Name} to {nuclideTo.Name}.");
-
-        var paths = decayPaths.Where(path => path.from == organFrom);
-
-        // organFromから、同じ子孫核種への2つ以上の壊変経路は定義できない。
-        if (paths.Any(path => path.to.Nuclide == nuclideTo))
-            Errors.AddError(lineNum, $"Multiple decay paths from {organFrom.Func} '{nuclideFrom.Name}/{organFrom.Name}' to nuclide '{nuclideTo.Name}'.");
-
-        decayPaths.Add((organFrom, organTo, hasCoeff));
-
-        var decayChain = GetDecayChain(organFrom);
-
-        var decayIndex = Array.IndexOf(decayChain.DecayNuclides, nuclideTo);
-        if (decayIndex == -1)
-        {
-            var rootNuc = decayChain.RootCompartment.Nuclide.Name;
-            Errors.AddError(lineNum, $"Cannot find progeny nuclide '{nuclideTo.Name}' in decay chain starts from '{rootNuc}'.");
             return null;
         }
 
-        ref var organDecay = ref decayChain.DecayCompartments[decayIndex];
-        if (organDecay != null)
+        // organFrom位置を共有する崩壊系列の1つをtargetChainとして取得する。
+        DecayChain targetChain;
+        if (JointChains.TryGetValue(organFrom, out var chainsFrom))
         {
-            if (hasCoeff)
-                Errors.AddError(lineNum, $"Decay compartment is already set.");
-            else
-                Errors.AddError(lineNum, $"Decay compartment '{organTo.Name}' conflicts with the implicitly deined one.");
-            return null;
+            targetChain = chainsFrom[0];
         }
-
-        if (hasCoeff)
+        else if (!hasCoeff &&
+            JointChains.TryGetValue(organTo, out chainsFrom) && chainsFrom.Count == 1 &&
+            GetAncestors(nuclideTo).All(ancestor => chainsFrom[0][ancestor].Organ is null))
         {
-            organDecay = AddDecayCompartment(decayChain.RootCompartment, nuclideTo);
+            // nuclideTo位置を通るただ1つの崩壊系列が、nuclideToの祖先核種全てについてコンパートメント未設定の場合に、
+            // これをorganFrom位置も通る崩壊系列として扱い、これに対してorganFromからorganToへの経路を「接ぎ木」する。
+            targetChain = chainsFrom[0];
+            targetChain[nuclideFrom] = (lineNum, organFrom);
 
-            // 以降の処理を核種が同じコンパートメント間organDecay -> organToの経路設定にすり替える。
-            return organDecay;
+            chainsFrom = [targetChain];
+            JointChains.Add(organFrom, chainsFrom);
         }
         else
         {
-            // organToを崩壊系列でorganDecayが占める位置に設定する。
-            organDecay = organTo;
+            targetChain = new DecayChain(Nuclides.Count);
+            DecayChains.Add(targetChain);
 
-            // transfersCorrectには核種が異なるコンパートメント間の壊変経路を追加しない。
-            return null;
+            ref var decayFrom = ref targetChain[nuclideFrom];
+            decayFrom = (lineNum, organFrom);
+
+            chainsFrom = [targetChain];
+            JointChains.Add(organFrom, chainsFrom);
         }
+
+        // organFromから壊変によって生成された子孫核種を
+        // nuclideTo位置で受けるためのコンパートメントorganDecayを取得する。
+        Organ organDecay;
+        {
+            var decayTo = targetChain[nuclideTo];
+            bool consistentPath;
+            if (hasCoeff)
+            {
+                organDecay = decayTo.Organ;
+
+                if (decayTo.Organ is null)
+                {
+                    organDecay = CreateDecayCompartment(nuclideTo, organFrom.Func);
+                    AfterDecayPath.Add(organDecay, (organTo, coeff));
+                    consistentPath = true;
+                }
+                else
+                {
+                    // 係数付きの壊変経路は、nuclideTo位置を高々一度だけ占めることができる。
+                    // 言い換えると、以前の経路設定でnuclideTo位置を(係数あり・なしにかかわらず)
+                    // 既に占めている場合はエラーにする。
+                    #region 詳細な説明
+
+                    // 係数なしの壊変経路の場合は、同じ崩壊系列を辿る場合でもfromが違えば経路設定が可能となっている。
+                    // 具体例を示すと：
+                    //   N1/C1 -> N2/C2 -> N3/C3 の崩壊系列に対して以下の3つの経路設定を行う場合に、
+                    //   - N1/C1 -> N2/C2
+                    //   - N1/C1 -> N3/C3 (経路A)
+                    //   - N2/C2 -> N3/C3 (経路B)
+                    //   これらをどのような順序で設定しても経路Aと経路Bが衝突なく受け付けられる。
+                    //   このとき、設定順序によってはDecayChainが2個作成され得るが、その場合でも設定順序に関係なく
+                    //   2つのDecayChainのN1,N2,N3位置のそれぞれはC1,C2,C3の3つのコンパートメントによって共有され、
+                    //   従って最終的にただ1つの崩壊系列を構成するためである。
+                    //
+                    // しかし係数付きの壊変経路では、organDecayを経路設定時に明示できないため、もしここで禁止している
+                    // 経路設定を受け付けると、設定順序に依存する挙動が生じる。
+                    // 具体例を示すと：
+                    //   N1/C1 -> N2/C2 -> N3/C3 の崩壊系列に対して以下の3つの経路設定を行う場合に、
+                    //   - N1/C1 -> N2/C2
+                    //   - N1/C1 -> N3/C3 + 移行速度 (経路X)
+                    //   - N2/C2 -> N3/C3 + 移行速度 (経路Y)
+                    //
+                    //     設定順序A：
+                    //     (1) N1/C1 -> N2/C2
+                    //     (2) N1/C1 -> N3/C3 + 移行速度 (経路X)
+                    //     (3) N2/C2 -> N3/C3 + 移行速度 (経路Y)
+                    //     …(2)の時点で DecayChain1 { C1, C2, organDecay } だけが作成される
+                    //     …(3)の時点で設定される経路Yは、この1つだけ存在するDecayChain1の一部と判断できるため、
+                    //       経路Yの設定は経路Xと衝突せず受け付けられる。
+                    //     
+                    //     設定順序B：
+                    //     (1) N1/C1 -> N3/C3 + 移行速度 (経路X)
+                    //     (2) N2/C2 -> N3/C3 + 移行速度 (経路Y)
+                    //     (3) N1/C1 -> N2/C2
+                    //     …(1)の時点で DecayChain1 { C1, null, organDecay1 } が作成される。
+                    //     …(2)の時点で DecayChain2 { null, C2, organDecay2 } が作成される。これは経路Yの設定が
+                    //       N3位置についてorganDecay1を明示できず、従ってDecayChain1とこれを共有するかどうかを
+                    //       この時点では判断できないためである。
+                    //       ※ 例えば、もしこの後に N1/C1 -> N4/C41 と N2/C2 -> N4/C42 という2つの経路設定が行われる場合、
+                    //          明らかにDecayChain1とDecayChain2は独立した2つの崩壊系列を構成することになる。
+                    //     …(3)の経路設定によって、DecayChain1とDecayChain2の2つがN1,N2位置についてそれぞれC1,C2を共有する形が作られるが、
+                    //       N3位置についてはorganDecay1とorganDecay2という異なるコンパートメントが設定済みであるため、
+                    //       2つの崩壊系列の分岐が検出されてエラーが報告される。
+                    //
+                    // このように設定順序に依存してエラーの有無が変わることを避けるため、
+                    // 係数付きの壊変経路では、経路Yを設定しようとした時点でエラーを報告する仕様としている。
+
+                    #endregion
+                    consistentPath = false;
+                }
+            }
+            else
+            {
+                organDecay = organTo;
+
+                if (decayTo.Organ is null)
+                {
+                    consistentPath = true;
+                }
+                else
+                {
+                    // 以前に設定された係数なしの壊変経路と、organDecay(== organTo)が整合している。
+                    consistentPath = decayTo.Organ == organDecay;
+                }
+            }
+
+            if (!consistentPath)
+            {
+                // 今回と前回の矛盾する2つの設定経路について、
+                // nuclideFrom位置からnuclideTo位置までを表示する。
+                var (prevTo, prevCoeff) = AfterDecayPath.GetValueOrDefault(decayTo.Organ, (decayTo.Organ, null));
+                var prev = $"'{prevTo.ToString()}'";
+                if (prevCoeff is decimal v) prev += $" (with coeff. {v})";
+
+                var here = $"'{organTo.ToString()}'";
+                if (hasCoeff) here += $" (with coeff. {coeff.Value})";
+
+                Errors.AddError(lineNum, "Decay paths conflict each other:");
+                Errors.AddError($"    the previous: '{organFrom}' --> {prev} at Line {decayTo.LineNum}");
+                Errors.AddError($"    and here    : '{organFrom}' --> {here}");
+                return null;
+            }
+        }
+
+        // nuclideTo位置に新たに合流する崩壊系列の集合を取得する。
+        var chainsInflow = CalcChainsInflow(targetChain, nuclideTo);
+
+        // organDecay位置を共有する崩壊系列のリストを取得する。
+        if (!JointChains.TryGetValue(organDecay, out var chainsTo))
+        {
+            chainsTo = chainsInflow;
+
+            // chainsToのnuclideTo位置にorganDecayを設定する。
+            foreach (var chain in chainsTo)
+            {
+                Debug.Assert(chain[nuclideTo].Organ is null);
+                chain[nuclideTo] = (lineNum, organDecay);
+            }
+
+            // organDecay位置を共有する崩壊系列群を設定する。
+            JointChains.Add(organDecay, chainsTo);
+        }
+        else
+        {
+            // chainsToに含まれる、言い換えるとnuclideTo位置を既に
+            // organDecayで占めている崩壊系列をchainsInflowから除外する。
+            // その結果、chainsToへ追加されるべき崩壊系列が0個となる場合は何もしない。
+            chainsInflow.RemoveAll(chain => chainsTo.Contains(chain));
+            if (chainsInflow.Count == 0)
+                goto Lend;
+
+            // ここからの処理で、
+            // organDecay位置を既に占めている崩壊系列群chainsToに
+            // organDecay位置へ新たに合流する崩壊系列群chainsInflowを追加する。
+
+            // chainsInflowのnuclideTo位置にorganDecayを設定する。
+            foreach (var chain in chainsInflow)
+            {
+                Debug.Assert(chain[nuclideTo].Organ is null);
+                chain[nuclideTo] = (lineNum, organDecay);
+            }
+
+            // chainsToとchainsInflowの間に、nuclideToより子孫核種の位置で矛盾がないことを確認する。
+            // 比較処理のために、2つの集合からそれぞれ1つずつ代表となる崩壊系列を取得する。
+            var chainTo = chainsTo[0];
+            var chainInflow = chainsInflow[0];
+            foreach (var progeny in GetProgenies(nuclideTo))
+            {
+                var decayTo = chainTo[progeny];
+                var decayInflow = chainInflow[progeny];
+
+                // 全ての崩壊系列がprogeny位置をまだ共有していない場合は何もしない。
+                if (decayInflow.Organ is null && decayTo.Organ is null)
+                    continue;
+
+                if (decayTo.Organ is null)
+                {
+                    foreach (var chain in chainsTo)
+                        chain[progeny] = decayInflow;
+                }
+                else if (decayInflow.Organ is null)
+                {
+                    foreach (var chain in chainsInflow)
+                        chain[progeny] = decayTo;
+                }
+                else if (decayTo.Organ != decayInflow.Organ)
+                {
+                    // nuclideTo位置より子孫のコンパートメントが全て共有されるべきにもかかわらず
+                    // nuclideToの子孫核種progenyの位置で分岐が生じてしまう2つの壊変経路について、
+                    // nuclideTo位置からprogeny位置までを表示する。
+                    var organStart = chainTo[nuclideTo].Organ;
+
+                    var (prevTo, prevCoeff) = AfterDecayPath.GetValueOrDefault(decayTo.Organ, (decayTo.Organ, null));
+                    var prev = $"'{prevTo.ToString()}'";
+                    if (prevCoeff.HasValue) prev += $" (with coeff. {prevCoeff.Value})";
+
+                    var (hereTo, hereCoeff) = AfterDecayPath.GetValueOrDefault(decayInflow.Organ, (decayInflow.Organ, null));
+                    var here = $"'{hereTo.ToString()}'";
+                    if (hereCoeff.HasValue) here += $" (with coeff. {hereCoeff.Value})";
+
+                    Errors.AddError(lineNum, "Decay paths conflict each other:");
+                    Errors.AddError($"    the previous: '{organStart}' --> {prev} at Line {decayTo.LineNum}");
+                    Errors.AddError($"    and another : '{organStart}' --> {here} at Line {decayInflow.LineNum}");
+                    return null;
+                }
+
+                // progeny位置を共有する崩壊系列にchainsInflowを追加する。
+                var chainsProgeny = JointChains[decayTo.Organ];
+                foreach (var chain in chainsInflow)
+                {
+                    if (!chainsProgeny.Contains(chain))
+                        chainsProgeny.Add(chain);
+                }
+            }
+
+            chainsTo.AddRange(chainsInflow);
+        }
+
+    Lend:
+        // chainsToの全ての崩壊系列は、nuclideTo位置でorganDecayコンパートメントを共有している。
+        Debug.Assert(chainsTo.All(chain => chain[nuclideTo].Organ == organDecay));
+
+        return hasCoeff ? organDecay : null;
     }
 
     /// <summary>
-    /// 対象核種から始まる崩壊系列を構成する子孫核種を列挙する。
+    /// targetChain上でnuclideTo位置に流入している崩壊系列の集合を計算する。
     /// </summary>
-    /// <param name="root"></param>
-    /// <returns>rootを含まない、子孫核種のみの配列。</returns>
-    private NuclideData[] GetDecayNuclides(NuclideData root)
+    /// <param name="targetChain"></param>
+    /// <param name="nuclideTo"></param>
+    /// <returns>結果を新しいリストに格納して返す。結果には少なくともtargetChainが含まれる。</returns>
+    private List<DecayChain> CalcChainsInflow(DecayChain targetChain, NuclideData nuclideTo)
     {
-        var results = new List<NuclideData> { root };
+        List<DecayChain> results = [targetChain];
 
-    Lagain:
-        var count = results.Count;
-        for (int i = 0; i < count; i++)
+        // targetChain上で、nuclideToの祖先核種の位置を確認し、コンパートメントが設定済みの箇所については
+        // それらの位置を共有する崩壊系列を全て取得しそれらの集合を返す。
+        foreach (var nuclide in GetAncestors(nuclideTo))
         {
-            // 系列を構成する核種の娘を追加する。
-            var nuclide = results[i];
-            var daughters = nuclide.Branches.Select(b => b.Daughter);
-            results.AddRange(daughters.Where(d => !results.Contains(d)));
+            if (targetChain[nuclide].Organ is not Organ organ)
+                continue;
+            foreach (var chain in JointChains[organ])
+            {
+                if (!results.Contains(chain))
+                    results.Add(chain);
+            }
         }
-        // 系列を構成する核種が増えなくなるまで繰り返す。
-        if (results.Count > count)
-            goto Lagain;
 
-        // rootを除いた、子孫核種のみの配列を返す。
-        return results.Skip(1).ToArray();
-    }
-
-    /// <summary>
-    /// organFromから始まる崩壊系列の情報を取得する。
-    /// </summary>
-    /// <param name="organFrom"></param>
-    /// <returns></returns>
-    private DecayChain GetDecayChain(Organ organFrom)
-    {
-        var funcFrom = organFrom.Func;
-        if (funcFrom != OrganFunc.acc && funcFrom != OrganFunc.exc)
-            return null;
-        if (organFrom.IsDecayCompartment)
-            return null;
-
-        var progenies = decayNuclides[organFrom.Nuclide];
-        if (progenies.Length == 0)
-            return null;
-
-        if (!decayChains.TryGetValue(organFrom, out var decayChain))
-        {
-            decayChain = new DecayChain(organFrom, progenies);
-            decayChains[organFrom] = decayChain;
-        }
-        return decayChain;
+        return results;
     }
 
     /// <summary>
     /// 核種が異なるコンパートメント間の移行経路を定義する。
     /// </summary>
-    public void DefineDecayTransfers()
+    /// <param name="compartments"></param>
+    public void DefineDecayTransfers(IList<Organ> compartments)
     {
-        foreach (var decayChain in decayChains.Values)
+        foreach (var decayChain in DecayChains)
         {
-            var organFrom = decayChain.RootCompartment;
-            var nuclideFrom = organFrom.Nuclide;
-            var decayTransfers = decayChain.GetDecayTransfers();
-            var decayCompartments = decayChain.DecayCompartments;
+            var froms = decayChain.Compartments.Select(o => o.Organ).Where(o => o != null).ToList();
+
+            // デバッグ用
+            var decayCompartmentName = $"<decay_from_{froms[0].Nuclide.Name}/{froms[0].Name}>";
 
             // 崩壊系列を構成するコンパートメント間の壊変経路を追加定義する。
-            // 壊変経路は一本道ではなく、nuclideFromから始まる有効非巡回グラフ(DAG)を構成する点に注意。
-            foreach (var path in decayTransfers)
+            // 壊変経路は一本道ではなく、親核種から始まる有効非巡回グラフ(DAG)を構成する点に注意。
+            while (froms.Count != 0)
             {
-                var from = path.Parent == nuclideFrom ? organFrom
-                       : decayCompartments.FirstOrDefault(o => o?.Nuclide == path.Parent);
-                var to = decayCompartments.FirstOrDefault(o => o?.Nuclide == path.Daughter);
+                var organFrom = froms[0];
 
-                // 壊変経路が既に設定されている＝インプットで明示的に定義されている場合は何もしない。
-                if (from != null && to != null && to.Inflows.Any(inflow => inflow.Organ == from))
-                    continue;
-
-                from ??= AddDecayCompartment(organFrom, path.Parent);
-                to ??= AddDecayCompartment(organFrom, path.Daughter);
-
-                var branch = from.Nuclide.Branches.First(b => b.Daughter == to.Nuclide);
-
-                to.Inflows.Add(new Inflow
+                foreach (var (daughter, fraction) in organFrom.Nuclide.Branches)
                 {
-                    ID = from.ID,
+                    ref var decayTo = ref decayChain[daughter];
+                    var organTo = decayTo.Organ;
 
-                    // 壊変経路では、親からの分岐比を移行割合としてとする。
-                    Rate = branch.Fraction,
+                    if (organTo is null)
+                    {
+                        organTo = CreateDecayCompartment(daughter, organFrom.Func);
+                        decayTo.Organ = organTo;
+                        froms.Add(organTo);
+                    }
+                    else if (organTo.Inflows.Any(inflow => inflow.Organ == organFrom))
+                    {
+                        // 壊変経路が既に設定されている場合は何もしない。
+                        continue;
+                    }
 
-                    // 流入経路から流入元臓器の情報を直接引くための参照を設定する。
-                    Organ = from,
-                });
+                    organTo.Inflows.Add(new Inflow
+                    {
+                        ID = organFrom.ID,
+                        Rate = fraction,    // 壊変経路では、親からの分岐比を移行割合としてとする。
+                        Organ = organFrom,  // 流入経路から流入元臓器の情報を直接引くための参照を設定する。
+                    });
+
+                    if (organTo.IsDecayCompartment)
+                    {
+                        organTo.Name = decayCompartmentName;
+
+                        SetSourceRegion(compartments, organFrom, organTo);
+                    }
+                }
+
+                froms.RemoveAt(0);
             }
+        }
+
+        var index = compartments.Count;
+        foreach (var organDecay in DecayCompartments)
+        {
+            organDecay.ID = index + 1;
+            organDecay.Index = index;
+            compartments.Add(organDecay);
+            index++;
         }
     }
 
     /// <summary>
-    /// 指定の子孫核種に対応する壊変コンパートメントを追加する。
+    /// 指定の子孫核種に対応する壊変コンパートメントを作成する。
     /// </summary>
-    /// <param name="organFrom"></param>
-    /// <param name="progeny"></param>
-    /// <returns>追加した壊変コンパートメント</returns>
-    private Organ AddDecayCompartment(Organ organFrom, NuclideData progeny)
+    /// <param name="nuclide"></param>
+    /// <param name="func"></param>
+    /// <returns>作成した壊変コンパートメント。</returns>
+    private Organ CreateDecayCompartment(NuclideData nuclide, OrganFunc func)
     {
-        var nuclideFrom = organFrom.Nuclide;
-
-        var index = Compartments.Count;
         var organDecay = new Organ
         {
-            Nuclide = progeny,
-            ID = index + 1,
-            Index = index,
-            Name = $"Decay-{nuclideFrom.Name}/{organFrom.Name}",
-            Func = OrganFunc.acc,
-            BioDecay = 1.0,     // accは後で設定する。
+            Nuclide = nuclide,
+            ID = 0,         // 後で設定する。
+            Index = -1,     // 後で設定する。
+            Name = "",      // 後で設定する。
+            Func = func,
+            BioDecay = 1.0, // accは後で設定する。
             IsDecayCompartment = true,
         };
-        Compartments.Add(organDecay);
+        DecayCompartments.Add(organDecay);
+
+        return organDecay;
+    }
+
+    /// <summary>
+    /// 壊変コンパートメントの線源領域を、親コンパートメントの線源領域から
+    /// 導出して設定する。
+    /// </summary>
+    /// <param name="compartments"></param>
+    /// <param name="organFrom"></param>
+    /// <param name="organDecay"></param>
+    private void SetSourceRegion(IList<Organ> compartments, Organ organFrom, Organ organDecay)
+    {
+        Debug.Assert(organDecay.IsDecayCompartment);
 
         var sourceRegion = organFrom.SourceRegion;
         if (sourceRegion != null)
         {
+            var daughter = organDecay.Nuclide;
+
             // 親核種のコンパートメントに設定された線源領域が、
             // 子孫核種の動態モデルおいても明示的に設定されているかどうかを調べる。
-            var explicitUsed = Compartments.Where(o => o.Nuclide == progeny)
+            var explicitUsed = compartments.Where(o => o.Nuclide == daughter)
                                            .Any(o => o.SourceRegion == sourceRegion);
 
             // 明示的に設定されていない場合は、ambiguous compartmentを'Other'に割り当てる。
@@ -282,7 +540,5 @@ internal class DecaySet
 
             organDecay.SourceRegion = sourceRegion;
         }
-
-        return organDecay;
     }
 }

--- a/FlexID.Calc/DotNetExtensions.cs
+++ b/FlexID.Calc/DotNetExtensions.cs
@@ -2,6 +2,21 @@ namespace System.Collections.Generic
 {
     internal static class Extensions
     {
+        public static int IndexOf<T>(this IReadOnlyList<T> list, T element)
+        {
+            if (list is null)
+                throw new ArgumentNullException(nameof(list));
+
+            var comparer = EqualityComparer<T>.Default;
+            int count = list.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (comparer.Equals(list[i], element))
+                    return i;
+            }
+            return -1;
+        }
+
         public static V GetValueOrDefault<K, V>(this IReadOnlyDictionary<K, V> dictionary, K key)
         {
             if (dictionary.TryGetValue(key, out var value))

--- a/FlexID.Calc/InputData.cs
+++ b/FlexID.Calc/InputData.cs
@@ -138,6 +138,11 @@ public class Organ
 public class NuclideData
 {
     /// <summary>
+    /// 核種のデータを配列から引くためのインデックス。
+    /// </summary>
+    public int Index;
+
+    /// <summary>
     /// 核種名。
     /// </summary>
     public string Name;

--- a/FlexID.Calc/InputData.cs
+++ b/FlexID.Calc/InputData.cs
@@ -110,7 +110,7 @@ public class Organ
     public bool IsInstantOutflow => Func == OrganFunc.inp || Func == OrganFunc.mix;
 
     /// <summary>
-    /// コンパートメントが移行速度付き壊変経路のために自動定義された場合に<see langword="true"/>。
+    /// コンパートメントが壊変経路のために自動定義された場合に<see langword="true"/>。
     /// </summary>
     public bool IsDecayCompartment;
 

--- a/FlexID.Calc/InputData.cs
+++ b/FlexID.Calc/InputData.cs
@@ -22,6 +22,8 @@ public class Inflow
     /// 流入割合
     /// </summary>
     public double Rate;
+
+    public override string ToString() => $"{Organ} =>{Rate}";
 }
 
 /// <summary>
@@ -53,7 +55,7 @@ public enum OrganFunc
 /// <summary>
 /// 臓器(コンパートメント)を表現する。
 /// </summary>
-[DebuggerDisplay("{Func} {Name} ({Nuclide})")]
+[DebuggerDisplay(@"\{{Func}, {ToString(),nq}\}")]
 public class Organ
 {
     /// <summary>
@@ -132,9 +134,10 @@ public class Organ
     /// コンパートメントに対応付けられた線源領域から各標的領域へのS係数(女性)。
     /// </summary>
     public double[] S_CoefficientsF;
+
+    public override string ToString() => $"{Nuclide}/{Name}";
 }
 
-[DebuggerDisplay("{Name}")]
 public class NuclideData
 {
     /// <summary>
@@ -216,6 +219,8 @@ public class NuclideData
         "ExcludeOtherSourceRegions",
         "IncludeOtherSourceRegions"
     ];
+
+    public override string ToString() => Name;
 }
 
 public class InputData

--- a/FlexID.Calc/InputDataReader_EIR.cs
+++ b/FlexID.Calc/InputDataReader_EIR.cs
@@ -77,6 +77,7 @@ public class InputDataReader_EIR : InputDataReaderBase
 
             var nuclide = new NuclideData
             {
+                Index = data.Nuclides.Count,
                 Name = values[0],
                 Lambda = double.Parse(values[1]),
                 IsProgeny = isProgeny,

--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -390,6 +390,7 @@ public class InputDataReader_OIR : InputDataReaderBase
 
                     var nuclide = new NuclideData
                     {
+                        Index = nuclides.Count,
                         Name = nuc,
                         HalfLife = halfLife ?? "---",
                         Lambda = lambda ?? 0.0,
@@ -432,6 +433,7 @@ public class InputDataReader_OIR : InputDataReaderBase
 
                 var nuclide = new NuclideData
                 {
+                    Index = nuclides.Count,
                     Name = nuc,
                     Lambda = lambda,
                     IsProgeny = nuclides.Count > 0,

--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -811,7 +811,7 @@ public class InputDataReader_OIR : InputDataReaderBase
     /// <param name="data"></param>
     private void DefineTransfers(InputData data)
     {
-        var decaySet = new DecaySet(data.Nuclides, errors, data.Organs);
+        var decaySet = new DecaySet(data.Nuclides, errors);
 
         foreach (var nuclide in nuclides)
         {
@@ -1072,7 +1072,7 @@ public class InputDataReader_OIR : InputDataReaderBase
         errors.RaiseIfAny();
 
         // 核種が異なるコンパートメントへの流入経路と、移行割合を設定する。
-        decaySet.DefineDecayTransfers();
+        decaySet.DefineDecayTransfers(data.Organs);
 
         // 移行経路の定義にエラーがないことを確定する。
         errors.RaiseIfAny();

--- a/FlexID.Calc/InputDataReader_OIR.cs
+++ b/FlexID.Calc/InputDataReader_OIR.cs
@@ -901,14 +901,22 @@ public class InputDataReader_OIR : InputDataReaderBase
                     if (funcTo == OrganFunc.inp)
                         errors.AddError(lineNum, $"Cannot set decay path to inp '{to}'.");
 
-                    // accからの壊変経路では、係数なし、または移行速度の設定を要求する。
-                    // パーセント値(移行割合)の設定はエラーとする。
-                    if (funcFrom == OrganFunc.acc && isFrac)
-                        errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{from}'.");
+                    if (funcFrom == OrganFunc.acc)
+                    {
+                        // accからの壊変経路では、係数なし、または移行速度の設定を要求する。
+                        // パーセント値(移行割合)の設定はエラーとする。
+                        if (isFrac)
+                            errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{from}'.");
+
+                        // accからの壊変経路はaccにしか移行できない。
+                        // ただし、excへの係数付きの壊変経路は、実際には途中に壊変コンパートメントとしてのaccが生成されるため許可する。
+                        if (funcTo != OrganFunc.acc && !(funcTo == OrganFunc.exc && hasCoeff))
+                            errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{from}' to non-acc '{to}'.");
+                    }
 
                     // excからの壊変経路では、子孫核種のexcへの移行のみ許可する。
                     if (funcFrom == OrganFunc.exc && funcTo != OrganFunc.exc)
-                        errors.AddError(lineNum, $"Cannot set output path from exc '{from}'.");
+                        errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{from}' to non-exc '{to}'.");
 
                     // inpやmixからの壊変経路は定義できない。
                     if (organFrom.IsInstantOutflow)

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_ing-Other.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_ing-Other.inp
@@ -292,8 +292,3 @@ Mo-93m Ingestion:Other
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_ing-Sulphide.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_ing-Sulphide.inp
@@ -292,8 +292,3 @@ Mo-93m Ingestion:Sulphide
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeF.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeF.inp
@@ -735,8 +735,3 @@ Mo-93m Inhalation:Type-F
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeM.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeM.inp
@@ -735,8 +735,3 @@ Mo-93m Inhalation:Type-M
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeS.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inh-TypeS.inp
@@ -735,8 +735,3 @@ Mo-93m Inhalation:Type-S
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inj.inp
+++ b/resources/inp/OIR/42-Mo/Mo-93m/Mo-93m_inj.inp
@@ -292,8 +292,3 @@ Mo-93m Injection
   Mo-93m/OtherTissue      Blood1                    1.39
 
   Mo-93/Blood1            Blood1                    ---
-  Mo-93/Blood2            Blood1                 1000
-  Mo-93/Liver             Blood1                    1.39
-  Mo-93/UrinaryPath       Blood1                    1.39
-  Mo-93/OtherKidneyTis    Blood1                    1.39
-  Mo-93/OtherTissue       Blood1                    1.39

--- a/resources/inp/OIR/51-Sb/Sb-129/Sb-129_ing.inp
+++ b/resources/inp/OIR/51-Sb/Sb-129/Sb-129_ing.inp
@@ -536,23 +536,7 @@ Sb-129 Ingestion
   Sb-129/ST2              Blood1                  200
 
   Te-129m/Blood1          Blood1                    ---
-  Te-129m/Blood2          Blood1                 1000
-  Te-129m/C-bone-S        Blood1                  200
-  Te-129m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-129m/T-bone-S        Blood1                  200
-  Te-129m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-129m/Liver           Blood1                  100
-  Te-129m/Thyroid         Blood1                   36
-  Te-129m/Kidneys         Blood1                  100
   Te-129m/ST              Blood1                  200
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeF.inp
+++ b/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeF.inp
@@ -918,23 +918,7 @@ Sb-129 Inhalation:Type-F
   Sb-129/ST2              Blood1                  200
 
   Te-129m/Blood1          Blood1                    ---
-  Te-129m/Blood2          Blood1                 1000
-  Te-129m/C-bone-S        Blood1                  200
-  Te-129m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-129m/T-bone-S        Blood1                  200
-  Te-129m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-129m/Liver           Blood1                  100
-  Te-129m/Thyroid         Blood1                   36
-  Te-129m/Kidneys         Blood1                  100
   Te-129m/ST              Blood1                  200
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeM.inp
+++ b/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeM.inp
@@ -918,23 +918,7 @@ Sb-129 Inhalation:Type-M
   Sb-129/ST2              Blood1                  200
 
   Te-129m/Blood1          Blood1                    ---
-  Te-129m/Blood2          Blood1                 1000
-  Te-129m/C-bone-S        Blood1                  200
-  Te-129m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-129m/T-bone-S        Blood1                  200
-  Te-129m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-129m/Liver           Blood1                  100
-  Te-129m/Thyroid         Blood1                   36
-  Te-129m/Kidneys         Blood1                  100
   Te-129m/ST              Blood1                  200
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeS.inp
+++ b/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inh-TypeS.inp
@@ -918,23 +918,7 @@ Sb-129 Inhalation:Type-S
   Sb-129/ST2              Blood1                  200
 
   Te-129m/Blood1          Blood1                    ---
-  Te-129m/Blood2          Blood1                 1000
-  Te-129m/C-bone-S        Blood1                  200
-  Te-129m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-129m/T-bone-S        Blood1                  200
-  Te-129m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-129m/Liver           Blood1                  100
-  Te-129m/Thyroid         Blood1                   36
-  Te-129m/Kidneys         Blood1                  100
   Te-129m/ST              Blood1                  200
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inj.inp
+++ b/resources/inp/OIR/51-Sb/Sb-129/Sb-129_inj.inp
@@ -536,23 +536,7 @@ Sb-129 Injection
   Sb-129/ST2              Blood1                  200
 
   Te-129m/Blood1          Blood1                    ---
-  Te-129m/Blood2          Blood1                 1000
-  Te-129m/C-bone-S        Blood1                  200
-  Te-129m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-129m/T-bone-S        Blood1                  200
-  Te-129m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-129m/Liver           Blood1                  100
-  Te-129m/Thyroid         Blood1                   36
-  Te-129m/Kidneys         Blood1                  100
   Te-129m/ST              Blood1                  200
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-131/Sb-131_ing.inp
+++ b/resources/inp/OIR/51-Sb/Sb-131/Sb-131_ing.inp
@@ -536,23 +536,7 @@ Sb-131 Ingestion
   Sb-131/ST2              Blood1                  200
 
   Te-131m/Blood1          Blood1                    ---
-  Te-131m/Blood2          Blood1                 1000
-  Te-131m/C-bone-S        Blood1                  200
-  Te-131m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-131m/T-bone-S        Blood1                  200
-  Te-131m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-131m/Liver           Blood1                  100
-  Te-131m/Thyroid         Blood1                   36
-  Te-131m/Kidneys         Blood1                  100
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeF.inp
+++ b/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeF.inp
@@ -918,23 +918,7 @@ Sb-131 Inhalation:Type-F
   Sb-131/ST2              Blood1                  200
 
   Te-131m/Blood1          Blood1                    ---
-  Te-131m/Blood2          Blood1                 1000
-  Te-131m/C-bone-S        Blood1                  200
-  Te-131m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-131m/T-bone-S        Blood1                  200
-  Te-131m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-131m/Liver           Blood1                  100
-  Te-131m/Thyroid         Blood1                   36
-  Te-131m/Kidneys         Blood1                  100
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeM.inp
+++ b/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeM.inp
@@ -918,23 +918,7 @@ Sb-131 Inhalation:Type-M
   Sb-131/ST2              Blood1                  200
 
   Te-131m/Blood1          Blood1                    ---
-  Te-131m/Blood2          Blood1                 1000
-  Te-131m/C-bone-S        Blood1                  200
-  Te-131m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-131m/T-bone-S        Blood1                  200
-  Te-131m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-131m/Liver           Blood1                  100
-  Te-131m/Thyroid         Blood1                   36
-  Te-131m/Kidneys         Blood1                  100
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeS.inp
+++ b/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inh-TypeS.inp
@@ -918,23 +918,7 @@ Sb-131 Inhalation:Type-S
   Sb-131/ST2              Blood1                  200
 
   Te-131m/Blood1          Blood1                    ---
-  Te-131m/Blood2          Blood1                 1000
-  Te-131m/C-bone-S        Blood1                  200
-  Te-131m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-131m/T-bone-S        Blood1                  200
-  Te-131m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-131m/Liver           Blood1                  100
-  Te-131m/Thyroid         Blood1                   36
-  Te-131m/Kidneys         Blood1                  100
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200

--- a/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inj.inp
+++ b/resources/inp/OIR/51-Sb/Sb-131/Sb-131_inj.inp
@@ -536,23 +536,7 @@ Sb-131 Injection
   Sb-131/ST2              Blood1                  200
 
   Te-131m/Blood1          Blood1                    ---
-  Te-131m/Blood2          Blood1                 1000
-  Te-131m/C-bone-S        Blood1                  200
-  Te-131m/C-bone-V        Blood1                $(0.03 / 365.25)
-  Te-131m/T-bone-S        Blood1                  200
-  Te-131m/T-bone-V        Blood1                $(0.03 / 365.25)
   Te-131m/Liver           Blood1                  100
-  Te-131m/Thyroid         Blood1                   36
-  Te-131m/Kidneys         Blood1                  100
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_ing.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_ing.inp
@@ -267,15 +267,6 @@ Te-129m Ingestion
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeF-Gas.inp
@@ -517,15 +517,6 @@ Te-129m Inhalation:Type-F_Gas
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeF.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeF.inp
@@ -529,15 +529,6 @@ Te-129m Inhalation:Type-F
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeM.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeM.inp
@@ -529,15 +529,6 @@ Te-129m Inhalation:Type-M
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeS.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_inh-TypeS.inp
@@ -529,15 +529,6 @@ Te-129m Inhalation:Type-S
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1

--- a/resources/inp/OIR/52-Te/Te-129m/Te-129m_inj.inp
+++ b/resources/inp/OIR/52-Te/Te-129m/Te-129m_inj.inp
@@ -267,15 +267,6 @@ Te-129m Injection
   Te-129/Urine            Urine                     ---
 
   Te-129/Blood1           Blood1                    ---
-  Te-129/Blood2           Blood1                 1000
-  Te-129/C-bone-S         Blood1                  200
-  Te-129/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-129/T-bone-S         Blood1                  200
-  Te-129/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-129/Liver            Blood1                  100
-  Te-129/Thyroid          Blood1                   36
-  Te-129/Kidneys          Blood1                  100
-  Te-129/ST               Blood1                  200
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_ing.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_ing.inp
@@ -281,18 +281,9 @@ Te-131 Ingestion
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeF-Gas.inp
@@ -471,29 +471,6 @@ Te-131 Inhalation:Type-F_Gas
   Te-131/INT-S            Exhaled                 100
   Te-131/LNTH-S           Exhaled                 100
 
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131/Oralcavity       Exhaled                 100
   Te-131/Oesophagus-f     Exhaled                 100
   Te-131/Oesophagus-s     Exhaled                 100
@@ -505,18 +482,9 @@ Te-131 Inhalation:Type-F_Gas
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeF.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeF.inp
@@ -483,29 +483,6 @@ Te-131 Inhalation:Type-F
   Te-131/INT-S            Exhaled                 100
   Te-131/LNTH-S           Exhaled                 100
 
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131/Oralcavity       Exhaled                 100
   Te-131/Oesophagus-f     Exhaled                 100
   Te-131/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-131 Inhalation:Type-F
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeM.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeM.inp
@@ -483,29 +483,6 @@ Te-131 Inhalation:Type-M
   Te-131/INT-S            Exhaled                 100
   Te-131/LNTH-S           Exhaled                 100
 
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131/Oralcavity       Exhaled                 100
   Te-131/Oesophagus-f     Exhaled                 100
   Te-131/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-131 Inhalation:Type-M
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeS.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_inh-TypeS.inp
@@ -483,29 +483,6 @@ Te-131 Inhalation:Type-S
   Te-131/INT-S            Exhaled                 100
   Te-131/LNTH-S           Exhaled                 100
 
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131/Oralcavity       Exhaled                 100
   Te-131/Oesophagus-f     Exhaled                 100
   Te-131/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-131 Inhalation:Type-S
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131/Te-131_inj.inp
+++ b/resources/inp/OIR/52-Te/Te-131/Te-131_inj.inp
@@ -281,18 +281,9 @@ Te-131 Injection
   Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_ing.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_ing.inp
@@ -362,15 +362,6 @@ Te-131m Ingestion
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -410,29 +401,11 @@ Te-131m Ingestion
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -487,15 +460,6 @@ Te-131m Ingestion
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeF-Gas.inp
@@ -660,15 +660,6 @@ Te-131m Inhalation:Type-F_Gas
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -720,52 +711,6 @@ Te-131m Inhalation:Type-F_Gas
   Te-131m/INT-S           Exhaled                 100
   Te-131m/LNTH-S          Exhaled                 100
 
-  Te-131/ET1-F            Exhaled                 100
-  Te-131/ET2-F            Exhaled                 100
-  Te-131/ETseq-F          Exhaled                 100
-  Te-131/LNET-F           Exhaled                 100
-  Te-131/BB-F             Exhaled                 100
-  Te-131/BBseq-F          Exhaled                 100
-  Te-131/bb-F             Exhaled                 100
-  Te-131/bbseq-F          Exhaled                 100
-  Te-131/ALV-F            Exhaled                 100
-  Te-131/INT-F            Exhaled                 100
-  Te-131/LNTH-F           Exhaled                 100
-  Te-131/ET1-S            Exhaled                 100
-  Te-131/ET2-S            Exhaled                 100
-  Te-131/ETseq-S          Exhaled                 100
-  Te-131/LNET-S           Exhaled                 100
-  Te-131/BB-S             Exhaled                 100
-  Te-131/BBseq-S          Exhaled                 100
-  Te-131/bb-S             Exhaled                 100
-  Te-131/bbseq-S          Exhaled                 100
-  Te-131/ALV-S            Exhaled                 100
-  Te-131/INT-S            Exhaled                 100
-  Te-131/LNTH-S           Exhaled                 100
-
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131m/Oralcavity      Exhaled                 100
   Te-131m/Oesophagus-f    Exhaled                 100
   Te-131m/Oesophagus-s    Exhaled                 100
@@ -777,29 +722,11 @@ Te-131m Inhalation:Type-F_Gas
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -854,15 +781,6 @@ Te-131m Inhalation:Type-F_Gas
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeF.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeF.inp
@@ -672,15 +672,6 @@ Te-131m Inhalation:Type-F
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -732,52 +723,6 @@ Te-131m Inhalation:Type-F
   Te-131m/INT-S           Exhaled                 100
   Te-131m/LNTH-S          Exhaled                 100
 
-  Te-131/ET1-F            Exhaled                 100
-  Te-131/ET2-F            Exhaled                 100
-  Te-131/ETseq-F          Exhaled                 100
-  Te-131/LNET-F           Exhaled                 100
-  Te-131/BB-F             Exhaled                 100
-  Te-131/BBseq-F          Exhaled                 100
-  Te-131/bb-F             Exhaled                 100
-  Te-131/bbseq-F          Exhaled                 100
-  Te-131/ALV-F            Exhaled                 100
-  Te-131/INT-F            Exhaled                 100
-  Te-131/LNTH-F           Exhaled                 100
-  Te-131/ET1-S            Exhaled                 100
-  Te-131/ET2-S            Exhaled                 100
-  Te-131/ETseq-S          Exhaled                 100
-  Te-131/LNET-S           Exhaled                 100
-  Te-131/BB-S             Exhaled                 100
-  Te-131/BBseq-S          Exhaled                 100
-  Te-131/bb-S             Exhaled                 100
-  Te-131/bbseq-S          Exhaled                 100
-  Te-131/ALV-S            Exhaled                 100
-  Te-131/INT-S            Exhaled                 100
-  Te-131/LNTH-S           Exhaled                 100
-
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131m/Oralcavity      Exhaled                 100
   Te-131m/Oesophagus-f    Exhaled                 100
   Te-131m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-131m Inhalation:Type-F
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-131m Inhalation:Type-F
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeM.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeM.inp
@@ -672,15 +672,6 @@ Te-131m Inhalation:Type-M
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -732,52 +723,6 @@ Te-131m Inhalation:Type-M
   Te-131m/INT-S           Exhaled                 100
   Te-131m/LNTH-S          Exhaled                 100
 
-  Te-131/ET1-F            Exhaled                 100
-  Te-131/ET2-F            Exhaled                 100
-  Te-131/ETseq-F          Exhaled                 100
-  Te-131/LNET-F           Exhaled                 100
-  Te-131/BB-F             Exhaled                 100
-  Te-131/BBseq-F          Exhaled                 100
-  Te-131/bb-F             Exhaled                 100
-  Te-131/bbseq-F          Exhaled                 100
-  Te-131/ALV-F            Exhaled                 100
-  Te-131/INT-F            Exhaled                 100
-  Te-131/LNTH-F           Exhaled                 100
-  Te-131/ET1-S            Exhaled                 100
-  Te-131/ET2-S            Exhaled                 100
-  Te-131/ETseq-S          Exhaled                 100
-  Te-131/LNET-S           Exhaled                 100
-  Te-131/BB-S             Exhaled                 100
-  Te-131/BBseq-S          Exhaled                 100
-  Te-131/bb-S             Exhaled                 100
-  Te-131/bbseq-S          Exhaled                 100
-  Te-131/ALV-S            Exhaled                 100
-  Te-131/INT-S            Exhaled                 100
-  Te-131/LNTH-S           Exhaled                 100
-
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131m/Oralcavity      Exhaled                 100
   Te-131m/Oesophagus-f    Exhaled                 100
   Te-131m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-131m Inhalation:Type-M
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-131m Inhalation:Type-M
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeS.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_inh-TypeS.inp
@@ -672,15 +672,6 @@ Te-131m Inhalation:Type-S
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -732,52 +723,6 @@ Te-131m Inhalation:Type-S
   Te-131m/INT-S           Exhaled                 100
   Te-131m/LNTH-S          Exhaled                 100
 
-  Te-131/ET1-F            Exhaled                 100
-  Te-131/ET2-F            Exhaled                 100
-  Te-131/ETseq-F          Exhaled                 100
-  Te-131/LNET-F           Exhaled                 100
-  Te-131/BB-F             Exhaled                 100
-  Te-131/BBseq-F          Exhaled                 100
-  Te-131/bb-F             Exhaled                 100
-  Te-131/bbseq-F          Exhaled                 100
-  Te-131/ALV-F            Exhaled                 100
-  Te-131/INT-F            Exhaled                 100
-  Te-131/LNTH-F           Exhaled                 100
-  Te-131/ET1-S            Exhaled                 100
-  Te-131/ET2-S            Exhaled                 100
-  Te-131/ETseq-S          Exhaled                 100
-  Te-131/LNET-S           Exhaled                 100
-  Te-131/BB-S             Exhaled                 100
-  Te-131/BBseq-S          Exhaled                 100
-  Te-131/bb-S             Exhaled                 100
-  Te-131/bbseq-S          Exhaled                 100
-  Te-131/ALV-S            Exhaled                 100
-  Te-131/INT-S            Exhaled                 100
-  Te-131/LNTH-S           Exhaled                 100
-
-  I-131/ET1-F             Exhaled                 100
-  I-131/ET2-F             Exhaled                 100
-  I-131/ETseq-F           Exhaled                 100
-  I-131/LNET-F            Exhaled                 100
-  I-131/BB-F              Exhaled                 100
-  I-131/BBseq-F           Exhaled                 100
-  I-131/bb-F              Exhaled                 100
-  I-131/bbseq-F           Exhaled                 100
-  I-131/ALV-F             Exhaled                 100
-  I-131/INT-F             Exhaled                 100
-  I-131/LNTH-F            Exhaled                 100
-  I-131/ET1-S             Exhaled                 100
-  I-131/ET2-S             Exhaled                 100
-  I-131/ETseq-S           Exhaled                 100
-  I-131/LNET-S            Exhaled                 100
-  I-131/BB-S              Exhaled                 100
-  I-131/BBseq-S           Exhaled                 100
-  I-131/bb-S              Exhaled                 100
-  I-131/bbseq-S           Exhaled                 100
-  I-131/ALV-S             Exhaled                 100
-  I-131/INT-S             Exhaled                 100
-  I-131/LNTH-S            Exhaled                 100
-
   Te-131m/Oralcavity      Exhaled                 100
   Te-131m/Oesophagus-f    Exhaled                 100
   Te-131m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-131m Inhalation:Type-S
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-131m Inhalation:Type-S
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-131m/Te-131m_inj.inp
+++ b/resources/inp/OIR/52-Te/Te-131m/Te-131m_inj.inp
@@ -362,15 +362,6 @@ Te-131m Injection
   Te-131m/ST              Blood1                  200
 
   Te-131/Blood1           Blood1                    ---
-  Te-131/Blood2           Blood1                 1000
-  Te-131/C-bone-S         Blood1                  200
-  Te-131/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-131/T-bone-S         Blood1                  200
-  Te-131/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-131/Liver            Blood1                  100
-  Te-131/Thyroid          Blood1                   36
-  Te-131/Kidneys          Blood1                  100
-  Te-131/ST               Blood1                  200
 
 
 [Xe-131m:compartment]
@@ -410,29 +401,11 @@ Te-131m Injection
   Te-131m/RS-con          Exhaled                 100
   Te-131m/UB-con          UB-con                    ---
 
-  Te-131/Oralcavity       Exhaled                 100
-  Te-131/Oesophagus-f     Exhaled                 100
-  Te-131/Oesophagus-s     Exhaled                 100
-  Te-131/St-con           Exhaled                 100
-  Te-131/SI-con           Exhaled                 100
-  Te-131/SI-conRe         Exhaled                 100
-  Te-131/RC-con           Exhaled                 100
-  Te-131/LC-con           Exhaled                 100
-  Te-131/RS-con           Exhaled                 100
   Te-131/UB-con           UB-con                    ---
 
-  I-131/Oralcavity        Exhaled                 100
   I-131/OralcavityRe      Exhaled                 100
-  I-131/Oesophagus-f      Exhaled                 100
-  I-131/Oesophagus-s      Exhaled                 100
   I-131/Oesophagus-sRe    Exhaled                 100
-  I-131/St-con            Exhaled                 100
   I-131/St-conRe          Exhaled                 100
-  I-131/SI-con            Exhaled                 100
-  I-131/SI-conRe          Exhaled                 100
-  I-131/RC-con            Exhaled                 100
-  I-131/LC-con            Exhaled                 100
-  I-131/RS-con            Exhaled                 100
   I-131/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -487,15 +460,6 @@ Te-131m Injection
   Te-131m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-131/Blood1           Blood                     ---
-  Te-131/Blood2           Blood                  1000
-  Te-131/C-bone-S         Blood                   100
-  Te-131/C-bone-V         Blood                   100
-  Te-131/T-bone-S         Blood                   100
-  Te-131/T-bone-V         Blood                   100
-  Te-131/Liver            Blood                  1000
-  Te-131/Thyroid          Blood                  1000
-  Te-131/Kidneys          Blood                  1000
-  Te-131/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-131/Blood1            Blood                     ---
   I-131/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_ing.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_ing.inp
@@ -281,18 +281,9 @@ Te-133 Ingestion
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -387,18 +378,9 @@ Te-133 Ingestion
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeF-Gas.inp
@@ -471,29 +471,6 @@ Te-133 Inhalation:Type-F_Gas
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -505,18 +482,9 @@ Te-133 Inhalation:Type-F_Gas
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -623,29 +591,6 @@ Te-133 Inhalation:Type-F_Gas
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -657,18 +602,9 @@ Te-133 Inhalation:Type-F_Gas
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeF.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeF.inp
@@ -483,29 +483,6 @@ Te-133 Inhalation:Type-F
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-133 Inhalation:Type-F
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -635,29 +603,6 @@ Te-133 Inhalation:Type-F
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -669,18 +614,9 @@ Te-133 Inhalation:Type-F
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeM.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeM.inp
@@ -483,29 +483,6 @@ Te-133 Inhalation:Type-M
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-133 Inhalation:Type-M
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -635,29 +603,6 @@ Te-133 Inhalation:Type-M
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -669,18 +614,9 @@ Te-133 Inhalation:Type-M
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeS.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_inh-TypeS.inp
@@ -483,29 +483,6 @@ Te-133 Inhalation:Type-S
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -517,18 +494,9 @@ Te-133 Inhalation:Type-S
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -635,29 +603,6 @@ Te-133 Inhalation:Type-S
   Te-133/INT-S            Exhaled                 100
   Te-133/LNTH-S           Exhaled                 100
 
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133/Oralcavity       Exhaled                 100
   Te-133/Oesophagus-f     Exhaled                 100
   Te-133/Oesophagus-s     Exhaled                 100
@@ -669,18 +614,9 @@ Te-133 Inhalation:Type-S
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133/Te-133_inj.inp
+++ b/resources/inp/OIR/52-Te/Te-133/Te-133_inj.inp
@@ -281,18 +281,9 @@ Te-133 Injection
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -387,18 +378,9 @@ Te-133 Injection
   Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_ing.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_ing.inp
@@ -304,15 +304,6 @@ Te-133m Ingestion
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
@@ -410,29 +401,11 @@ Te-133m Ingestion
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -487,15 +460,6 @@ Te-133m Ingestion
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -538,29 +502,11 @@ Te-133m Ingestion
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -579,15 +525,6 @@ Te-133m Ingestion
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeF-Gas.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeF-Gas.inp
@@ -554,15 +554,6 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -720,52 +711,6 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -777,29 +722,11 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -854,15 +781,6 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -917,52 +835,6 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -974,29 +846,11 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -1015,15 +869,6 @@ Te-133m Inhalation:Type-F_Gas
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeF.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeF.inp
@@ -566,15 +566,6 @@ Te-133m Inhalation:Type-F
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -732,52 +723,6 @@ Te-133m Inhalation:Type-F
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-133m Inhalation:Type-F
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-133m Inhalation:Type-F
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -929,52 +847,6 @@ Te-133m Inhalation:Type-F
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -986,29 +858,11 @@ Te-133m Inhalation:Type-F
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -1027,15 +881,6 @@ Te-133m Inhalation:Type-F
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeM.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeM.inp
@@ -566,15 +566,6 @@ Te-133m Inhalation:Type-M
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -732,52 +723,6 @@ Te-133m Inhalation:Type-M
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-133m Inhalation:Type-M
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-133m Inhalation:Type-M
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -929,52 +847,6 @@ Te-133m Inhalation:Type-M
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -986,29 +858,11 @@ Te-133m Inhalation:Type-M
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -1027,15 +881,6 @@ Te-133m Inhalation:Type-M
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeS.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_inh-TypeS.inp
@@ -566,15 +566,6 @@ Te-133m Inhalation:Type-S
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.65 Fig.3.4
 # ICRP Publ.130 p.151 Table A.1
@@ -732,52 +723,6 @@ Te-133m Inhalation:Type-S
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -789,29 +734,11 @@ Te-133m Inhalation:Type-S
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -866,15 +793,6 @@ Te-133m Inhalation:Type-S
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -929,52 +847,6 @@ Te-133m Inhalation:Type-S
   Te-133m/INT-S           Exhaled                 100
   Te-133m/LNTH-S          Exhaled                 100
 
-  Te-133/ET1-F            Exhaled                 100
-  Te-133/ET2-F            Exhaled                 100
-  Te-133/ETseq-F          Exhaled                 100
-  Te-133/LNET-F           Exhaled                 100
-  Te-133/BB-F             Exhaled                 100
-  Te-133/BBseq-F          Exhaled                 100
-  Te-133/bb-F             Exhaled                 100
-  Te-133/bbseq-F          Exhaled                 100
-  Te-133/ALV-F            Exhaled                 100
-  Te-133/INT-F            Exhaled                 100
-  Te-133/LNTH-F           Exhaled                 100
-  Te-133/ET1-S            Exhaled                 100
-  Te-133/ET2-S            Exhaled                 100
-  Te-133/ETseq-S          Exhaled                 100
-  Te-133/LNET-S           Exhaled                 100
-  Te-133/BB-S             Exhaled                 100
-  Te-133/BBseq-S          Exhaled                 100
-  Te-133/bb-S             Exhaled                 100
-  Te-133/bbseq-S          Exhaled                 100
-  Te-133/ALV-S            Exhaled                 100
-  Te-133/INT-S            Exhaled                 100
-  Te-133/LNTH-S           Exhaled                 100
-
-  I-133/ET1-F             Exhaled                 100
-  I-133/ET2-F             Exhaled                 100
-  I-133/ETseq-F           Exhaled                 100
-  I-133/LNET-F            Exhaled                 100
-  I-133/BB-F              Exhaled                 100
-  I-133/BBseq-F           Exhaled                 100
-  I-133/bb-F              Exhaled                 100
-  I-133/bbseq-F           Exhaled                 100
-  I-133/ALV-F             Exhaled                 100
-  I-133/INT-F             Exhaled                 100
-  I-133/LNTH-F            Exhaled                 100
-  I-133/ET1-S             Exhaled                 100
-  I-133/ET2-S             Exhaled                 100
-  I-133/ETseq-S           Exhaled                 100
-  I-133/LNET-S            Exhaled                 100
-  I-133/BB-S              Exhaled                 100
-  I-133/BBseq-S           Exhaled                 100
-  I-133/bb-S              Exhaled                 100
-  I-133/bbseq-S           Exhaled                 100
-  I-133/ALV-S             Exhaled                 100
-  I-133/INT-S             Exhaled                 100
-  I-133/LNTH-S            Exhaled                 100
-
   Te-133m/Oralcavity      Exhaled                 100
   Te-133m/Oesophagus-f    Exhaled                 100
   Te-133m/Oesophagus-s    Exhaled                 100
@@ -986,29 +858,11 @@ Te-133m Inhalation:Type-S
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -1027,15 +881,6 @@ Te-133m Inhalation:Type-S
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/52-Te/Te-133m/Te-133m_inj.inp
+++ b/resources/inp/OIR/52-Te/Te-133m/Te-133m_inj.inp
@@ -304,15 +304,6 @@ Te-133m Injection
   Te-133m/ST              Blood1                  200
 
   Te-133/Blood1           Blood1                    ---
-  Te-133/Blood2           Blood1                 1000
-  Te-133/C-bone-S         Blood1                  200
-  Te-133/C-bone-V         Blood1                $(0.03 / 365.25)
-  Te-133/T-bone-S         Blood1                  200
-  Te-133/T-bone-V         Blood1                $(0.18 / 365.25)
-  Te-133/Liver            Blood1                  100
-  Te-133/Thyroid          Blood1                   36
-  Te-133/Kidneys          Blood1                  100
-  Te-133/ST               Blood1                  200
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
@@ -410,29 +401,11 @@ Te-133m Injection
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -487,15 +460,6 @@ Te-133m Injection
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000
@@ -538,29 +502,11 @@ Te-133m Injection
   Te-133m/RS-con          Exhaled                 100
   Te-133m/UB-con          UB-con                    ---
 
-  Te-133/Oralcavity       Exhaled                 100
-  Te-133/Oesophagus-f     Exhaled                 100
-  Te-133/Oesophagus-s     Exhaled                 100
-  Te-133/St-con           Exhaled                 100
-  Te-133/SI-con           Exhaled                 100
-  Te-133/SI-conRe         Exhaled                 100
-  Te-133/RC-con           Exhaled                 100
-  Te-133/LC-con           Exhaled                 100
-  Te-133/RS-con           Exhaled                 100
   Te-133/UB-con           UB-con                    ---
 
-  I-133/Oralcavity        Exhaled                 100
   I-133/OralcavityRe      Exhaled                 100
-  I-133/Oesophagus-f      Exhaled                 100
-  I-133/Oesophagus-s      Exhaled                 100
   I-133/Oesophagus-sRe    Exhaled                 100
-  I-133/St-con            Exhaled                 100
   I-133/St-conRe          Exhaled                 100
-  I-133/SI-con            Exhaled                 100
-  I-133/SI-conRe          Exhaled                 100
-  I-133/RC-con            Exhaled                 100
-  I-133/LC-con            Exhaled                 100
-  I-133/RS-con            Exhaled                 100
   I-133/UB-con            UB-con                    ---
 
 # ICRP Publ.130 p.85 Para.172
@@ -579,15 +525,6 @@ Te-133m Injection
   Te-133m/ST              Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   Te-133/Blood1           Blood                     ---
-  Te-133/Blood2           Blood                  1000
-  Te-133/C-bone-S         Blood                   100
-  Te-133/C-bone-V         Blood                   100
-  Te-133/T-bone-S         Blood                   100
-  Te-133/T-bone-V         Blood                   100
-  Te-133/Liver            Blood                  1000
-  Te-133/Thyroid          Blood                  1000
-  Te-133/Kidneys          Blood                  1000
-  Te-133/ST               Blood                 $(0.693 / (20/60/24))   # 半減期20分
 
   I-133/Blood1            Blood                     ---
   I-133/Liver1            Blood                  1000

--- a/resources/inp/OIR/79-Au/Au-186/Au-186_ing.inp
+++ b/resources/inp/OIR/79-Au/Au-186/Au-186_ing.inp
@@ -944,7 +944,6 @@ Au-186 Ingestion
 
 # ICRP Publ.151 p.307 Para.601
   Pt-186/Blood1           Blood                     ---
-  Pt-186/Blood2           Blood                  1000
   Pt-186/C-bone-S         C-bone-S                  ---
   Pt-186/C-bone-V         C-bone-V                  ---
   Pt-186/T-bone-S         T-bone-S                  ---
@@ -959,7 +958,6 @@ Au-186 Ingestion
 
 # ICRP Publ.151 p.299 Para.588
   Os-182/Blood1           Blood                     ---
-  Os-182/Blood2           Blood                  1000
   Os-182/C-bone-S         C-bone-S                  ---
   Os-182/C-bone-V         C-bone-V                  ---
   Os-182/T-bone-S         T-bone-S                  ---
@@ -968,6 +966,3 @@ Au-186 Ingestion
   Os-182/Liver2           Liver2                    ---
   Os-182/UrinaryPath      UrinaryPath               ---
   Os-182/OtherKidneyTis   OtherKidneyTis            ---
-  Os-182/ST0              Blood                     0.462
-  Os-182/ST1              Blood                     0.462
-  Os-182/ST2              Blood                     0.462

--- a/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeF.inp
+++ b/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeF.inp
@@ -1991,7 +1991,6 @@ Au-186 Inhalation:Type-F
 
 # ICRP Publ.151 p.307 Para.601
   Pt-186/Blood1           Blood                     ---
-  Pt-186/Blood2           Blood                  1000
   Pt-186/C-bone-S         C-bone-S                  ---
   Pt-186/C-bone-V         C-bone-V                  ---
   Pt-186/T-bone-S         T-bone-S                  ---
@@ -2006,7 +2005,6 @@ Au-186 Inhalation:Type-F
 
 # ICRP Publ.151 p.299 Para.588
   Os-182/Blood1           Blood                     ---
-  Os-182/Blood2           Blood                  1000
   Os-182/C-bone-S         C-bone-S                  ---
   Os-182/C-bone-V         C-bone-V                  ---
   Os-182/T-bone-S         T-bone-S                  ---
@@ -2015,6 +2013,3 @@ Au-186 Inhalation:Type-F
   Os-182/Liver2           Liver2                    ---
   Os-182/UrinaryPath      UrinaryPath               ---
   Os-182/OtherKidneyTis   OtherKidneyTis            ---
-  Os-182/ST0              Blood                     0.462
-  Os-182/ST1              Blood                     0.462
-  Os-182/ST2              Blood                     0.462

--- a/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeM.inp
+++ b/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeM.inp
@@ -1991,7 +1991,6 @@ Au-186 Inhalation:Type-M
 
 # ICRP Publ.151 p.307 Para.601
   Pt-186/Blood1           Blood                     ---
-  Pt-186/Blood2           Blood                  1000
   Pt-186/C-bone-S         C-bone-S                  ---
   Pt-186/C-bone-V         C-bone-V                  ---
   Pt-186/T-bone-S         T-bone-S                  ---
@@ -2006,7 +2005,6 @@ Au-186 Inhalation:Type-M
 
 # ICRP Publ.151 p.299 Para.588
   Os-182/Blood1           Blood                     ---
-  Os-182/Blood2           Blood                  1000
   Os-182/C-bone-S         C-bone-S                  ---
   Os-182/C-bone-V         C-bone-V                  ---
   Os-182/T-bone-S         T-bone-S                  ---
@@ -2015,6 +2013,3 @@ Au-186 Inhalation:Type-M
   Os-182/Liver2           Liver2                    ---
   Os-182/UrinaryPath      UrinaryPath               ---
   Os-182/OtherKidneyTis   OtherKidneyTis            ---
-  Os-182/ST0              Blood                     0.462
-  Os-182/ST1              Blood                     0.462
-  Os-182/ST2              Blood                     0.462

--- a/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeS.inp
+++ b/resources/inp/OIR/79-Au/Au-186/Au-186_inh-TypeS.inp
@@ -1991,7 +1991,6 @@ Au-186 Inhalation:Type-S
 
 # ICRP Publ.151 p.307 Para.601
   Pt-186/Blood1           Blood                     ---
-  Pt-186/Blood2           Blood                  1000
   Pt-186/C-bone-S         C-bone-S                  ---
   Pt-186/C-bone-V         C-bone-V                  ---
   Pt-186/T-bone-S         T-bone-S                  ---
@@ -2006,7 +2005,6 @@ Au-186 Inhalation:Type-S
 
 # ICRP Publ.151 p.299 Para.588
   Os-182/Blood1           Blood                     ---
-  Os-182/Blood2           Blood                  1000
   Os-182/C-bone-S         C-bone-S                  ---
   Os-182/C-bone-V         C-bone-V                  ---
   Os-182/T-bone-S         T-bone-S                  ---
@@ -2015,6 +2013,3 @@ Au-186 Inhalation:Type-S
   Os-182/Liver2           Liver2                    ---
   Os-182/UrinaryPath      UrinaryPath               ---
   Os-182/OtherKidneyTis   OtherKidneyTis            ---
-  Os-182/ST0              Blood                     0.462
-  Os-182/ST1              Blood                     0.462
-  Os-182/ST2              Blood                     0.462

--- a/resources/inp/OIR/79-Au/Au-186/Au-186_inj.inp
+++ b/resources/inp/OIR/79-Au/Au-186/Au-186_inj.inp
@@ -944,7 +944,6 @@ Au-186 Injection
 
 # ICRP Publ.151 p.307 Para.601
   Pt-186/Blood1           Blood                     ---
-  Pt-186/Blood2           Blood                  1000
   Pt-186/C-bone-S         C-bone-S                  ---
   Pt-186/C-bone-V         C-bone-V                  ---
   Pt-186/T-bone-S         T-bone-S                  ---
@@ -959,7 +958,6 @@ Au-186 Injection
 
 # ICRP Publ.151 p.299 Para.588
   Os-182/Blood1           Blood                     ---
-  Os-182/Blood2           Blood                  1000
   Os-182/C-bone-S         C-bone-S                  ---
   Os-182/C-bone-V         C-bone-V                  ---
   Os-182/T-bone-S         T-bone-S                  ---
@@ -968,6 +966,3 @@ Au-186 Injection
   Os-182/Liver2           Liver2                    ---
   Os-182/UrinaryPath      UrinaryPath               ---
   Os-182/OtherKidneyTis   OtherKidneyTis            ---
-  Os-182/ST0              Blood                     0.462
-  Os-182/ST1              Blood                     0.462
-  Os-182/ST2              Blood                     0.462

--- a/resources/inp/OIR/81-Tl/Tl-195/Tl-195_ing.inp
+++ b/resources/inp/OIR/81-Tl/Tl-195/Tl-195_ing.inp
@@ -459,14 +459,7 @@ Tl-195 Ingestion
   Hg-195m/Other1          Blood1                    0.0693
   Hg-195m/Other2          Blood1                    0.0693
 
-  Hg-195/Plasma1          Blood1                 1000
-  Hg-195/Plasma2          Blood1                 1000
-  Hg-195/RBC              Blood1                 1000
   Hg-195/C-bone-S         C-bone-S                  ---
   Hg-195/T-bone-S         T-bone-S                  ---
   Hg-195/Liver            Liver                     ---
   Hg-195/Kidneys          Kidneys                   ---
-  Hg-195/Brain1           Blood1                    0.0693
-  Hg-195/Brain2           Blood1                    0.0693
-  Hg-195/Other1           Blood1                    0.0693
-  Hg-195/Other2           Blood1                    0.0693

--- a/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeF.inp
+++ b/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeF.inp
@@ -1077,14 +1077,7 @@ Tl-195 Inhalation:Type-F
   Hg-195m/Other1          Blood1                    0.0693
   Hg-195m/Other2          Blood1                    0.0693
 
-  Hg-195/Plasma1          Blood1                 1000
-  Hg-195/Plasma2          Blood1                 1000
-  Hg-195/RBC              Blood1                 1000
   Hg-195/C-bone-S         C-bone-S                  ---
   Hg-195/T-bone-S         T-bone-S                  ---
   Hg-195/Liver            Liver                     ---
   Hg-195/Kidneys          Kidneys                   ---
-  Hg-195/Brain1           Blood1                    0.0693
-  Hg-195/Brain2           Blood1                    0.0693
-  Hg-195/Other1           Blood1                    0.0693
-  Hg-195/Other2           Blood1                    0.0693

--- a/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeM.inp
+++ b/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeM.inp
@@ -1077,14 +1077,7 @@ Tl-195 Inhalation:Type-M
   Hg-195m/Other1          Blood1                    0.0693
   Hg-195m/Other2          Blood1                    0.0693
 
-  Hg-195/Plasma1          Blood1                 1000
-  Hg-195/Plasma2          Blood1                 1000
-  Hg-195/RBC              Blood1                 1000
   Hg-195/C-bone-S         C-bone-S                  ---
   Hg-195/T-bone-S         T-bone-S                  ---
   Hg-195/Liver            Liver                     ---
   Hg-195/Kidneys          Kidneys                   ---
-  Hg-195/Brain1           Blood1                    0.0693
-  Hg-195/Brain2           Blood1                    0.0693
-  Hg-195/Other1           Blood1                    0.0693
-  Hg-195/Other2           Blood1                    0.0693

--- a/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeS.inp
+++ b/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inh-TypeS.inp
@@ -1077,14 +1077,7 @@ Tl-195 Inhalation:Type-S
   Hg-195m/Other1          Blood1                    0.0693
   Hg-195m/Other2          Blood1                    0.0693
 
-  Hg-195/Plasma1          Blood1                 1000
-  Hg-195/Plasma2          Blood1                 1000
-  Hg-195/RBC              Blood1                 1000
   Hg-195/C-bone-S         C-bone-S                  ---
   Hg-195/T-bone-S         T-bone-S                  ---
   Hg-195/Liver            Liver                     ---
   Hg-195/Kidneys          Kidneys                   ---
-  Hg-195/Brain1           Blood1                    0.0693
-  Hg-195/Brain2           Blood1                    0.0693
-  Hg-195/Other1           Blood1                    0.0693
-  Hg-195/Other2           Blood1                    0.0693

--- a/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inj.inp
+++ b/resources/inp/OIR/81-Tl/Tl-195/Tl-195_inj.inp
@@ -459,14 +459,7 @@ Tl-195 Injection
   Hg-195m/Other1          Blood1                    0.0693
   Hg-195m/Other2          Blood1                    0.0693
 
-  Hg-195/Plasma1          Blood1                 1000
-  Hg-195/Plasma2          Blood1                 1000
-  Hg-195/RBC              Blood1                 1000
   Hg-195/C-bone-S         C-bone-S                  ---
   Hg-195/T-bone-S         T-bone-S                  ---
   Hg-195/Liver            Liver                     ---
   Hg-195/Kidneys          Kidneys                   ---
-  Hg-195/Brain1           Blood1                    0.0693
-  Hg-195/Brain2           Blood1                    0.0693
-  Hg-195/Other1           Blood1                    0.0693
-  Hg-195/Other2           Blood1                    0.0693


### PR DESCRIPTION
Close #230

問題の改修と共に強化されたインプットに対する経路設定のエラーチェック処理によって、作成済みのOIRインプットのいくつかで係数付き壊変経路の設定に対してエラーが報告されようになった。これらのエラーとなる経路設定を削除した核種では、孫核種以降で残留放射能が少し減る変化が生じているが、総じて対OIRについては影響ないことを確認している。
