### PR TITLE
OIR計算実行画面への機能追加を実施

### DIFF
--- a/FlexUI/ViewModels/ElementsViewModel.cs
+++ b/FlexUI/ViewModels/ElementsViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using R3;
 
 namespace FlexID.ViewModels;
 
@@ -9,6 +10,14 @@ public partial class ElementsViewModel : ViewModelBase
     {
         Elements = Enumerable.Range(1, ElementTable.Names.Count)
             .Select(n => new ElementViewModel(n, ElementTable.Names[n - 1])).ToArray();
+
+        IEnumerable<ElementViewModel> ListVMs(string[] elements) =>
+            Elements.Where(el => elements.Contains(el.Element));
+
+        OirPart2 = new ElementGroup(ListVMs(Elements_OirPart2)).AddTo(disposables);
+        OirPart3 = new ElementGroup(ListVMs(Elements_OirPart3)).AddTo(disposables);
+        OirPart4 = new ElementGroup(ListVMs(Elements_OirPart4)).AddTo(disposables);
+        OirPart5 = new ElementGroup(ListVMs(Elements_OirPart5)).AddTo(disposables);
     }
 
     public ElementViewModel[] Elements { get; }
@@ -23,6 +32,9 @@ public partial class ElementsViewModel : ViewModelBase
         throw new ArgumentOutOfRangeException(nameof(number));
     }
 
+    /// <summary>
+    /// 全ての元素のチェックを外す。
+    /// </summary>
     [RelayCommand]
     private void ClearAll()
     {
@@ -30,19 +42,104 @@ public partial class ElementsViewModel : ViewModelBase
             element.IsChecked = false;
     }
 
+    [ObservableProperty]
+    public partial bool IsEnableOirSelector { get; set; }
+
+    public ElementGroup OirPart2 { get; }
+    public ElementGroup OirPart3 { get; }
+    public ElementGroup OirPart4 { get; }
+    public ElementGroup OirPart5 { get; }
+
+    private static readonly string[] Elements_OirPart2 =
+    [
+        "H", "C", "P", "S", "Ca", "Fe", "Co", "Zn", "Sr", "Y", "Zr", "Nb", "Mo", "Tc",
+    ];
+
+    private static readonly string[] Elements_OirPart3 =
+    [
+        "Ru", "Sb", "Te", "I", "Cs", "Ba", "Ir", "Pb", "Bi", "Po", "Rn", "Ra", "Th", "U",
+    ];
+
+    private static readonly string[] Elements_OirPart4 =
+    [
+        "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+        "Ac", /* */ "Pa", /* */ "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm",
+    ];
+
+    private static readonly string[] Elements_OirPart5 =
+    [
+        "Be", "F", "Na", "Mg", "Al", "Si", "Cl", "K", "Sc", "Ti", "V", "Cr", "Mn", "Ni",
+        "Cu", "Ga", "Ge", "As", "Se", "Br", "Rb", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
+        "Hf", "Ta", "W", "Re", "Os", "Pt", "Au", "Hg", "Tl", "At", "Fr",
+    ];
 }
 
+/// <summary>
+/// 1つの元素を表現する。
+/// </summary>
 public partial class ElementViewModel(int number, string element) : ViewModelBase
 {
-    [ObservableProperty]
-    public partial bool IsChecked { get; set; }
-
+    /// <summary>
+    /// 原子番号。
+    /// </summary>
     public int Number { get; } = number;
 
+    /// <summary>
+    /// 元素記号。
+    /// </summary>
     public string Element { get; } = element;
 
-    //partial void OnIsCheckedChanged(bool value)
-    //{
-    //    System.Diagnostics.Debug.WriteLine($"{Number}-{Element} IsChecked = {value}");
-    //}
+    /// <summary>
+    /// 元素がチェックされている場合は<see langword="true"/>。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsChecked { get; set; }
+}
+
+/// <summary>
+/// 複数の元素をグループ化し、それらのチェック状態をまとめて取り扱う。
+/// </summary>
+public partial class ElementGroup : ViewModelBase
+{
+    /// <summary>
+    /// コンストラクタ。
+    /// </summary>
+    /// <param name="elementVMs"></param>
+    public ElementGroup(IEnumerable<ElementViewModel> elementVMs)
+    {
+        ElementVMs = [.. elementVMs];
+
+        ElementVMs.Select(el =>
+            // IsCheckedの変更に対して、ElementViewModelそれ自体を通知する
+            el.ObservePropertyChanged(vm => vm.IsChecked).Skip(1).Select(_ => el)
+        ).Merge().Subscribe(el =>
+        {
+            CheckedCout += el.IsChecked ? +1 : -1;
+            IsChecked = CheckedCout != 0;
+        }).AddTo(disposables);
+    }
+
+    private IEnumerable<ElementViewModel> ElementVMs { get; }
+
+    /// <summary>
+    /// チェックされている元素の数。
+    /// </summary>
+    public int CheckedCout { get; private set; }
+
+    /// <summary>
+    /// 1個以上の元素がチェックされている場合は<see langword="true"/>。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsChecked { get; private set; }
+
+    /// <summary>
+    /// 全ての元素のチェック状態を切り替える。
+    /// </summary>
+    [RelayCommand]
+    private void Switch()
+    {
+        var newValue = !IsChecked;
+        foreach (var elementVM in ElementVMs)
+            elementVM.IsChecked = newValue;
+    }
 }

