### PR TITLE
Srインプットの間違いを修正

### DIFF
--- a/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeF.inp
@@ -275,6 +275,54 @@ Sr-80 Inhalation, Aerosols Type F
   Sr-80/UB-con            UB-con                    ---
   Sr-80/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeM.inp
@@ -275,6 +275,54 @@ Sr-80 Inhalation, Aerosols Type M
   Sr-80/UB-con            UB-con                    ---
   Sr-80/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-80/Sr-80_inh_Aerosols-TypeS.inp
@@ -275,6 +275,54 @@ Sr-80 Inhalation, Aerosols Type S
   Sr-80/UB-con            UB-con                    ---
   Sr-80/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_ing_Other.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_ing_Other.inp
@@ -399,12 +399,12 @@ Sr-81 Ingestion, Other
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -450,11 +450,11 @@ Sr-81 Ingestion, Other
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_ing_Titanate.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_ing_Titanate.inp
@@ -399,12 +399,12 @@ Sr-81 Ingestion, Strontium titanate
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -450,11 +450,11 @@ Sr-81 Ingestion, Strontium titanate
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeF.inp
@@ -275,6 +275,54 @@ Sr-81 Inhalation, Aerosols Type F
   Sr-81/UB-con            UB-con                    ---
   Sr-81/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720
@@ -464,6 +512,54 @@ Sr-81 Inhalation, Aerosols Type F
   Rb-81m/Muscle           Muscle                    ---
   Rb-81m/OtherTissue      OtherTissue               ---
   Rb-81m/Excreta(sweat)   Excreta(sweat)            ---
+
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeF.inp
@@ -708,12 +708,12 @@ Sr-81 Inhalation, Aerosols Type F
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -782,11 +782,11 @@ Sr-81 Inhalation, Aerosols Type F
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeM.inp
@@ -275,6 +275,54 @@ Sr-81 Inhalation, Aerosols Type M
   Sr-81/UB-con            UB-con                    ---
   Sr-81/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720
@@ -464,6 +512,54 @@ Sr-81 Inhalation, Aerosols Type M
   Rb-81m/Muscle           Muscle                    ---
   Rb-81m/OtherTissue      OtherTissue               ---
   Rb-81m/Excreta(sweat)   Excreta(sweat)            ---
+
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeM.inp
@@ -708,12 +708,12 @@ Sr-81 Inhalation, Aerosols Type M
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -782,11 +782,11 @@ Sr-81 Inhalation, Aerosols Type M
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeS.inp
@@ -275,6 +275,54 @@ Sr-81 Inhalation, Aerosols Type S
   Sr-81/UB-con            UB-con                    ---
   Sr-81/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720
@@ -464,6 +512,54 @@ Sr-81 Inhalation, Aerosols Type S
   Rb-81m/Muscle           Muscle                    ---
   Rb-81m/OtherTissue      OtherTissue               ---
   Rb-81m/Excreta(sweat)   Excreta(sweat)            ---
+
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
 
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inh_Aerosols-TypeS.inp
@@ -708,12 +708,12 @@ Sr-81 Inhalation, Aerosols Type S
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -782,11 +782,11 @@ Sr-81 Inhalation, Aerosols Type S
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inj.inp
+++ b/resources/inp/OIR/38-Sr/Sr-81/Sr-81_inj.inp
@@ -399,12 +399,12 @@ Sr-81 Injection
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分
 
@@ -450,11 +450,11 @@ Sr-81 Injection
   Sr-81/Exch-T-bone-V     Blood                     1.5
   Sr-81/C-bone-S          Blood                   100
   Sr-81/T-bone-S          Blood                   100
-  Sr-81/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-81/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/RBC              Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-81/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-81/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/RBC              Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/Muscle           Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-81m/OtherTissue      Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeF.inp
@@ -275,6 +275,54 @@ Sr-82 Inhalation, Aerosols Type F
   Sr-82/UB-con            UB-con                    ---
   Sr-82/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeM.inp
@@ -275,6 +275,54 @@ Sr-82 Inhalation, Aerosols Type M
   Sr-82/UB-con            UB-con                    ---
   Sr-82/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-82/Sr-82_inh_Aerosols-TypeS.inp
@@ -275,6 +275,54 @@ Sr-82 Inhalation, Aerosols Type S
   Sr-82/UB-con            UB-con                    ---
   Sr-82/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_ing_Other.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_ing_Other.inp
@@ -299,11 +299,11 @@ Sr-83 Ingestion, Other
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_ing_Titanate.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_ing_Titanate.inp
@@ -299,11 +299,11 @@ Sr-83 Ingestion, Strontium titanate
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeF.inp
@@ -512,11 +512,11 @@ Sr-83 Inhalation, Aerosols Type F
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeF.inp
@@ -275,6 +275,54 @@ Sr-83 Inhalation, Aerosols Type F
   Sr-83/UB-con            UB-con                    ---
   Sr-83/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeM.inp
