### PR TITLE
Windows App SDK 2.0へ更新

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="EPPlus" Version="8.5.3" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260416003" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <PackageVersion Include="MSTest" Version="4.0.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="ObservableCollections.R3" Version="3.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,12 +9,12 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.251219" />
-    <PackageVersion Include="EPPlus" Version="8.5.3" />
+    <PackageVersion Include="EPPlus" Version="8.5.4" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
-    <PackageVersion Include="MSTest" Version="4.0.2" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="ObservableCollections.R3" Version="3.3.4" />
     <PackageVersion Include="R3" Version="1.3.0" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="ScottPlot.WinUI" Version="5.1.58" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Sprache" Version="2.3.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
     <PackageVersion Include="WinUIEx" Version="2.9.0" />
   </ItemGroup>
 </Project>

--- a/FlexUI/ViewModels/InputEirViewModel.cs
+++ b/FlexUI/ViewModels/InputEirViewModel.cs
@@ -105,7 +105,6 @@ public partial class InputEirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
             };
 
             var results = await picker.PickMultipleFilesAsync();
@@ -173,7 +172,7 @@ public partial class InputEirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = Path.GetDirectoryName(ComputeTimeMeshFilePath),
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -196,7 +195,7 @@ public partial class InputEirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = Path.GetDirectoryName(OutputTimeMeshFilePath),
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -219,8 +218,7 @@ public partial class InputEirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedStartLocation = Microsoft.Windows.Storage.Pickers.PickerLocationId.Unspecified,
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = OutputDirectory,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/InputOirViewModel.cs
+++ b/FlexUI/ViewModels/InputOirViewModel.cs
@@ -106,7 +106,6 @@ public partial class InputOirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
             };
 
             var results = await picker.PickMultipleFilesAsync();
@@ -164,7 +163,7 @@ public partial class InputOirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = Path.GetDirectoryName(ComputeTimeMeshFilePath),
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -187,7 +186,7 @@ public partial class InputOirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = Path.GetDirectoryName(OutputTimeMeshFilePath),
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -210,8 +209,7 @@ public partial class InputOirViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedStartLocation = Microsoft.Windows.Storage.Pickers.PickerLocationId.Unspecified,
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = OutputDirectory,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/InputScoeffViewModel.cs
+++ b/FlexUI/ViewModels/InputScoeffViewModel.cs
@@ -72,8 +72,7 @@ public partial class InputScoeffViewModel : ViewModelBase
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedStartLocation = Microsoft.Windows.Storage.Pickers.PickerLocationId.Unspecified,
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = OutputDirectory,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/ViewerViewModel.cs
+++ b/FlexUI/ViewModels/ViewerViewModel.cs
@@ -41,7 +41,7 @@ public partial class ViewerViewModel : ObservableObject
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                //SuggestedFolder = Environment.CurrentDirectory, // Windows App SDK 2.0
+                SuggestedFolder = Path.GetDirectoryName(OutputFilePath),
             };
 
             var result = await picker.PickSingleFileAsync();

--- a/FlexUI/ViewModels/ViewerViewModel.cs
+++ b/FlexUI/ViewModels/ViewerViewModel.cs
@@ -57,11 +57,8 @@ public partial class ViewerViewModel : ObservableObject
 
     private static string? CheckLogToOutRelation(string? path)
     {
-        if (path is null)
-            return null;
-
-        if (Path.GetExtension(path).Equals(".log", StringComparison.OrdinalIgnoreCase) != true)
-            return null;
+        if (Path.GetExtension(path)?.Equals(".log", StringComparison.OrdinalIgnoreCase) != true)
+            return path;
 
         var basePath = Path.GetFileNameWithoutExtension(path);
         if (Path.GetDirectoryName(path) is string dir)


### PR DESCRIPTION
WPFからWinUI 3への移行時に、Pickerの初期フォルダを指定できなくなってきた問題が`SuggestedFolder`プロパティの追加で解決したため、この対応を追加する。