--- a/FlexUI/ViewModels/InputEirViewModel.cs
+++ b/FlexUI/ViewModels/InputEirViewModel.cs
@@ -169,10 +169,14 @@ public partial class InputEirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = Path.GetDirectoryName(ComputeTimeMeshFilePath) ?? "";
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.BaseDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                SuggestedFolder = Path.GetDirectoryName(ComputeTimeMeshFilePath),
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -192,10 +196,14 @@ public partial class InputEirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = Path.GetDirectoryName(OutputTimeMeshFilePath) ?? "";
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.BaseDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                SuggestedFolder = Path.GetDirectoryName(OutputTimeMeshFilePath),
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -215,10 +223,14 @@ public partial class InputEirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = OutputDirectory;
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.ProcessDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedFolder = OutputDirectory,
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/InputOirViewModel.cs
+++ b/FlexUI/ViewModels/InputOirViewModel.cs
@@ -160,10 +160,14 @@ public partial class InputOirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = Path.GetDirectoryName(ComputeTimeMeshFilePath) ?? "";
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.BaseDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                SuggestedFolder = Path.GetDirectoryName(ComputeTimeMeshFilePath),
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -183,10 +187,14 @@ public partial class InputOirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = Path.GetDirectoryName(OutputTimeMeshFilePath) ?? "";
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.BaseDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                SuggestedFolder = Path.GetDirectoryName(OutputTimeMeshFilePath),
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFileAsync();
@@ -206,10 +214,14 @@ public partial class InputOirViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = OutputDirectory;
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.ProcessDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedFolder = OutputDirectory,
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/InputOirViewModel.cs
+++ b/FlexUI/ViewModels/InputOirViewModel.cs
@@ -151,6 +151,25 @@ public partial class InputOirViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool IsCompareWithOir { get; set; } = true;
 