@@ -512,11 +512,11 @@ Sr-83 Inhalation, Aerosols Type M
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeM.inp
@@ -275,6 +275,54 @@ Sr-83 Inhalation, Aerosols Type M
   Sr-83/UB-con            UB-con                    ---
   Sr-83/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeS.inp
@@ -512,11 +512,11 @@ Sr-83 Inhalation, Aerosols Type S
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inh_Aerosols-TypeS.inp
@@ -275,6 +275,54 @@ Sr-83 Inhalation, Aerosols Type S
   Sr-83/UB-con            UB-con                    ---
   Sr-83/Urine             Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inj.inp
+++ b/resources/inp/OIR/38-Sr/Sr-83/Sr-83_inj.inp
@@ -299,11 +299,11 @@ Sr-83 Injection
   Sr-83/Exch-T-bone-V     Blood                     1.5
   Sr-83/C-bone-S          Blood                   100
   Sr-83/T-bone-S          Blood                   100
-  Sr-83/ST0               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST1               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Sr-83/ST2               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/RBC               Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/Muscle            Blood                 $(0.693 / (15/60/25))   # 半減期15分
-  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/25))   # 半減期15分
+  Sr-83/ST0               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST1               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Sr-83/ST2               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/RBC               Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/Muscle            Blood                 $(0.693 / (15/60/24))   # 半減期15分
+  Rb-83/OtherTissue       Blood                 $(0.693 / (15/60/24))   # 半減期15分
 
   Blood                   Exhaled                1000   # ≒半減期1分

--- a/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeF.inp
@@ -275,6 +275,54 @@ Sr-87m Inhalation, Aerosols Type F
   Sr-87m/UB-con           UB-con                    ---
   Sr-87m/Urine            Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeM.inp
@@ -275,6 +275,54 @@ Sr-87m Inhalation, Aerosols Type M
   Sr-87m/UB-con           UB-con                    ---
   Sr-87m/Urine            Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720

--- a/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/38-Sr/Sr-87m/Sr-87m_inh_Aerosols-TypeS.inp
@@ -275,6 +275,54 @@ Sr-87m Inhalation, Aerosols Type S
   Sr-87m/UB-con           UB-con                    ---
   Sr-87m/Urine            Urine                     ---
 
+# ICRP Publ.130 p.65 Fig.3.4
+# ICRP Publ.130 p.77 Para.143 & p.75 Fig.3.6
+  ALV-F                   bb-F                      0.002
+  ALV-F                   INT-F                     0.001
+  INT-F                   LNTH-F                    0.00003
+  bb-F                    BB-F                      0.2
+  bbseq-F                 LNTH-F                    0.001
+  BB-F                    ET2-F                    10
+  BBseq-F                 LNTH-F                    0.001
+  ET2-F                   Oesophagus-s            100
+  ETseq-F                 LNET-F                    0.001
+  ET1-F                   Environment               0.6
+  ET1-F                   ET2-F                     1.5
+
+  ALV-S                   bb-S                      0.002
+  ALV-S                   INT-S                     0.001
+  INT-S                   LNTH-S                    0.00003
+  bb-S                    BB-S                      0.2
+  bbseq-S                 LNTH-S                    0.001
+  BB-S                    ET2-S                    10
+  BBseq-S                 LNTH-S                    0.001
+  ET2-S                   Oesophagus-s            100
+  ETseq-S                 LNET-S                    0.001
+  ET1-S                   Environment               0.6
+  ET1-S                   ET2-S                     1.5
+
+  ALV-F                   Plasma                $sr
+  INT-F                   Plasma                $sr
+  bb-F                    Plasma                $sr
+  bbseq-F                 Plasma                $sr
+  BB-F                    Plasma                $sr
+  BBseq-F                 Plasma                $sr
+  ET2-F                   Plasma                $sr
+  ETseq-F                 Plasma                $sr
+  LNET-F                  Plasma                $sr
+  LNTH-F                  Plasma                $sr
+
+  ALV-S                   Plasma                $ss
+  INT-S                   Plasma                $ss
+  bb-S                    Plasma                $ss
+  bbseq-S                 Plasma                $ss
+  BB-S                    Plasma                $ss
+  BBseq-S                 Plasma                $ss
+  ET2-S                   Plasma                $ss
+  ETseq-S                 Plasma                $ss
+  LNET-S                  Plasma                $ss
+  LNTH-S                  Plasma                $ss
+
 # ICRP Publ.130 p.76 Table 3.4 & footnote
   Oralcavity              Oesophagus-f           6480
   Oralcavity              Oesophagus-s            720


### PR DESCRIPTION
以下の2つのインプット設定間違いを修正した。
- 子孫核種のRbモデルにおけるHRTMの移行経路設定が欠落していた問題を修正
- 子孫核種のKrモデルにおける半減期15分の移行速度について計算式が間違っていた問題を修正
