### PR TITLE
壊変コンパートメントに対する線源領域の設定処理を修正

### DIFF
--- a/FlexID.Core/DecaySet.cs
+++ b/FlexID.Core/DecaySet.cs
@@ -531,18 +531,13 @@ internal class DecaySet
         var sourceRegion = organFrom.SourceRegion;
         if (sourceRegion != null)
         {
-            var daughter = organDecay.Nuclide;
-
-            // 親核種のコンパートメントに設定された線源領域が、
-            // 子孫核種の動態モデルおいても明示的に設定されているかどうかを調べる。
-            var explicitUsed = compartments.Where(o => o.Nuclide == daughter)
-                                           .Any(o => o.SourceRegion == sourceRegion);
-
-            // 明示的に設定されていない場合は、ambiguous compartmentを'Other'に割り当てる。
-            if (!explicitUsed)
-                sourceRegion = "Other";
-
+            // 親核種のコンパートメントに設定されていた線源領域を、
+            // 生成核種を受ける壊変コンパートメントの線源領域としても設定する。
             organDecay.SourceRegion = sourceRegion;
+
+            // 生成核種のモデルにおける線源領域Otherの内訳から、
+            // 壊変コンパートメントの線源領域を(存在する場合は)取り除く。
+            organDecay.Nuclide.OtherSourceRegions.Remove(sourceRegion);
         }
     }
 }

--- a/FlexID.Core/InputData.cs
+++ b/FlexID.Core/InputData.cs
@@ -180,7 +180,7 @@ public class NuclideData
     /// 動態モデルでコンパートメントとして定義されておらず線源領域Otherの一部として取り扱う
     /// 各線源領域の名称。
     /// </summary>
-    public string[] OtherSourceRegions;
+    public List<string> OtherSourceRegions;
 
     /// <summary>
     /// 消化管に対応するコンパートメント群のインデックスと寄与率。

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -840,7 +840,7 @@ public class InputDataReader_OIR : InputDataReaderBase
                     errors.AddError(sectionLineNum, "Both of C/T-marrow and R/Y-marrow source region pairs are used.");
             }
 
-            nuclide.OtherSourceRegions = otherSourceRegions.ToArray();
+            nuclide.OtherSourceRegions = otherSourceRegions;
         }
 
         // コンパートメント定義にエラーがないことを確定する。


### PR DESCRIPTION
移行速度付き壊変経路のために自動生成される壊変コンパートメントは、保持している娘核種の線量計算のため、その壊変元となった親核種のコンパートメントの線源領域を引き継ぐ。ただし従来の処理では、この線源領域が娘核種のモデルにおいて明示されていない場合に、代わりに線源領域Otherを壊変コンパートメントに設定する、ということを行っていた。

しかしこの従来処理を物理的な挙動として考えると、生成された娘核種が壊変コンパートメントに入った瞬間に、（全身に分布する）「その他の軟組織」に瞬時かつ均等に拡散することと同義となってしまい、これは明らかに間違った処理を行っていた。

この問題の修正のため、壊変コンパートメントは、娘核種が生成された親核種コンパートメントの線源領域を必ず引き継ぐよう変更し、また娘核種のモデルにおける線源領域Otherから壊変コンパートメントの線源領域を除外するように変更した。

この変更によって、PbやThの線量計算の結果がOIRと極端に合わなかった問題が概ね解消されるようになる。