+    public bool CanCompareWithOir => OutputDose && OutputRetention;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCompareWithOir))]
+    public partial bool OutputDose { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool OutputDoseRate { get; set; } = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCompareWithOir))]
+    public partial bool OutputRetention { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool OutputCumulative { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool OutputAtoms { get; set; } = false;
+
     [ObservableProperty]
     public partial string ComputeTimeMeshFilePath { get; set; }
 
@@ -293,6 +312,11 @@ public partial class InputOirViewModel : ViewModelBase
             await runner.StartAsync((target, cancellationToken) =>
             {
                 var data = new InputDataReader_OIR(target.InputFilePath, calcProgeny: true).Read();
+                data.OutputDose = OutputDose;
+                data.OutputDoseRate = OutputDoseRate;
+                data.OutputRetention = OutputRetention;
+                data.OutputCumulative = OutputCumulative;
+                data.OutputAtoms = OutputAtoms;
 
                 var main = new MainRoutine_OIR(data)
                 {
@@ -309,8 +333,9 @@ public partial class InputOirViewModel : ViewModelBase
                 var output = Path.Combine(outputDir, target.Name);
                 target.OutputFilePath = output + "_Retention.out";
 
+                var isCompareWithOir = IsCompareWithOir && CanCompareWithOir;
                 (string Name, string Path)? compare = null;
-                if (IsCompareWithOir && expects.TryGetValue(target.Name, out var expectPath))
+                if (isCompareWithOir && expects.TryGetValue(target.Name, out var expectPath))
                     compare = (Name: target.Name, Path: expectPath);
 
                 var report = new ReportData(new FileInfo(outputDir), output, compare);

--- a/FlexUI/ViewModels/InputScoeffViewModel.cs
+++ b/FlexUI/ViewModels/InputScoeffViewModel.cs
@@ -69,10 +69,14 @@ public partial class InputScoeffViewModel : ViewModelBase
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = OutputDirectory;
+            if (!Path.IsPathFullyQualified(initialDir))
+                initialDir = Path.Combine(AppResource.ProcessDir, initialDir);
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FolderPicker(appId)
             {
-                SuggestedFolder = OutputDirectory,
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFolderAsync();

--- a/FlexUI/ViewModels/ViewerViewModel.cs
+++ b/FlexUI/ViewModels/ViewerViewModel.cs
@@ -38,10 +38,12 @@ public partial class ViewerViewModel : ObservableObject
         var selected = paths?[0];
         if (selected is null)
         {
+            var initialDir = Path.GetDirectoryName(Path.GetFullPath(OutputFilePath)) ?? "";
+
             var appId = App.Current.AppWindow!.Id;
             var picker = new Microsoft.Windows.Storage.Pickers.FileOpenPicker(appId)
             {
-                SuggestedFolder = Path.GetDirectoryName(OutputFilePath),
+                SuggestedFolder = initialDir,
             };
 
             var result = await picker.PickSingleFileAsync();

--- a/FlexUI/Views/ElementsPage.xaml
+++ b/FlexUI/Views/ElementsPage.xaml
@@ -4,11 +4,16 @@
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+  xmlns:converters="using:CommunityToolkit.WinUI.Converters"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:v="using:FlexID.Views"
   xmlns:vm="using:FlexID.ViewModels"
   mc:Ignorable="d">
+
+  <Page.Resources>
+    <converters:BoolToVisibilityConverter x:Key="BoolToVisibility" />
+  </Page.Resources>
 
   <controls:UniformGrid
     RowSpacing="1"
@@ -97,17 +102,68 @@
       Grid.Column="2"
       Grid.ColumnSpan="16" />
     <Border
-      Grid.Row="2"
-      Grid.RowSpan="2"
+      Grid.Row="1"
+      Grid.RowSpan="3"
       Grid.Column="3"
       Grid.ColumnSpan="10">
-      <Button
-        Padding="12,8"
+      <Grid
+        RowSpacing="4"
+        ColumnSpacing="4"
         HorizontalAlignment="Center"
-        VerticalAlignment="Top"
-        Command="{x:Bind ViewModel.ClearAllCommand}"
-        Content="Clear All"
-        TabIndex="0" />
+        VerticalAlignment="Center">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Button
+          Grid.Row="0"
+          Grid.Column="0"
+          Padding="12,8"
+          Command="{x:Bind ViewModel.ClearAllCommand}"
+          Content="Clear All"
+          TabIndex="-5" />
+        <ToggleButton
+          Grid.Row="0"
+          Grid.Column="1"
+          Padding="12,8"
+          Command="{x:Bind ViewModel.OirPart2.SwitchCommand}"
+          Content="Publ.134, OIR: Part 2"
+          IsChecked="{x:Bind ViewModel.OirPart2.IsChecked, Mode=OneWay}"
+          TabIndex="-4"
+          Visibility="{x:Bind ViewModel.IsEnableOirSelector, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+        <ToggleButton
+          Grid.Row="0"
+          Grid.Column="2"
+          Padding="12,8"
+          Command="{x:Bind ViewModel.OirPart3.SwitchCommand}"
+          Content="Publ.137, OIR: Part 3"
+          IsChecked="{x:Bind ViewModel.OirPart3.IsChecked, Mode=OneWay}"
+          TabIndex="-3"
+          Visibility="{x:Bind ViewModel.IsEnableOirSelector, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+        <ToggleButton
+          Grid.Row="1"
+          Grid.Column="1"
+          Padding="12,8"
+          Command="{x:Bind ViewModel.OirPart4.SwitchCommand}"
+          Content="Publ.141, OIR: Part 4"
+          IsChecked="{x:Bind ViewModel.OirPart4.IsChecked, Mode=OneWay}"
+          TabIndex="-2"
+          Visibility="{x:Bind ViewModel.IsEnableOirSelector, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+        <ToggleButton
+          Grid.Row="1"
+          Grid.Column="2"
+          Padding="12,8"
+          Command="{x:Bind ViewModel.OirPart5.SwitchCommand}"
+          Content="Publ.151, OIR: Part 5"
+          IsChecked="{x:Bind ViewModel.OirPart5.IsChecked, Mode=OneWay}"
+          TabIndex="-1"
+          Visibility="{x:Bind ViewModel.IsEnableOirSelector, Mode=OneWay, Converter={StaticResource BoolToVisibility}}" />
+      </Grid>
     </Border>
     <Border
       Grid.Row="9"

--- a/FlexUI/Views/InputOirPage.xaml
+++ b/FlexUI/Views/InputOirPage.xaml
@@ -33,6 +33,7 @@
         Grid.Row="0"
         AddCommand="{x:Bind ViewModel.AddInputFilesCommand}"
         IsBuiltin="{x:Bind ViewModel.IsBuiltin, Mode=TwoWay}"
+        IsEnableOirSelector="True"
         RemoveCommand="{x:Bind ViewModel.RemoveInputFilesCommand}"
         Targets="{x:Bind ViewModel.Targets, Mode=OneWay}">
         <i:Interaction.Behaviors>

--- a/FlexUI/Views/InputOirPage.xaml
+++ b/FlexUI/Views/InputOirPage.xaml
@@ -72,7 +72,6 @@
         <StackPanel
           Grid.Row="0"
           Grid.Column="1"
-          Grid.ColumnSpan="2"
           Spacing="8"
           Orientation="Horizontal">
           <TextBox
@@ -93,8 +92,34 @@
           <CheckBox
             AccessKey="C"
             Content="Compare with OIR data"
-            IsChecked="{x:Bind ViewModel.IsCompareWithOir, Mode=TwoWay}" />
+            IsChecked="{x:Bind ViewModel.IsCompareWithOir, Mode=TwoWay}"
+            IsEnabled="{x:Bind ViewModel.CanCompareWithOir, Mode=OneWay}" />
         </StackPanel>
+
+        <Button
+          Grid.Row="0"
+          Grid.Column="2"
+          HorizontalAlignment="Stretch"
+          Content="&#xE713;"
+          FontFamily="Segoe Fluent Icons">
+          <Button.Flyout>
+            <Flyout Placement="TopEdgeAlignedRight">
+              <StackPanel Orientation="Vertical">
+                <CheckBox
+                  Content="Output Doses"
+                  IsChecked="{x:Bind ViewModel.OutputDose, Mode=TwoWay}"
+                  IsEnabled="False" />
+                <CheckBox Content="Output Dose Rates" IsChecked="{x:Bind ViewModel.OutputDoseRate, Mode=TwoWay}" />
+                <CheckBox
+                  Content="Output Retention Activities"
+                  IsChecked="{x:Bind ViewModel.OutputRetention, Mode=TwoWay}"
+                  IsEnabled="False" />
+                <CheckBox Content="Output Cumulative Activities" IsChecked="{x:Bind ViewModel.OutputCumulative, Mode=TwoWay}" />
+                <CheckBox Content="Output Atoms" IsChecked="{x:Bind ViewModel.OutputAtoms, Mode=TwoWay}" />
+              </StackPanel>
+            </Flyout>
+          </Button.Flyout>
+        </Button>
 
         <TextBlock
           Grid.Row="1"

--- a/FlexUI/Views/InputsPage.xaml.cs
+++ b/FlexUI/Views/InputsPage.xaml.cs
@@ -26,6 +26,22 @@ public sealed partial class InputsPage : Page
         set => SetValue(IsBuiltinProperty, value);
     }
 
+    public static readonly DependencyProperty IsEnableOirSelectorProperty =
+        DependencyProperty.Register(
+            nameof(IsEnableOirSelector), typeof(bool), typeof(InputsPage),
+            new PropertyMetadata(false, IsEnableOirSelectorPropertyChanged));
+
+    private static void IsEnableOirSelectorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        ((InputsPage)d).ElementsTable.IsEnableOirSelector = (bool)e.NewValue;
+    }
+
+    public bool IsEnableOirSelector
+    {
+        get => (bool)GetValue(IsEnableOirSelectorProperty);
+        set => SetValue(IsEnableOirSelectorProperty, value);
+    }
+
     public static readonly DependencyProperty TargetsProperty =
         DependencyProperty.Register(
             nameof(Targets), typeof(CheckableItemsView<InputTarget, InputTargetViewModel>), typeof(InputsPage),


### PR DESCRIPTION
- OIR計算実行画面に、計算結果ファイルの出力有無を選択する機能を追加
    
    <img width="1190" height="454" alt="image" src="https://github.com/user-attachments/assets/fafec53a-f3ad-4993-8514-d555813f9769" />

- OIRの各Partに対応する元素のチェック状態を切り替える機能を、OIR計算実行画面の周期表Flyoutに追加

    <img width="1339" height="1004" alt="image" src="https://github.com/user-attachments/assets/c63fc0d3-f81d-4604-a958-8d8764e8cca3" />

