### PR TITLE
一部が重なり合う速度付き壊変経路の定義がエラーになる制約を解消する

### DIFF
--- a/FlexID.Core.Tests/DecaySetTests.cs
+++ b/FlexID.Core.Tests/DecaySetTests.cs
@@ -5,26 +5,26 @@ using static InputErrorTestHelpers;
 [TestClass]
 public class DecaySetTests
 {
-    // N1 --> N2 --> N3 --> N4 --> (stable)
-    [TestClass]
+    /// <summary>
+    /// N1 --> N2 --> N3 --> N4 --> (stable)
+    /// </summary>
     public class StraightDecayChain
     {
-        const int LineNum = 1;
-        const int Line1 = LineNum + 0;
-        const int Line2 = LineNum + 1;
-        const int Line3 = LineNum + 2;
-        const int Line4 = LineNum + 3;
-        const int Line5 = LineNum + 4;
-        const int Line6 = LineNum + 5;
-        const int Line7 = LineNum + 6;
+        protected const int L1 = 1;
+        protected const int L2 = 2;
+        protected const int L3 = 3;
+        protected const int L4 = 4;
+        protected const int L5 = 5;
+        protected const int L6 = 6;
+        protected const int L7 = 7;
 
-        readonly NuclideData N1; readonly Organ C11, C12, C13, C14;
-        readonly NuclideData N2; readonly Organ C21, C22;
-        readonly NuclideData N3; readonly Organ C31, C32;
-        readonly NuclideData N4; readonly Organ C41;
+        protected readonly NuclideData N1; protected readonly Organ C11, C12, C13, C14;
+        protected readonly NuclideData N2; protected readonly Organ C21, C22;
+        protected readonly NuclideData N3; protected readonly Organ C31, C32;
+        protected readonly NuclideData N4; protected readonly Organ C41;
 
-        readonly DecaySet decaySet;
-        readonly InputErrors errors = new();
+        protected readonly DecaySet decaySet;
+        protected readonly InputErrors errors = new();
 
         public StraightDecayChain()
         {
@@ -58,901 +58,1942 @@ public class DecaySetTests
 
             decaySet = new DecaySet([N1, N2, N3, N4], errors);
         }
+    }
 
-        // [Line1] N1/C11 --> N2/C21
-        // =========================
-        //         N1/C11 --> N2/C21
+    /// <summary>
+    /// 単一、または並列な壊変経路の定義動作。
+    /// </summary>
+    [TestClass]
+    public class BasicTests1 : StraightDecayChain
+    {
+        //      N1      N2
+        // [L1] C11 --> C21
+        // ================
+        //      C11 --> C21
         [TestMethod]
-        [DataRow(null)]
-        [DataRow(1.23)]
-        public void SinglePath(double? coeff)
+        public void 単一の壊変経路_N1からN2_係数なし()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            if (coeff is null)
+            decaySet.AddDecayPath(L1, C11, C21, null);
             {
-                chain1[N1].ShouldBe((Line1, C11));
-                chain1[N2].ShouldBe((Line1, C21));
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
 
                 decaySet.JointChains[C11].ShouldBe([chain1]);
                 decaySet.JointChains[C21].ShouldBe([chain1]);
             }
-            else
-            {
-                var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == ((decimal)coeff, C21)).Key;
+        }
 
-                chain1[N1].ShouldBe((Line1, C11));
-                chain1[N2].ShouldBe((Line1, d21));
+        //      N1              N2
+        // [L1] C11 -(coeff.)-> C21
+        // ===========================
+        //      C11 -(coeff.)-> d21
+        //                      ↓
+        //                    (coeff.)
+        //                      ↓
+        //                      C21
+        [TestMethod]
+        public void 単一の壊変経路_N1からN2_係数あり()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, 1.23m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (1.23m, C21)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, d21));
 
                 decaySet.JointChains[C11].ShouldBe([chain1]);
                 decaySet.JointChains[d21].ShouldBe([chain1]);
+                decaySet.JointChains.ContainsKey(C21).ShouldBeFalse();
             }
         }
 
-        // [Line1] N1/C11 --> N2/C21
-        // [Line2] N1/C12 --> N2/C22
-        // =========================
-        //         N1/C11 --> N2/C21
-        //         N1/C12 --> N2/C22
+        //      N1    N2    N3
+        // [L1] C11 ------> C31
+        // ====================
+        //      C11 ------> C31
         [TestMethod]
-        public void ParallelPaths()
+        public void 単一の壊変経路_N1からN3_係数なし()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C22, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C22));
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, C31));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C22].ShouldBe([chain2]);
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
         }
 
-        // [Line1] N1/C11 ----------> N2/C21
-        // [Line2] N1/C12 -(coeff.)-> N2/C21
-        // ===============================
-        //         N1/C11 ----------> N2/C21
-        //                              ↑
-        //                            (coeff.)
-        //                              ↑
-        //         N1/C12 ----------> N2/d21
+        //      N1    N2             N3
+        // [L1] C11 ------(coeff.)-> C31
+        // ================================
+        //      C11 ------(coeff.)-> d31
+        //                           ↓
+        //                         (coeff.)
+        //                           ↓
+        //                           C31
         [TestMethod]
-        public void ParallelPaths2()
+        public void 単一の壊変経路_N1からN3_係数あり()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, 1.23m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (1.23m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+                decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+            }
+        }
+
+        //      N1      N2
+        // [L1] C11 --> C21
+        // [L2] C12 --> C22
+        // ================
+        //      C11 --> C21
+        //      C12 --> C22
+        [TestMethod]
+        public void 並列の壊変経路_N1からN2_係数なし()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C22, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C22));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C22].ShouldBe([chain2]);
+            }
+        }
+
+        //      N1              N2
+        // [L1] C11 ----------> C21
+        // [L2] C12 -(coeff.)-> C21
+        // ===========================
+        //      C11 ----------> C21
+        //                      ↑
+        //                    (coeff.)
+        //                      ↑
+        //      C12 ----------> d21
+        [TestMethod]
+        public void 並列の壊変経路_N1からN2_係数あり()
         {
             // 2つの経路設定は、終端側がC21で合流しているように見えるが
             // 2つ目の経路は移行速度付きのため実際はN2位置で壊変コンパートメントが自動作成され、
             // 従ってこれらは独立した2つの壊変経路を作成する。
-            decaySet.AddDecayPath(Line1, C11, C21, null);   // 壊変経路1
-            decaySet.AddDecayPath(Line2, C12, C21, 123m);   // 壊変経路2: 経路1とは関係ない
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, null);   // 壊変経路1
+            decaySet.AddDecayPath(L2, C12, C21, 123m);   // 壊変経路2: 経路1とは関係ない
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-            var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C21)).Key;
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C21)).Key;
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
 
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, d21));
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, d21));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[d21].ShouldBe([chain2]);
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d21].ShouldBe([chain2]);
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C12 -----> N2/C21
-        // =========================
-        //         N1/C11 ---+-> N2/C21
-        //                  /
-        //         N1/C12 -+
+        //      N1               N2
+        // [L1] C11 -(coeff.A)-> C21
+        // [L2] C12 -(coeff.B)-> C21
+        // ===========================
+        //      C11 -----------> d21a
+        //                       ↓
+        //                     (coeff.A)
+        //                       ↓
+        //                       C21
+        //                       ↑
+        //                     (coeff.B)
+        //                       ↑
+        //      C12 -----------> d21b
         [TestMethod]
-        public void JoinPathsAtN2()
+        public void 並列の壊変経路_N1からN2_係数あり_2nd()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
+            // 2つの経路設定は、終端側がC21で合流しているように見えるが
+            // それぞれの経路は移行速度付きのため実際はN2位置で壊変コンパートメントが自動作成され、
+            // 従ってこれらは独立した2つの壊変経路を作成する。
+            decaySet.AddDecayPath(L1, C11, C21, 123m);   // 壊変経路A
+            decaySet.AddDecayPath(L2, C12, C21, 456m);   // 壊変経路B: 経路Aとは関係ない
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d21a = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C21)).Key;
+                var d21b = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (456m, C21)).Key;
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C21));
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, d21a));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, d21b));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[d21a].ShouldBe([chain1]);
+                decaySet.JointChains[d21b].ShouldBe([chain2]);
+                decaySet.JointChains.ContainsKey(C21).ShouldBeFalse();
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C12 -----> N2/C21
-        // [Line3]               N2/C21 --> N3/C31
-        // =======================================
-        //         N1/C11 ---+-> N2/C21 --> N3/C31
-        //                  /
-        //         N1/C12 -+
+        //      N1    N2    N3
+        // [L1] C11 ------> C31
+        // [L2] C12 ------> C32
+        // ====================
+        //      C11 ------> C31
+        //      C12 ------> C32
         [TestMethod]
-        public void JoinPathsAtN2_AndShareN3_Order1()
+        public void 並列の壊変経路_N1からN3_係数なし()
         {
-            // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
-            // 自動的に合流した2つの系列で共有される。
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C12, C32, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line3, C31));
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, C31));
 
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line3, C31));
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe(default);
+                chain2[N3].ShouldBe((L2, C32));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+                decaySet.JointChains[C32].ShouldBe([chain2]);
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line3]               N2/C21 --> N3/C31
-        // [Line2] N1/C12 -----> N2/C21
-        // =======================================
-        //         N1/C11 ---+-> N2/C21 --> N3/C31
-        //                  /
-        //         N1/C12 -+
+        //      N1    N2             N3
+        // [L1] C11 ---------------> C31
+        // [L2] C12 ------(coeff.)-> C31
+        // ================================
+        //      C11 ---------------> C31
+        //                           ↑
+        //                         (coeff.)
+        //                           ↑
+        //      C12 ---------------> d31
         [TestMethod]
-        public void JoinPathsAtN2_AndShareN3_Order2()
+        public void 並列の壊変経路_N1からN3_係数あり()
         {
-            // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
-            // 自動的に合流した2つの系列で共有される。
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
+            // 2つの経路設定は、終端側がC31で合流しているように見えるが
+            // 2つ目の経路は移行速度付きのため実際はN3位置で壊変コンパートメントが自動作成され、
+            // 従ってこれらは独立した2つの壊変経路を作成する。
+            decaySet.AddDecayPath(L1, C11, C31, null);   // 壊変経路1
+            decaySet.AddDecayPath(L2, C12, C31, 123m);   // 壊変経路2: 経路1とは関係ない
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line3, C31));
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, C31));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe(default);
+                chain2[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain2]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 壊変経路の接続、経路の穴埋め、合流と合流点以降での系列共有動作。
+    /// </summary>
+    [TestClass]
+    public class BasicTests2 : StraightDecayChain
+    {
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1] C11 --> C21
+        /// [L2]         C21 --> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1N2とN2N3の経路接続_順序1()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1]         C21 --> C31
+        /// [L2] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1N2とN2N3の経路接続_順序2()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        /// 
+        ///      N1      N2      N3
+        /// [L1] C11 ----------> C31
+        /// [L2] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序1()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        /// 
+        ///      N1      N2      N3
+        /// [L1] C11 --> C21
+        /// [L2] C11 ----------> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序2()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1] C11 --> C21
+        /// [L2]         C21 --> C31
+        /// [L3] C11 ----------> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序3()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            decaySet.AddDecayPath(L3, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1]         C21 --> C31
+        /// [L2] C11 --> C21
+        /// [L3] C11 ----------> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序4()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            decaySet.AddDecayPath(L3, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1] C11 --> C21
+        /// [L2] C11 ----------> C31
+        /// [L3]         C21 --> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序5()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C11, C31, null);
+            decaySet.AddDecayPath(L3, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1]         C21 --> C31
+        /// [L2] C11 ----------> C31
+        /// [L3] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序6()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, null);
+            decaySet.AddDecayPath(L2, C11, C31, null);
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L3, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                chain2[N1].ShouldBe((L2, C11));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        ///
+        ///      N1      N2      N3
+        /// [L1] C11 ----------> C31
+        /// [L2] C11 --> C21
+        /// [L3]         C21 --> C31
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序7()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            decaySet.AddDecayPath(L3, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2      N3
+        /// [L1] C11 ----------> C31
+        /// [L2]         C21 --> C31
+        /// [L3] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 --> C31
+        /// </summary>
+        [TestMethod]
+        public void N1からN3への経路の穴埋め_順序8()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L3, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                chain2[N1].ShouldBe((L3, C11));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        //      N1         N2
+        // [L1] C11 -----> C21
+        // [L2] C12 -----> C21
+        // ===================
+        //      C11 ---+-> C21
+        //            /
+        //      C12 -+
+        [TestMethod]
+        public void N2での合流()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C21));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        // FlexIDではこのような経路を直接作ることはできない。
+        // 代わりに、d21をd21a,d21bの2つに分けることで同等の経路にする。
+        // //      N1              N2
+        // // [L1] C11 -(coeff.)-> C21
+        // // [L2] C12 -(coeff.)-> C21
+        // // ========================
+        // //      C11 ---+------> d21
+        // //            /         ↓
+        // //      C12 -+        (coeff.)
+        // //                      ↓
+        // //                      C21
+        // [TestMethod]
+        // public void N2での合流_係数あり()
+
+        /// <summary>
+        /// 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
+        /// 自動的に合流した2つの系列で共有される。
+        /// 
+        ///      N1         N2      N3
+        /// [L1] C11 -----> C21
+        /// [L2] C12 -----> C21
+        /// [L3]            C21 --> C31
+        /// ===========================
+        ///      C11 ---+-> C21 --> C31
+        ///            /
+        ///      C12 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流によるN3の共有_係数なし_パターン1()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L3, C31));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L3, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        ///      N1         N2      N3
+        /// [L1] C11 -----> C21
+        /// [L2]            C21 --> C31
+        /// [L3] C12 -----> C21
+        /// ===========================
+        ///      C11 ---+-> C21 --> C31
+        ///            /
+        ///      C12 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流によるN3の共有_係数なし_パターン2()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
 
             // chain1に対してN2位置で合流するchain2を追加する。
-            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain2 = decaySet.DecayChains[1];
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line3, C31));
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
         }
 
-        // [Line1] N1/C11 -------> N2/C21
-        // [Line2] N1/C12 -------> N2/C21
-        // [Line3]                 N2/C21 -(coeff.)-> N3/C31
-        // ===============================================
-        //         N1/C11 -----+-> N2/C21 ----------> N3/d31
-        //                    /                         ↓
-        //                   /                        (coeff.)
-        //                  /                           ↓
-        //         N1/C12 -+                          N3/C31
+        /// <summary>
+        ///      N1         N2      N3
+        /// [L1]            C21 --> C31
+        /// [L2] C11 -----> C21
+        /// [L3] C12 -----> C21
+        /// ===========================
+        ///      C11 ---+-> C21 --> C31
+        ///            /
+        ///      C12 -+
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAtN2_AndShareN3_WithCoeff()
+        public void N2での合流によるN3の共有_係数なし_パターン3()
         {
-            // 合流が発生した核種N2の子孫核種N3の位置が壊変コンパートメントである場合も、
-            // 自動的に合流した2つの系列で共有される。
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, 123m);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C21, C31, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-            var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line3, d31));
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
 
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line3, d31));
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
+            }
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+            // chain1に対してN2位置で合流するchain2を追加する。
+            decaySet.AddDecayPath(L3, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L1, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
         }
 
-        // [Line1] N1/C11 -------> N2/C21
-        // [Line2]                 N2/C21 --> N3/C31
-        // [Line3]                            N3/C31 --> N4/C41
-        // [Line4] N1/C12 -------> N2/C21
-        // ====================================================
-        //         N1/C11 -----+-> N2/C21 --> N3/C31 --> N4/C41
-        //                    /
-        //                   /
-        //                  /
-        //         N1/C12 -+
+        /// <summary>
+        /// 合流が発生した核種N2の子孫核種N3の位置が壊変コンパートメントである場合も、
+        /// 自動的に合流した2つの系列で共有される。
+        /// 
+        ///      N1           N2              N3
+        /// [L1] C11 -------> C21
+        /// [L2] C12 -------> C21
+        /// [L3]              C21 -(coeff.)-> C31
+        /// ========================================
+        ///      C11 -----+-> C21 ----------> d31
+        ///              /                    ↓
+        ///             /                   (coeff.)
+        ///            /                      ↓
+        ///      C12 -+                       C31
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAtN2_AndShareN3N4()
+        public void N2での合流によるN3の共有_係数あり_パターン1()
         {
-            // 核種N2で合流が発生した場合、その子孫核種であるN3,N4のコンパートメントは
-            // 自動的に合流した2つの系列で共有される。
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C21, C31, null);
-            decaySet.AddDecayPath(Line3, C31, C41, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line2, C31));
-            chain1[N4].ShouldBe((Line3, C41));
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
 
-            decaySet.AddDecayPath(Line4, C12, C21, null);
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L3, d31));
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain2 = decaySet.DecayChains[1];
-            chain2[N1].ShouldBe((Line4, C12));
-            chain2[N2].ShouldBe((Line4, C21));
-            chain2[N3].ShouldBe((Line2, C31));
-            chain2[N4].ShouldBe((Line3, C41));
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L3, d31));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C41].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+            }
         }
 
-        // [Line1] N1/C11 -------> N2/C21
-        // [Line2] N1/C12 -------> N2/C21
-        // [Line3]                 N2/C21 -------> N3/C31
-        // [Line4]                                 N3/C31 --> N4/C41
-        // [Line5] N1/C13 -------> N2/C22
-        // [Line6] N1/C14 -------> N2/C22
-        // [Line7]                 N2/C22 -------> N3/C31
-        // =========================================================
-        //         N1/C11 ---+---> N2/C21 -----+-> N3/C31 --> N4/C41
-        //                  /                 /
-        //         N1/C12 -+                 /
-        //                                  /
-        //         N1/C13 ---+---> N2/C22 -+
-        //                  /
-        //         N1/C14 -+
+        /// <summary>
+        ///      N1           N2              N3
+        /// [L1] C11 -------> C21
+        /// [L2]              C21 -(coeff.)-> C31
+        /// [L3] C12 -------> C21
+        /// ========================================
+        ///      C11 -----+-> C21 ----------> d31
+        ///              /                    ↓
+        ///             /                   (coeff.)
+        ///            /                      ↓
+        ///      C12 -+                       C31
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAtN2N3_AndShareN4()
+        public void N2での合流によるN3の共有_係数あり_パターン2()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            decaySet.AddDecayPath(Line4, C31, C41, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, 123m);
+            decaySet.AddDecayPath(L3, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line3, C31));
-            chain1[N4].ShouldBe((Line4, C41));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line3, C31));
-            chain2[N4].ShouldBe((Line4, C41));
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
 
-            decaySet.AddDecayPath(Line5, C13, C22, null);
-            decaySet.AddDecayPath(Line6, C14, C22, null);
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, d31));
 
-            decaySet.DecayChains.Count.ShouldBe(4);
-            var chain3 = decaySet.DecayChains[2];
-            var chain4 = decaySet.DecayChains[3];
-            chain3[N1].ShouldBe((Line5, C13));
-            chain3[N2].ShouldBe((Line5, C22));
-            chain3[N3].ShouldBe(default);
-            chain3[N4].ShouldBe(default);
-            chain4[N1].ShouldBe((Line6, C14));
-            chain4[N2].ShouldBe((Line6, C22));
-            chain4[N3].ShouldBe(default);
-            chain4[N4].ShouldBe(default);
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L2, d31));
 
-            decaySet.AddDecayPath(Line7, C22, C31, null);
-
-            decaySet.DecayChains.Count.ShouldBe(4);
-            chain3[N3].ShouldBe((Line7, C31));
-            chain3[N4].ShouldBe((Line4, C41));
-            chain4[N3].ShouldBe((Line7, C31));
-            chain4[N4].ShouldBe((Line4, C41));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C13].ShouldBe([chain3]);
-            decaySet.JointChains[C14].ShouldBe([chain4]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
-            decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C12 -----> N2/C21
-        // [Line3] N1/C13 -----> N2/C22
-        // [Line4] N1/C14 -----> N2/C22
-        // [Line5]               N2/C21 -------> N3/C31
-        // [Line6]               N2/C22 -------> N3/C31
-        // =========================
-        //         N1/C11 ---+-> N2/C21 -----+-> N3/C31
-        //                  /               /
-        //         N1/C12 -+               /
-        //                                /
-        //         N1/C13 ---+-> N2/C22 -+
-        //                  /
-        //         N1/C14 -+
+        /// <summary>
+        ///      N1           N2              N3
+        /// [L1]              C21 -(coeff.)-> C31
+        /// [L2] C11 -------> C21
+        /// [L3] C12 -------> C21
+        /// ========================================
+        ///      C11 -----+-> C21 ----------> d31
+        ///              /                    ↓
+        ///             /                   (coeff.)
+        ///            /                      ↓
+        ///      C12 -+                       C31
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAtN3_Order1()
+        public void N2での合流によるN3の共有_係数あり_パターン3()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C13, C22, null);
-            decaySet.AddDecayPath(Line4, C14, C22, null);
+            decaySet.AddDecayPath(L1, C21, C31, 123m);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            decaySet.AddDecayPath(L3, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(4);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-            var chain3 = decaySet.DecayChains[2];
-            var chain4 = decaySet.DecayChains[3];
-            chain1[N1].ShouldBe((Line1, C11));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain3[N1].ShouldBe((Line3, C13));
-            chain4[N1].ShouldBe((Line4, C14));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain3[N2].ShouldBe((Line3, C22));
-            chain4[N2].ShouldBe((Line4, C22));
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
 
-            decaySet.AddDecayPath(Line5, C21, C31, null);
-            decaySet.AddDecayPath(Line6, C22, C31, null);
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, d31));
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain3[N1].ShouldBe((Line3, C13));
-            chain4[N1].ShouldBe((Line4, C14));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain3[N2].ShouldBe((Line3, C22));
-            chain4[N2].ShouldBe((Line4, C22));
-            chain1[N3].ShouldBe((Line5, C31));
-            chain2[N3].ShouldBe((Line5, C31));
-            chain3[N3].ShouldBe((Line6, C31));
-            chain4[N3].ShouldBe((Line6, C31));
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains.ContainsKey(C31).ShouldBeFalse();
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C12 -----> N2/C21
-        // [Line3] N1/C13 -----> N2/C22
-        // [Line4] N1/C14 -----> N2/C22
-        // [Line5] N1/C11 ---------------------> N3/C31
-        // [Line6] N2/C14 ---------------------> N3/C31
-        // =========================
-        //         N1/C11 ---+-> N2/C21 -----+-> N3/C31
-        //                  /               /
-        //         N1/C12 -+               /
-        //                                /
-        //         N1/C13 ---+-> N2/C22 -+
-        //                  /
-        //         N1/C14 -+
+        /// <summary>
+        /// 
+        ///      N1   N2         N3
+        /// [L1] C11 ----------> C31
+        /// [L2]      C21 -----> C31
+        /// ========================
+        ///      C11 -( )----+-> C31
+        ///                 /
+        ///           C21 -+
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAtN3_Order2()
+        public void N3での合流_順序1()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C13, C22, null);
-            decaySet.AddDecayPath(Line4, C14, C22, null);
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(4);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-            var chain3 = decaySet.DecayChains[2];
-            var chain4 = decaySet.DecayChains[3];
-            chain1[N1].ShouldBe((Line1, C11));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain3[N1].ShouldBe((Line3, C13));
-            chain4[N1].ShouldBe((Line4, C14));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain3[N2].ShouldBe((Line3, C22));
-            chain4[N2].ShouldBe((Line4, C22));
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
 
-            decaySet.AddDecayPath(Line5, C11, C31, null);
-            decaySet.AddDecayPath(Line6, C14, C31, null);
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, C31));
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain2[N1].ShouldBe((Line2, C12));
-            chain3[N1].ShouldBe((Line3, C13));
-            chain4[N1].ShouldBe((Line4, C14));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain3[N2].ShouldBe((Line3, C22));
-            chain4[N2].ShouldBe((Line4, C22));
-            chain1[N3].ShouldBe((Line5, C31));
-            chain2[N3].ShouldBe((Line5, C31));
-            chain3[N3].ShouldBe((Line6, C31));
-            chain4[N3].ShouldBe((Line6, C31));
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+                chain2[N1].ShouldBe(default);
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain2]);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C11 -----> N2/C22
-        // ============================
-        //         N1/C11 -+---> N2/C21
-        //                  \ 
-        //                   +-> N2/C22 (error)
+        /// <summary>
+        /// 
+        ///      N1   N2        N3
+        /// [L1]      C21 ----> C31
+        /// [L2] C11 ---------> C31
+        /// =======================
+        ///           C21 --+-> C31
+        ///                /
+        ///      C11 -( )-+
+        /// </summary>
+        [TestMethod]
+        public void N3での合流_順序2()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, null);
+            decaySet.AddDecayPath(L2, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe(default);
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, C31));
+
+                chain2[N1].ShouldBe((L2, C11));
+                chain2[N2].ShouldBe(default);
+                chain2[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 同じ移行先への速度付き壊変経路が、経路の定義順序に関わらずマージされる動作。
+    /// </summary>
+    [TestClass]
+    public class BasicTests3 : StraightDecayChain
+    {
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1] C11 --> C21
+        /// [L2]         C21 -(coeff.)-> C31
+        /// [L3] C11 ---------(coeff.)-> C31
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン1()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+
+            decaySet.AddDecayPath(L3, C11, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1] C11 --> C21
+        /// [L2] C11 ---------(coeff.)-> C31
+        /// [L3]         C21 -(coeff.)-> C31
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン2()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C11, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+
+            decaySet.AddDecayPath(L3, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1]         C21 -(coeff.)-> C31
+        /// [L2] C11 --> C21
+        /// [L3] C11 ---------(coeff.)-> C31
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン3()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, 123m);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+
+            decaySet.AddDecayPath(L3, C11, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L2, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1]         C21 -(coeff.)-> C31
+        /// [L2] C11 ---------(coeff.)-> C31
+        /// [L3] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン4()
+        {
+            decaySet.AddDecayPath(L1, C21, C31, 123m);
+            decaySet.AddDecayPath(L2, C11, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var d31a = chain1[N3].Organ.ShouldNotBeNull();
+                var d31b = chain2[N3].Organ.ShouldNotBeNull();
+                decaySet.AfterDecayPath.Keys.ShouldBe([d31a, d31b], ignoreOrder: true);
+
+                chain1[N1].ShouldBe(default);
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, d31a));
+
+                chain2[N1].ShouldBe((L2, C11));
+                chain2[N2].ShouldBe(default);
+                chain2[N3].ShouldBe((L2, d31b));
+
+                decaySet.JointChains[C11].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31a].ShouldBe([chain1]);
+                decaySet.JointChains[d31b].ShouldBe([chain2]);
+            }
+
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                // d31a, d31bは1つにマージされる。
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+                decaySet.AfterDecayPath.Keys.ShouldBe([d31]);
+
+                chain1[N1].ShouldBe((L3, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                chain2[N1].ShouldBe((L2, C11));
+                chain2[N2].ShouldBe((L3, C21));
+                chain2[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1] C11 ---------(coeff.)-> C31
+        /// [L2] C11 --> C21
+        /// [L3]         C21 -(coeff.)-> C31
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン5()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, 123m);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+
+            decaySet.AddDecayPath(L3, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[d31].ShouldBe([chain1]);
+            }
+        }
+
+        /// <summary>
+        ///      N1      N2              N3
+        /// [L1] C11 ---------(coeff.)-> C31
+        /// [L2]         C21 -(coeff.)-> C31
+        /// [L3] C11 --> C21
+        /// ========================
+        ///      C11 --> C21 ----------> d31
+        //                               ↓
+        //                             (coeff.)
+        //                               ↓
+        ///                              C31
+        /// </summary>
+        [TestMethod]
+        public void N3への係数付き経路のマージ_パターン6()
+        {
+            decaySet.AddDecayPath(L1, C11, C31, 123m);
+            decaySet.AddDecayPath(L2, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                var d31a = chain1[N3].Organ.ShouldNotBeNull();
+                var d31b = chain2[N3].Organ.ShouldNotBeNull();
+                decaySet.AfterDecayPath.Keys.ShouldBe([d31a, d31b], ignoreOrder: true);
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe(default);
+                chain1[N3].ShouldBe((L1, d31a));
+
+                chain2[N1].ShouldBe(default);
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L2, d31b));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain2]);
+                decaySet.JointChains[d31a].ShouldBe([chain1]);
+                decaySet.JointChains[d31b].ShouldBe([chain2]);
+            }
+
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                // d31a, d31bは1つにマージされる。
+                var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
+                decaySet.AfterDecayPath.Keys.ShouldBe([d31]);
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L3, C21));
+                chain1[N3].ShouldBe((L1, d31));
+
+                chain2[N1].ShouldBe((L3, C11));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L2, d31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[d31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+    }
+
+    [TestClass]
+    public class BasicTests4 : StraightDecayChain
+    {
+        /// <summary>
+        /// 核種N2で合流が発生した場合、その子孫核種であるN3,N4のコンパートメントは
+        /// 自動的に合流した2つの系列で共有される。
+        /// 
+        ///      N1           N2      N3      N4
+        /// [L1] C11 -------> C21
+        /// [L2]              C21 --> C31
+        /// [L3]                      C31 --> C41
+        /// [L4] C12 -------> C21
+        /// =====================================
+        ///      C11 -----+-> C21 --> C31 --> C41
+        ///              /
+        ///             /
+        ///            /
+        ///      C12 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流によるN3とN4の共有()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, null);
+            decaySet.AddDecayPath(L3, C31, C41, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+                chain1[N4].ShouldBe((L3, C41));
+            }
+
+            decaySet.AddDecayPath(L4, C12, C21, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain2[N1].ShouldBe((L4, C12));
+                chain2[N2].ShouldBe((L4, C21));
+                chain2[N3].ShouldBe((L2, C31));
+                chain2[N4].ShouldBe((L3, C41));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C41].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        /// 
+        ///
+        ///      N1          N2           N3      N4
+        /// [L1] C11 ------> C21
+        /// [L2] C12 ------> C21
+        /// [L3]             C21 -------> C31
+        /// [L4]                          C31 --> C41
+        /// [L5] C13 ------> C22
+        /// [L6] C14 ------> C22
+        /// [L7]             C22 -------> C31
+        /// =========================================
+        ///      C11 ---+--> C21 -----+-> C31 --> C41
+        ///            /             /
+        ///      C12 -+             /
+        ///                        /
+        ///      C13 ---+--> C22 -+
+        ///            /
+        ///      C14 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流2つとN3での合流1つとN4の共有()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C21, C31, null);
+            decaySet.AddDecayPath(L4, C31, C41, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L3, C31));
+                chain1[N4].ShouldBe((L4, C41));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L3, C31));
+                chain2[N4].ShouldBe((L4, C41));
+            }
+
+            decaySet.AddDecayPath(L5, C13, C22, null);
+            decaySet.AddDecayPath(L6, C14, C22, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain3[N1].ShouldBe((L5, C13));
+                chain3[N2].ShouldBe((L5, C22));
+                chain3[N3].ShouldBe(default);
+                chain3[N4].ShouldBe(default);
+
+                chain4[N1].ShouldBe((L6, C14));
+                chain4[N2].ShouldBe((L6, C22));
+                chain4[N3].ShouldBe(default);
+                chain4[N4].ShouldBe(default);
+            }
+            decaySet.AddDecayPath(L7, C22, C31, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain3[N3].ShouldBe((L7, C31));
+                chain3[N4].ShouldBe((L4, C41));
+                chain4[N3].ShouldBe((L7, C31));
+                chain4[N4].ShouldBe((L4, C41));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C13].ShouldBe([chain3]);
+                decaySet.JointChains[C14].ShouldBe([chain4]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+                decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        /// 
+        ///      N1          N2
+        /// [L1] C11 ------> C21
+        /// [L2] C12 ------> C21
+        /// [L3] C13 ------> C22
+        /// [L4] C14 ------> C22
+        /// [L5]             C21 -------> C31
+        /// [L6]             C22 -------> C31
+        /// =================================
+        ///      C11 ---+--> C21 -----+-> C31
+        ///            /             /
+        ///      C12 -+             /
+        ///                        /
+        ///      C13 ---+--> C22 -+
+        ///            /
+        ///      C14 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流2つとN3での合流_順序1()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C13, C22, null);
+            decaySet.AddDecayPath(L4, C14, C22, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain2[N1].ShouldBe((L2, C12));
+                chain3[N1].ShouldBe((L3, C13));
+                chain4[N1].ShouldBe((L4, C14));
+                chain1[N2].ShouldBe((L1, C21));
+                chain2[N2].ShouldBe((L2, C21));
+                chain3[N2].ShouldBe((L3, C22));
+                chain4[N2].ShouldBe((L4, C22));
+
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+            }
+
+            decaySet.AddDecayPath(L5, C21, C31, null);
+            decaySet.AddDecayPath(L6, C22, C31, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain2[N1].ShouldBe((L2, C12));
+                chain3[N1].ShouldBe((L3, C13));
+                chain4[N1].ShouldBe((L4, C14));
+                chain1[N2].ShouldBe((L1, C21));
+                chain2[N2].ShouldBe((L2, C21));
+                chain3[N2].ShouldBe((L3, C22));
+                chain4[N2].ShouldBe((L4, C22));
+                chain1[N3].ShouldBe((L5, C31));
+                chain2[N3].ShouldBe((L5, C31));
+                chain3[N3].ShouldBe((L6, C31));
+                chain4[N3].ShouldBe((L6, C31));
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        /// 
+        ///      N1          N2           N3
+        /// [L1] C11 ------> C21
+        /// [L2] C12 ------> C21
+        /// [L3] C13 ------> C22
+        /// [L4] C14 ------> C22
+        /// [L5] C11 -------------------> C31
+        /// [L6] C14 -------------------> C31
+        /// =================================
+        ///      C11 ---+--> C21 -----+-> C31
+        ///            /             /
+        ///      C12 -+             /
+        ///                        /
+        ///      C13 ---+--> C22 -+
+        ///            /
+        ///      C14 -+
+        /// </summary>
+        [TestMethod]
+        public void N2での合流2つとN3での合流_順序2()
+        {
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C13, C22, null);
+            decaySet.AddDecayPath(L4, C14, C22, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain2[N1].ShouldBe((L2, C12));
+                chain3[N1].ShouldBe((L3, C13));
+                chain4[N1].ShouldBe((L4, C14));
+                chain1[N2].ShouldBe((L1, C21));
+                chain2[N2].ShouldBe((L2, C21));
+                chain3[N2].ShouldBe((L3, C22));
+                chain4[N2].ShouldBe((L4, C22));
+
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C22].ShouldBe([chain3, chain4], ignoreOrder: true);
+            }
+
+            // L5はchain1に対して直接の関係を発見できるが、
+            // chain2に対してはN3の位置がまだ共有されていないため、間接的な関係を見つけてマージする必要がある。
+            // 同様の処理を、L6ではchain4に対して行う必要がある。
+            decaySet.AddDecayPath(L5, C11, C31, null);
+            decaySet.AddDecayPath(L6, C14, C31, null);
+            {
+                decaySet.DecayChains.Count.ShouldBe(4);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+                var chain4 = decaySet.DecayChains[3];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain2[N1].ShouldBe((L2, C12));
+                chain3[N1].ShouldBe((L3, C13));
+                chain4[N1].ShouldBe((L4, C14));
+
+                chain1[N2].ShouldBe((L1, C21));
+                chain2[N2].ShouldBe((L2, C21));
+                chain3[N2].ShouldBe((L3, C22));
+                chain4[N2].ShouldBe((L4, C22));
+
+                chain1[N3].ShouldBe((L5, C31));
+                chain2[N3].ShouldBe((L5, C31));
+                chain3[N3].ShouldBe((L6, C31));
+                chain4[N3].ShouldBe((L6, C31));
+
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2, chain3, chain4], ignoreOrder: true);
+            }
+        }
+
+        /// <summary>
+        ///      N1         N2      N3      N4
+        /// [L1] C11 ---------------------> C41
+        /// [L2] C11 -----> C21
+        /// [L3] C12 ---------------------> C41
+        /// [L4] C12 -----> C21
+        /// [L5] C11 -------------> C31
+        /// ===================================
+        ///      C11 ---+-> C21 --> C31 --> C41
+        //             /
+        //       C12 -+
+        /// </summary>
+        [TestMethod]
+        public void N3への経路設定を契機にN2位置での合流経路を発見する()
+        {
+            decaySet.AddDecayPath(L1, C11, C41, null);
+            decaySet.AddDecayPath(L2, C11, C21, null);
+            decaySet.AddDecayPath(L3, C12, C41, null);
+            decaySet.AddDecayPath(L4, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe(default);
+                chain1[N4].ShouldBe((L1, C41));
+
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L4, C21));
+                chain2[N3].ShouldBe(default);
+                chain2[N4].ShouldBe((L3, C41));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C41].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+
+            // chain1(C11→C41)経路に対するN3位置へのC31設定を契機として
+            // chain1とchain2(C12→C41)がN2位置のC21で合流していることを発見し、
+            // (N4位置は既に共有済みのため)N2位置とN3位置それぞれでの共有設定を行う。
+            decaySet.AddDecayPath(L5, C11, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L2, C21));
+                chain1[N3].ShouldBe((L5, C31));
+                chain1[N4].ShouldBe((L1, C41));
+
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L4, C21));
+                chain2[N3].ShouldBe((L5, C31));
+                chain2[N4].ShouldBe((L3, C41));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C41].ShouldBe([chain1, chain2], ignoreOrder: true);
+            }
+        }
+    }
+
+    [TestClass]
+    public class ErrorTests : StraightDecayChain
+    {
+        /// <summary>
+        /// 壊変経路の移行先が分岐する場合に対するエラー報告。
+        ///
+        ///      N1                     N2
+        /// [L1] C11 -----(coeff1.?)--> C21
+        /// [L2] C11 -----(coeff2.?)--> C22
+        /// ===============================
+        ///      C11 -+---(coeff1.?)--> C21
+        ///            \ 
+        ///             +-(coeff2.?)--> C22 (error)
+        /// </summary>
         [TestMethod]
         [DataRow(null, null)]
         [DataRow(1.23, null)]
         [DataRow(null, 2.34)]
         [DataRow(1.23, 2.34)]
-        public void DivergePathsOnTheToPoint1(double? coeff1, double? coeff2)
+        public void N1からN2での分岐エラー(double? coeff1, double? coeff2)
         {
-            decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff1);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, (decimal?)coeff1);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+            }
 
-            decaySet.AddDecayPath(Line2, C11, C22, (decimal?)coeff2);
-            errors.GetErrorLines().ShouldBe(
-            [
-                $"Line {Line2}: Conflict of decay path definitions found:",
-                $"Line {Line1}:     previous, decay to '{C21}' {(coeff1 is null ? "without coefficient": $"with coefficient {coeff1.Value}")},",
-                $"Line {Line2}:     and here, decay to '{C22}' {(coeff2 is null ? "without coefficient": $"with coefficient {coeff2.Value}")}.",
-            ]);
+            decaySet.AddDecayPath(L2, C11, C22, (decimal?)coeff2);
+            {
+                errors.GetErrorLines().ShouldBe(
+                [
+                    $"Line {L2}: Conflict of decay path definitions found:",
+                    $"Line {L1}:     previous, decay to '{C21}' {(coeff1 is null ? "without coefficient" : $"with coefficient {coeff1.Value}")},",
+                    $"Line {L2}:     and here, decay to '{C22}' {(coeff2 is null ? "without coefficient" : $"with coefficient {coeff2.Value}")}.",
+                ]);
+            }
         }
 
-        // [Line1] N1/C11 -----> N2/C21
-        // [Line2] N1/C12 -----> N2/C21
-        // [Line3]               N2/C21 -----> N3/C31
-        // [Line4] N1/C12 -------------------> N3/C32
-        // ==========================================
-        //         N1/C11 ---+-> N2/C21 -+---> N3/C31
-        //                  /             \
-        //         N1/C12 -+               +-> N3/C32 (error)
+        /// <summary>
+        /// 壊変経路の移行先が分岐する場合に対するエラー。
+        /// 
+        ///      N1         N2         N3
+        /// [L1] C11 -----> C21
+        /// [L2] C12 -----> C21
+        /// [L3]            C21 -----> C31
+        /// [L4] C12 ----------------> C32
+        /// ==============================
+        ///      C11 ---+-> C21 -+---> C31
+        ///            /          \
+        ///      C12 -+            +-> C32 (error)
+        /// </summary>
         [TestMethod]
-        public void DivergePathsOnTheToPoint2()
+        public void N2での合流後にN3での分岐エラー()
         {
             // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
             // 自動的に合流した2つの系列で共有される。
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C12, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C12, C21, null);
+            decaySet.AddDecayPath(L3, C21, C31, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            {
-                chain1[N1].ShouldBe((Line1, C11));
-                chain1[N2].ShouldBe((Line1, C21));
-                chain1[N3].ShouldBe((Line3, C31));
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L3, C31));
+
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe((L2, C21));
+                chain2[N3].ShouldBe((L3, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
             }
-            var chain2 = decaySet.DecayChains[1];
-            {
-                chain2[N1].ShouldBe((Line2, C12));
-                chain2[N2].ShouldBe((Line2, C21));
-                chain2[N3].ShouldBe((Line3, C31));
-            }
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
 
             // 新しい経路の末端側の位置(核種N3)で壊変経路の分岐が生じる。
-            decaySet.AddDecayPath(Line4, C12, C32, null);
-            errors.GetErrorLines().ShouldBe(
-            [
-                $"Line {Line4}: Conflict of decay path definitions found:",
-                $"Line {Line3}:     previous, decay to '{C31}' without coefficient,",
-                $"Line {Line4}:     and here, decay to '{C32}' without coefficient.",
-            ]);
+            decaySet.AddDecayPath(L4, C12, C32, null);
+            {
+                errors.GetErrorLines().ShouldBe(
+                [
+                    $"Line {L4}: Conflict of decay path definitions found:",
+                    $"Line {L3}:     previous, decay to '{C31}' without coefficient,",
+                    $"Line {L4}:     and here, decay to '{C32}' without coefficient.",
+                ]);
+            }
         }
 
-        // [Line1] N1/C11 -------------------> N3/C31
-        // [Line2] N1/C12 -------------------> N3/C32
-        // [Line3] N1/C11 -----> N2/C21
-        // [Line4] N1/C12 -----> N2/C21
-        // ==========================================
-        //         N1/C11 ---+-> N2/C21 -+---> N3/C31
-        //                  /             \
-        //         N1/C12 -+               +-> N3/C32 (error)
+        /// <summary>
+        ///      N1         N2         N3
+        /// [L1] C11 ----------------> C31
+        /// [L2] C12 ----------------> C32
+        /// [L3] C11 -----> C21
+        /// [L4] C12 -----> C21
+        /// ==============================
+        ///      C11 ---+-> C21 -+---> C31
+        ///            /          \
+        ///      C12 -+            +-> C32 (error)
+        /// </summary>
         [TestMethod]
-        public void DivergePathsOnTheProgenyOfToPoint()
+        public void N3への並列とN2での合流によるエラー()
         {
-            decaySet.AddDecayPath(Line1, C11, C31, null);
-            decaySet.AddDecayPath(Line2, C12, C32, null);
-            decaySet.AddDecayPath(Line3, C11, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
+            // C11 -> C21 -> C31 と
+            // C12 --------> C32 の並列な壊変経路を作る。
+            decaySet.AddDecayPath(L1, C11, C31, null);
+            decaySet.AddDecayPath(L2, C12, C32, null);
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe([]);
 
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
+                decaySet.DecayChains.Count.ShouldBe(2);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
 
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line3, C21));
-            chain1[N3].ShouldBe((Line1, C31));
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L3, C21));
+                chain1[N3].ShouldBe((L1, C31));
 
-            chain2[N1].ShouldBe((Line2, C12));
-            chain2[N2].ShouldBe(default);
-            chain2[N3].ShouldBe((Line2, C32));
+                chain2[N1].ShouldBe((L2, C12));
+                chain2[N2].ShouldBe(default);
+                chain2[N3].ShouldBe((L2, C32));
+            }
 
             // 新しい経路の末端側(核種N2)より子孫の位置(核種N3)で壊変経路の分岐が生じる。
-            decaySet.AddDecayPath(Line4, C12, C21, null);
-            errors.GetErrorLines().ShouldBe(
-            [
-                $"Line 4: Conflict of decay path definitions found:",
-                $"Line 1:     previous,  decay to '{C31}' without coefficient,",
-                $"Line 2:     and there, decay to '{C32}' without coefficient.",
-            ]);
+            decaySet.AddDecayPath(L4, C12, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe(
+                [
+                    $"Line {L4}: Conflict of decay path definitions found:",
+                    $"Line {L1}:     previous,  decay to '{C31}' without coefficient,",
+                    $"Line {L2}:     and there, decay to '{C32}' without coefficient.",
+                ]);
+            }
         }
 
-        // [Line1] N1/C11 --> N2/C21
-        // [Line2]            N2/C21 --> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
+        /// <summary>
+        ///      N1      N2               N3
+        /// [L1] C11 --> C21
+        /// [L2]         C21 -(coeff.A)-> C31
+        /// [L3] C11 ---------(coeff.B)-> C31
+        /// =================================
+        ///      C11 --> C21 -----------> d31
+        //                                ↓
+        //                      (coeff.A) vs (coeff.B) (error)
+        //                                ↓
+        ///                               C31
+        /// </summary>
         [TestMethod]
-        public void FillChainPaths_Order1a()
+        public void N3への係数付き経路のマージ_パターン1における係数不一致エラー()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C21, C31, 123m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+            }
 
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
+            decaySet.AddDecayPath(L3, C11, C31, 456m);
+            {
+                errors.GetErrorLines().ShouldBe(
+                [
+                    $"Line {L3}: Conflict of decay path definitions found:",
+                    $"Line {L2}:     previous, decay to '{C31}' with coefficient 123,",
+                    $"Line {L3}:     and here, decay to '{C31}' with coefficient 456.",
+                ]);
+            }
         }
 
-        // [Line1]            N2/C21 --> N3/C31
-        // [Line2] N1/C11 --> N2/C21
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
+        /// <summary>
+        ///      N1      N2               N3
+        /// [L1] C11 ---------(coeff.A)-> C31
+        /// [L2]         C21 -(coeff.B)-> C31
+        /// [L3] C11 --> C21
+        /// =================================
+        ///      C11 --> C21 -----------> d31
+        //                                ↓
+        //                      (coeff.A) vs (coeff.B) (error)
+        //                                ↓
+        ///                               C31
+        /// </summary>
         [TestMethod]
-        public void FillChainPaths_Order1b()
+        public void N3への係数付き経路のマージ_パターン6における係数不一致エラー()
         {
-            decaySet.AddDecayPath(Line1, C21, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
+            decaySet.AddDecayPath(L1, C11, C31, 123m);
+            decaySet.AddDecayPath(L2, C21, C31, 456m);
+            {
+                errors.GetErrorLines().ShouldBe([]);
+            }
 
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line2, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1] N1/C11 -------------> N3/C31
-        // [Line2]         N2/C21 -----> N3/C31
-        // ====================================
-        //         N1/C11 -----------+-> N3/C31
-        //                          /
-        //                 N2/C21 -+
-        [TestMethod]
-        public void FillChainPaths_Order2a()
-        {
-            decaySet.AddDecayPath(Line1, C11, C31, null);
-            decaySet.AddDecayPath(Line2, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe(default);
-            chain1[N3].ShouldBe((Line1, C31));
-
-            chain2[N1].ShouldBe(default);
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain2]);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
-        }
-
-        // [Line1]         N2/C21 ---> N3/C31
-        // [Line2] N1/C11 -----------> N3/C31
-        // ==================================
-        //                 N2/C21 -+-> N3/C31
-        //                        /
-        //         N1/C11 -------+
-        [TestMethod]
-        public void FillChainPaths_Order2b()
-        {
-            decaySet.AddDecayPath(Line1, C21, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-
-            chain1[N1].ShouldBe(default);
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            chain2[N1].ShouldBe((Line2, C11));
-            chain2[N2].ShouldBe(default);
-            chain2[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain2]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
-        }
-
-        // [Line1] N1/C11 -------------> N3/C31
-        // [Line2] N1/C11 --> N2/C21
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order3a()
-        {
-            decaySet.AddDecayPath(Line1, C11, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line2, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1] N1/C11 --> N2/C21
-        // [Line2] N1/C11 -------------> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order3b()
-        {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C11, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1] N1/C11 --> N2/C21
-        // [Line2]            N2/C21 --> N3/C31
-        // [Line3] N1/C11 -------------> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4a()
-        {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C21, C31, null);
-            decaySet.AddDecayPath(Line3, C11, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1]            N2/C21 --> N3/C31
-        // [Line2] N1/C11 --> N2/C21
-        // [Line3] N1/C11 -------------> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4b()
-        {
-            decaySet.AddDecayPath(Line1, C21, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C21, null);
-            decaySet.AddDecayPath(Line3, C11, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line2, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1] N1/C11 --> N2/C21
-        // [Line2] N1/C11 -------------> N3/C31
-        // [Line3]            N2/C21 --> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4c()
-        {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C11, C31, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1]            N2/C21 --> N3/C31
-        // [Line2] N1/C11 -------------> N3/C31
-        // [Line3] N1/C11 --> N2/C21
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4d()
-        {
-            decaySet.AddDecayPath(Line1, C21, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C31, null);
-            decaySet.AddDecayPath(Line3, C11, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-
-            chain1[N1].ShouldBe((Line3, C11));
-            chain1[N2].ShouldBe((Line1, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            chain2[N1].ShouldBe((Line2, C11));
-            chain2[N2].ShouldBe((Line3, C21));
-            chain2[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
-        }
-
-        // [Line1] N1/C11 -------------> N3/C31
-        // [Line2] N1/C11 --> N2/C21
-        // [Line3]            N2/C21 --> N3/C31
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4e()
-        {
-            decaySet.AddDecayPath(Line1, C11, C31, null);
-            decaySet.AddDecayPath(Line2, C11, C21, null);
-            decaySet.AddDecayPath(Line3, C21, C31, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line2, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
-        }
-
-        // [Line1] N1/C11 -------------> N3/C31
-        // [Line2]            N2/C21 --> N3/C31
-        // [Line3] N1/C11 --> N2/C21
-        // ====================================
-        //         N1/C11 --> N2/C21 --> N3/C31
-        [TestMethod]
-        public void FillChainPaths_Order4f()
-        {
-            decaySet.AddDecayPath(Line1, C11, C31, null);
-            decaySet.AddDecayPath(Line2, C21, C31, null);
-            decaySet.AddDecayPath(Line3, C11, C21, null);
-            errors.GetErrorLines().ShouldBe([]);
-
-            decaySet.DecayChains.Count.ShouldBe(2);
-            var chain1 = decaySet.DecayChains[0];
-            var chain2 = decaySet.DecayChains[1];
-
-            chain1[N1].ShouldBe((Line1, C11));
-            chain1[N2].ShouldBe((Line3, C21));
-            chain1[N3].ShouldBe((Line1, C31));
-
-            chain2[N1].ShouldBe((Line3, C11));
-            chain2[N2].ShouldBe((Line2, C21));
-            chain2[N3].ShouldBe((Line2, C31));
-
-            decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C21].ShouldBe([chain2, chain1], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
+            decaySet.AddDecayPath(L3, C11, C21, null);
+            {
+                errors.GetErrorLines().ShouldBe(
+                [
+                    $"Line {L3}: Conflict of decay path definitions found:",
+                    $"Line {L1}:     previous,  decay to '{C31}' with coefficient 123,",
+                    $"Line {L2}:     and there, decay to '{C31}' with coefficient 456.",
+                ]);
+            }
         }
     }
 
-    //        +--> N2 --+
-    //       /           \
-    // N1 --+             +-> N4
-    //       \           /
-    //        +--> N3 --+
+    /// <summary>
+    ///        +--> N2 --+
+    ///       /           \
+    /// N1 --+             +-> N4
+    ///       \           /
+    ///        +--> N3 --+
+    /// </summary>
     [TestClass]
-    public class DiamondDecayChain
+    public class DecayChainType_Diamond
     {
-        const int LineNum = 1;
-        const int Line1 = LineNum + 0;
-        const int Line2 = LineNum + 1;
-        const int Line3 = LineNum + 2;
-        const int Line4 = LineNum + 3;
-        const int Line5 = LineNum + 4;
+        const int L1 = 1;
+        const int L2 = 2;
+        const int L3 = 3;
+        const int L4 = 4;
+        const int L5 = 5;
 
         readonly NuclideData N1; readonly Organ C11, C12, C13;
         readonly NuclideData N2; readonly Organ C21;
@@ -962,7 +2003,7 @@ public class DecaySetTests
         readonly DecaySet decaySet;
         readonly InputErrors errors = new();
 
-        public DiamondDecayChain()
+        public DecayChainType_Diamond()
         {
             N1 = new NuclideData { Index = 0, Name = "N1", };
             N2 = new NuclideData { Index = 1, Name = "N2", IsProgeny = true, };
@@ -989,80 +2030,92 @@ public class DecaySetTests
             decaySet = new DecaySet([N1, N2, N3, N4], errors);
         }
 
-        // [Line1] N1/C11 --------> N2/C21
-        // [Line2] N1/C11 ------------------> N3/C31
-        // [Line1] N1/C12 --------> N2/C21
-        // [Line2] N1/C13 ------------------> N3/C31
-        // [Line3] N1/C11 ---------------------------------> N4/C41
-        // =================================================
-        //         N1/C21 -----+--> N2/C21 ------------+
-        //                    /                         \
-        //         N1/C11 ---+                           +-> N4/C41
-        //                    \                         /
-        //                     +------------> N3/C31 --+
-        //                    /
-        //         N1/C13 ---+
+        /// <summary>
+        ///
+        ///      N1            N2     N3          N4
+        /// [L1] C11 --------> C21
+        /// [L2] C11 ---------------> C31
+        /// [L1] C12 --------> C21
+        /// [L2] C13 ---------------> C31
+        /// [L3] C11 ---------------------------> C41
+        /// =========================================
+        ///      C12 -----+--> C21 ---------+
+        ///              /                   \
+        ///      C11 ---+                     +-> C41
+        ///              \                   /
+        ///               +---------> C31 --+
+        ///              /
+        ///      C13 ---+
+        /// </summary>
         [TestMethod]
-        public void JoinPathsAndShareGrandDaughter()
+        public void 間接的な壊変経路の設定が分岐合流を網羅する()
         {
-            decaySet.AddDecayPath(Line1, C11, C21, null);
-            decaySet.AddDecayPath(Line2, C11, C31, null);
-
-            decaySet.DecayChains.Count.ShouldBe(1);
-            var chain1 = decaySet.DecayChains[0];
+            decaySet.AddDecayPath(L1, C11, C21, null);
+            decaySet.AddDecayPath(L2, C11, C31, null);
             {
-                chain1[N1].ShouldBe((Line1, C11));
-                chain1[N2].ShouldBe((Line1, C21));
-                chain1[N3].ShouldBe((Line2, C31));
+                decaySet.DecayChains.Count.ShouldBe(1);
+                var chain1 = decaySet.DecayChains[0];
+
+                chain1[N1].ShouldBe((L1, C11));
+                chain1[N2].ShouldBe((L1, C21));
+                chain1[N3].ShouldBe((L2, C31));
+
+                decaySet.JointChains[C11].ShouldBe([chain1]);
+                decaySet.JointChains[C21].ShouldBe([chain1]);
+                decaySet.JointChains[C31].ShouldBe([chain1]);
             }
-            decaySet.JointChains[C11].ShouldBe([chain1]);
-            decaySet.JointChains[C21].ShouldBe([chain1]);
-            decaySet.JointChains[C31].ShouldBe([chain1]);
 
-            decaySet.AddDecayPath(Line3, C12, C21, null);
-            decaySet.AddDecayPath(Line4, C13, C31, null);
-
-            decaySet.DecayChains.Count.ShouldBe(3);
-            var chain2 = decaySet.DecayChains[1];
+            decaySet.AddDecayPath(L3, C12, C21, null);
+            decaySet.AddDecayPath(L4, C13, C31, null);
             {
-                chain2[N1].ShouldBe((Line3, C12));
-                chain2[N2].ShouldBe((Line3, C21));
+                decaySet.DecayChains.Count.ShouldBe(3);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+
+                chain2[N1].ShouldBe((L3, C12));
+                chain2[N2].ShouldBe((L3, C21));
                 chain2[N3].ShouldBe(default);
-            }
-            var chain3 = decaySet.DecayChains[2];
-            {
-                chain3[N1].ShouldBe((Line4, C13));
+
+                chain3[N1].ShouldBe((L4, C13));
                 chain3[N2].ShouldBe(default);
-                chain3[N3].ShouldBe((Line4, C31));
-            }
-            decaySet.JointChains[C12].ShouldBe([chain2]);
-            decaySet.JointChains[C13].ShouldBe([chain3]);
-            decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
-            decaySet.JointChains[C31].ShouldBe([chain1, chain3], ignoreOrder: true);
+                chain3[N3].ShouldBe((L4, C31));
 
-            // chain1の中でC41への経路を設定した時点で、chain1に加えて
-            // C21に合流している崩壊系列chain2とC31に合流している崩壊系列chain3も
+                decaySet.JointChains[C12].ShouldBe([chain2]);
+                decaySet.JointChains[C13].ShouldBe([chain3]);
+                decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
+                decaySet.JointChains[C31].ShouldBe([chain1, chain3], ignoreOrder: true);
+            }
+
+            // chain1の中でC41への経路を設定した時点で、これに加えて
+            // C21に合流している崩壊系列chain2と
+            // C31に合流している崩壊系列chain3も
             // C41を共有する崩壊系列として判定される。
-            decaySet.AddDecayPath(Line5, C11, C41, null);
-
-            decaySet.DecayChains.Count.ShouldBe(3);
+            decaySet.AddDecayPath(L5, C11, C41, null);
             {
-                chain1[N4].ShouldBe((Line5, C41));
-                chain2[N4].ShouldBe((Line5, C41));
-                chain3[N4].ShouldBe((Line5, C41));
+                decaySet.DecayChains.Count.ShouldBe(3);
+                var chain1 = decaySet.DecayChains[0];
+                var chain2 = decaySet.DecayChains[1];
+                var chain3 = decaySet.DecayChains[2];
+
+                chain1[N4].ShouldBe((L5, C41));
+                chain2[N4].ShouldBe((L5, C41));
+                chain3[N4].ShouldBe((L5, C41));
+
+                decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3], ignoreOrder: true);
             }
-            decaySet.JointChains[C41].ShouldBe([chain1, chain2, chain3], ignoreOrder: true);
         }
     }
 
     /// <summary>
     /// 直接的・間接的な壊変経路の設定を混合した場合でも、系列内の壊変経路が正しく接続されることを確認する。
+    /// 
+    /// N1 -+-> N2 -+-+-> N3 -+-> N4 --> (stable)
+    ///      \       X       /
+    ///       +-----+ +-----+
     /// </summary>
-    // N1 -+-> N2 -+-+-> N3 -+-> N4 --> (stable)
-    //      \       X       /
-    //       +-----+ +-----+
     [TestClass]
-    public class ComplexDecayChain
+    public class DecayChainType_Ladder
     {
         readonly NuclideData N1; readonly Organ C1;
         readonly NuclideData N2; readonly Organ C2;
@@ -1072,7 +2125,7 @@ public class DecaySetTests
         readonly DecaySet decaySet;
         readonly InputErrors errors = new();
 
-        public ComplexDecayChain()
+        public DecayChainType_Ladder()
         {
             N1 = new NuclideData { Index = 0, Name = "N1", };
             N2 = new NuclideData { Index = 1, Name = "N2", IsProgeny = true, };
@@ -1180,9 +2233,8 @@ public class DecaySetTests
         }
     }
 
-
     [TestClass]
-    public class DecayChainTestsX
+    public class InputAndDecayChainTests
     {
         // Sb-129 -+-> Te-129m -+-+-> Te-129 -+-> I-129 --> (Xe-129)
         //          \            X           /
@@ -1190,7 +2242,6 @@ public class DecaySetTests
 
         private static string[] GetInflows(Organ organ) => [.. organ.Inflows.Select(i => i.Organ.ToString())];
 
-#if false
         /// <summary>
         /// 直接的・間接的な壊変経路の設定を混合した場合でも、系列内の壊変経路が正しく接続されることを確認する。
         /// </summary>
@@ -1340,7 +2391,6 @@ public class DecaySetTests
                 ]),
             };
         }
-#endif
 
         /// <summary>
         /// 移行速度付き壊変経路を設定する際の開始核種によらず、系列内の壊変経路が正しく接続されることを確認する。

--- a/FlexID.Core.Tests/DecaySetTests.cs
+++ b/FlexID.Core.Tests/DecaySetTests.cs
@@ -67,7 +67,7 @@ public class DecaySetTests
         [DataRow(1.23)]
         public void SinglePath(double? coeff)
         {
-            var organDecay = decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff);
+            decaySet.AddDecayPath(Line1, C11, C21, (decimal?)coeff);
             errors.GetErrorLines().ShouldBe([]);
 
             decaySet.DecayChains.Count.ShouldBe(1);
@@ -83,11 +83,13 @@ public class DecaySetTests
             }
             else
             {
+                var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == ((decimal)coeff, C21)).Key;
+
                 chain1[N1].ShouldBe((Line1, C11));
-                chain1[N2].ShouldBe((Line1, organDecay));
+                chain1[N2].ShouldBe((Line1, d21));
 
                 decaySet.JointChains[C11].ShouldBe([chain1]);
-                decaySet.JointChains[organDecay].ShouldBe([chain1]);
+                decaySet.JointChains[d21].ShouldBe([chain1]);
             }
         }
 
@@ -132,15 +134,14 @@ public class DecaySetTests
             // 2つの経路設定は、終端側がC21で合流しているように見えるが
             // 2つ目の経路は移行速度付きのため実際はN2位置で壊変コンパートメントが自動作成され、
             // 従ってこれらは独立した2つの壊変経路を作成する。
-            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);   // 壊変経路1
-            var d21 = decaySet.AddDecayPath(Line2, C12, C21, 123m);   // 壊変経路2: 経路1とは関係ない
+            decaySet.AddDecayPath(Line1, C11, C21, null);   // 壊変経路1
+            decaySet.AddDecayPath(Line2, C12, C21, 123m);   // 壊変経路2: 経路1とは関係ない
             errors.GetErrorLines().ShouldBe([]);
-            d11.ShouldBeNull();
-            d21.ShouldNotBeNull();
 
             decaySet.DecayChains.Count.ShouldBe(2);
             var chain1 = decaySet.DecayChains[0];
             var chain2 = decaySet.DecayChains[1];
+            var d21 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C21)).Key;
 
             chain1[N1].ShouldBe((Line1, C11));
             chain1[N2].ShouldBe((Line1, C21));
@@ -193,13 +194,10 @@ public class DecaySetTests
         {
             // 核種N2で合流が発生した場合、その子孫核種であるN3のコンパートメントは
             // 自動的に合流した2つの系列で共有される。
-            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);
-            var d21 = decaySet.AddDecayPath(Line2, C12, C21, null);
-            var d31 = decaySet.AddDecayPath(Line3, C21, C31, null);
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, null);
             errors.GetErrorLines().ShouldBe([]);
-            d11.ShouldBeNull();
-            d21.ShouldBeNull();
-            d31.ShouldBeNull();
 
             decaySet.DecayChains.Count.ShouldBe(2);
             var chain1 = decaySet.DecayChains[0];
@@ -270,17 +268,15 @@ public class DecaySetTests
         {
             // 合流が発生した核種N2の子孫核種N3の位置が壊変コンパートメントである場合も、
             // 自動的に合流した2つの系列で共有される。
-            var d11 = decaySet.AddDecayPath(Line1, C11, C21, null);
-            var d21 = decaySet.AddDecayPath(Line2, C12, C21, null);
-            var d31 = decaySet.AddDecayPath(Line3, C21, C31, 123m);
+            decaySet.AddDecayPath(Line1, C11, C21, null);
+            decaySet.AddDecayPath(Line2, C12, C21, null);
+            decaySet.AddDecayPath(Line3, C21, C31, 123m);
             errors.GetErrorLines().ShouldBe([]);
-            d11.ShouldBeNull();
-            d21.ShouldBeNull();
-            d31.ShouldNotBeNull();
 
             decaySet.DecayChains.Count.ShouldBe(2);
             var chain1 = decaySet.DecayChains[0];
             var chain2 = decaySet.DecayChains[1];
+            var d31 = decaySet.AfterDecayPath.First(p => p.Value.Outflow == (123m, C31)).Key;
 
             chain1[N1].ShouldBe((Line1, C11));
             chain1[N2].ShouldBe((Line1, C21));
@@ -540,9 +536,9 @@ public class DecaySetTests
             decaySet.AddDecayPath(Line2, C11, C22, (decimal?)coeff2);
             errors.GetErrorLines().ShouldBe(
             [
-                $"Line {Line2}: Decay paths conflict each other:",
-                $"    the previous: '{C11}' --> '{C21}'" + (coeff1 is null ? "": $" (with coeff. {coeff1.Value})") + $" at Line {Line1}",
-                $"    and here    : '{C11}' --> '{C22}'" + (coeff2 is null ? "": $" (with coeff. {coeff2.Value})"),
+                $"Line {Line2}: Conflict of decay path definitions found:",
+                $"Line {Line1}:     previous, decay to '{C21}' {(coeff1 is null ? "without coefficient": $"with coefficient {coeff1.Value}")},",
+                $"Line {Line2}:     and here, decay to '{C22}' {(coeff2 is null ? "without coefficient": $"with coefficient {coeff2.Value}")}.",
             ]);
         }
 
@@ -586,9 +582,9 @@ public class DecaySetTests
             decaySet.AddDecayPath(Line4, C12, C32, null);
             errors.GetErrorLines().ShouldBe(
             [
-                $"Line {Line4}: Decay paths conflict each other:",
-                $"    the previous: '{C12}' --> '{C31}'" + $" at Line {Line3}",
-                $"    and here    : '{C12}' --> '{C32}'",
+                $"Line {Line4}: Conflict of decay path definitions found:",
+                $"Line {Line3}:     previous, decay to '{C31}' without coefficient,",
+                $"Line {Line4}:     and here, decay to '{C32}' without coefficient.",
             ]);
         }
 
@@ -624,9 +620,9 @@ public class DecaySetTests
             decaySet.AddDecayPath(Line4, C12, C21, null);
             errors.GetErrorLines().ShouldBe(
             [
-                $"Line 4: Decay paths conflict each other:",
-                $"    the previous: '{C21}' --> '{C31}' at Line {Line1}",
-                $"    and another : '{C21}' --> '{C32}' at Line {Line2}",
+                $"Line 4: Conflict of decay path definitions found:",
+                $"Line 1:     previous,  decay to '{C31}' without coefficient,",
+                $"Line 2:     and there, decay to '{C32}' without coefficient.",
             ]);
         }
 
@@ -874,7 +870,7 @@ public class DecaySetTests
             var chain1 = decaySet.DecayChains[0];
             var chain2 = decaySet.DecayChains[1];
 
-            chain1[N1].ShouldBe(default);
+            chain1[N1].ShouldBe((Line3, C11));
             chain1[N2].ShouldBe((Line1, C21));
             chain1[N3].ShouldBe((Line1, C31));
 
@@ -882,7 +878,7 @@ public class DecaySetTests
             chain2[N2].ShouldBe((Line3, C21));
             chain2[N3].ShouldBe((Line2, C31));
 
-            decaySet.JointChains[C11].ShouldBe([chain2]);
+            decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
             decaySet.JointChains[C21].ShouldBe([chain1, chain2], ignoreOrder: true);
             decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
         }
@@ -933,11 +929,11 @@ public class DecaySetTests
             chain1[N2].ShouldBe((Line3, C21));
             chain1[N3].ShouldBe((Line1, C31));
 
-            chain2[N1].ShouldBe(default);
+            chain2[N1].ShouldBe((Line3, C11));
             chain2[N2].ShouldBe((Line2, C21));
             chain2[N3].ShouldBe((Line2, C31));
 
-            decaySet.JointChains[C11].ShouldBe([chain1]);
+            decaySet.JointChains[C11].ShouldBe([chain1, chain2], ignoreOrder: true);
             decaySet.JointChains[C21].ShouldBe([chain2, chain1], ignoreOrder: true);
             decaySet.JointChains[C31].ShouldBe([chain1, chain2], ignoreOrder: true);
         }

--- a/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_ing_Other.log
+++ b/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_ing_Other.log
@@ -123,9 +123,6 @@ Transfers:
   Y-90/RS-con                  -> Y-90/Faeces          = 2
   Y-90/Blood1                  -> Y-90/UB-con          = 2.49
   Y-90/UB-con                  -> Y-90/Urine           = 12
-  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/SI-con                  -> Y-90/Blood1          = 0.0006000600060006
   Y-90/SI-conRe                -> Y-90/Blood1          = 0.0006000600060006
   Y-90/Blood2                  -> Y-90/Blood1          = 0.462
@@ -138,6 +135,9 @@ Transfers:
   Y-90/T-bone-V                -> Y-90/Blood1          = 0.000493
   Y-90/C-bone-S                -> Y-90/Blood1          = 8.21E-05
   Y-90/C-bone-V                -> Y-90/Blood1          = 8.21E-05
+  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/Blood1                  -> Y-90/Blood2          = 0.498
   Y-90/Blood1                  -> Y-90/ST0             = 3.652
   Y-90/Blood1                  -> Y-90/ST1             = 1.328

--- a/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_ing_Titanate.log
+++ b/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_ing_Titanate.log
@@ -123,9 +123,6 @@ Transfers:
   Y-90/RS-con                  -> Y-90/Faeces          = 2
   Y-90/Blood1                  -> Y-90/UB-con          = 2.49
   Y-90/UB-con                  -> Y-90/Urine           = 12
-  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/SI-con                  -> Y-90/Blood1          = 0.0006000600060006
   Y-90/SI-conRe                -> Y-90/Blood1          = 0.0006000600060006
   Y-90/Blood2                  -> Y-90/Blood1          = 0.462
@@ -138,6 +135,9 @@ Transfers:
   Y-90/T-bone-V                -> Y-90/Blood1          = 0.000493
   Y-90/C-bone-S                -> Y-90/Blood1          = 8.21E-05
   Y-90/C-bone-V                -> Y-90/Blood1          = 8.21E-05
+  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/Blood1                  -> Y-90/Blood2          = 0.498
   Y-90/Blood1                  -> Y-90/ST0             = 3.652
   Y-90/Blood1                  -> Y-90/ST1             = 1.328

--- a/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeF.log
+++ b/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeF.log
@@ -272,9 +272,6 @@ Transfers:
   Y-90/RS-con                  -> Y-90/Faeces          = 2
   Y-90/Blood1                  -> Y-90/UB-con          = 2.49
   Y-90/UB-con                  -> Y-90/Urine           = 12
-  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/ALV-F                   -> Y-90/Blood1          = 30
   Y-90/INT-F                   -> Y-90/Blood1          = 30
   Y-90/bb-F                    -> Y-90/Blood1          = 30
@@ -307,6 +304,9 @@ Transfers:
   Y-90/T-bone-V                -> Y-90/Blood1          = 0.000493
   Y-90/C-bone-S                -> Y-90/Blood1          = 8.21E-05
   Y-90/C-bone-V                -> Y-90/Blood1          = 8.21E-05
+  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/Blood1                  -> Y-90/Blood2          = 0.498
   Y-90/Blood1                  -> Y-90/ST0             = 3.652
   Y-90/Blood1                  -> Y-90/ST1             = 1.328

--- a/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeM.log
+++ b/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeM.log
@@ -272,9 +272,6 @@ Transfers:
   Y-90/RS-con                  -> Y-90/Faeces          = 2
   Y-90/Blood1                  -> Y-90/UB-con          = 2.49
   Y-90/UB-con                  -> Y-90/Urine           = 12
-  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/ALV-F                   -> Y-90/Blood1          = 3
   Y-90/INT-F                   -> Y-90/Blood1          = 3
   Y-90/bb-F                    -> Y-90/Blood1          = 3
@@ -307,6 +304,9 @@ Transfers:
   Y-90/T-bone-V                -> Y-90/Blood1          = 0.000493
   Y-90/C-bone-S                -> Y-90/Blood1          = 8.21E-05
   Y-90/C-bone-V                -> Y-90/Blood1          = 8.21E-05
+  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/Blood1                  -> Y-90/Blood2          = 0.498
   Y-90/Blood1                  -> Y-90/ST0             = 3.652
   Y-90/Blood1                  -> Y-90/ST1             = 1.328

--- a/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeS.log
+++ b/FlexID.Core.Tests/TestFiles/TrialCalc/Expect_OIR/Sr-90/Sr-90_inh_Aerosols-TypeS.log
@@ -272,9 +272,6 @@ Transfers:
   Y-90/RS-con                  -> Y-90/Faeces          = 2
   Y-90/Blood1                  -> Y-90/UB-con          = 2.49
   Y-90/UB-con                  -> Y-90/Urine           = 12
-  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
-  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/ALV-F                   -> Y-90/Blood1          = 3
   Y-90/INT-F                   -> Y-90/Blood1          = 3
   Y-90/bb-F                    -> Y-90/Blood1          = 3
@@ -307,6 +304,9 @@ Transfers:
   Y-90/T-bone-V                -> Y-90/Blood1          = 0.000493
   Y-90/C-bone-S                -> Y-90/Blood1          = 8.21E-05
   Y-90/C-bone-V                -> Y-90/Blood1          = 8.21E-05
+  Y-90/<decay_from_Sr-90/ST0>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST1>  -> Y-90/Blood1          = 0.23105
+  Y-90/<decay_from_Sr-90/ST2>  -> Y-90/Blood1          = 0.23105
   Y-90/Blood1                  -> Y-90/Blood2          = 0.498
   Y-90/Blood1                  -> Y-90/ST0             = 3.652
   Y-90/Blood1                  -> Y-90/ST1             = 1.328

--- a/FlexID.Core/DecaySet.cs
+++ b/FlexID.Core/DecaySet.cs
@@ -2,14 +2,12 @@ using System.Diagnostics;
 
 namespace FlexID;
 
-#nullable disable
-
 /// <summary>
 /// インプットで設定されてる壊変経路の集合から、
 /// 暗黙に構成される崩壊系列の集合を計算する。またこれらの中で
 /// 暗黙に作成される壊変コンパートメントを取り扱う。
 /// </summary>
-internal class DecaySet
+public class DecaySet
 {
     /// <summary>
     /// 処理対象となる核種のリスト。
@@ -32,14 +30,15 @@ internal class DecaySet
     public List<Organ> DecayCompartments { get; } = [];
 
     /// <summary>
-    /// コンパートメントをキーとし、当該位置を共有する崩壊系列のリストを値とする辞書。
+    /// 定義済みのコンパートメントをキーとし、当該位置を共有する崩壊系列のリストを値とする辞書。
     /// </summary>
     public Dictionary<Organ, List<DecayChain>> JointChains { get; } = [];
 
     /// <summary>
-    /// 移行速度付きの壊変経路が移行した先(organDecay)をキーとし、そこから同じ核種のまま移行した先とその係数を値とする辞書。
+    /// 移行速度付きの壊変経路に対して自動作成されたOrganDecayをキーとし、
+    /// そこから同じ核種のまま移行した先であるOragnToとその係数Coeffを値とする辞書。
     /// </summary>
-    private Dictionary<Organ, (Organ OrganTo, decimal? Coeff)> AfterDecayPath { get; } = [];
+    public Dictionary<Organ, (int LineNum, (decimal Coeff, Organ OrganTo) Outflow)> AfterDecayPath { get; } = [];
 
     /// <summary>
     /// コンストラクタ。
@@ -51,7 +50,7 @@ internal class DecaySet
         Nuclides = nuclides;
         Errors = errors;
 
-        nuclideAncestors = Nuclides.Select(root =>
+        nuclideAncestors = [.. Nuclides.Select(root =>
         {
             // 対象核種を末端とする崩壊系列を構成する祖先核種を列挙する。
             var results = new List<NuclideData> { root };
@@ -72,9 +71,9 @@ internal class DecaySet
             // rootを除いた、祖先核種のみの配列を返す。
             results.RemoveAt(0);
             return (IReadOnlyList<NuclideData>)results;
-        }).ToArray();
+        })];
 
-        nuclideProgenies = Nuclides.Select(root =>
+        nuclideProgenies = [.. Nuclides.Select(root =>
         {
             // 対象核種を始点とする崩壊系列を構成する子孫核種を列挙する。
             var results = new List<NuclideData> { root };
@@ -95,7 +94,7 @@ internal class DecaySet
             // rootを除いた、子孫核種のみの配列を返す。
             results.RemoveAt(0);
             return (IReadOnlyList<NuclideData>)results;
-        }).ToArray();
+        })];
     }
 
     private readonly IReadOnlyList<NuclideData>[] nuclideAncestors;
@@ -109,7 +108,7 @@ internal class DecaySet
     /// <summary>
     /// 対象コンパートメントの核種から始まる崩壊系列の情報を保持する。
     /// </summary>
-    internal class DecayChain
+    public class DecayChain
     {
         /// <summary>
         /// コンストラクタ。
@@ -117,26 +116,25 @@ internal class DecaySet
         /// <param name="nuclideCount">核種の総数。</param>
         public DecayChain(int nuclideCount)
         {
-            Compartments = new (int, Organ)[nuclideCount];
+            Compartments = new (int, Organ?)[nuclideCount];
         }
 
         /// <summary>
         /// 崩壊系列において、これを構成する核種毎の位置を占めるコンパートメントを保持する。
         /// </summary>
-        public (int LineNum, Organ Organ)[] Compartments;
+        public (int LineNum, Organ? Organ)[] Compartments;
 
         /// <summary>
         /// 指定の子孫核種に対応する壊変コンパートメントを取得する。
         /// </summary>
         /// <param name="progeny"></param>
         /// <returns></returns>
-        public ref (int LineNum, Organ Organ) this[NuclideData progeny] => ref Compartments[progeny.Index];
+        public ref (int LineNum, Organ? Organ) this[NuclideData progeny] => ref Compartments[progeny.Index];
 
-        public bool IsSubsetOf(DecayChain other)
-        {
-            return other.Compartments.Zip(this.Compartments)
-                        .All(x => x.Item1.Organ == x.Item2.Organ || x.Item2.Organ is null);
-        }
+        public bool IsSubsetOf(DecayChain other) =>
+            other.Compartments
+                 .Zip(this.Compartments)
+                 .All(x => x.First.Organ == x.Second.Organ || x.Second.Organ is null);
 
         public override string ToString()
         {
@@ -151,280 +149,249 @@ internal class DecaySet
     /// <param name="organFrom"></param>
     /// <param name="organTo"></param>
     /// <param name="coeff"></param>
-    /// <remarks>organFrom + organTo + coeffの組み合わせは高々1回だけ与えられることを前提としている。</remarks>
-    /// <returns></returns>
-    public Organ AddDecayPath(int lineNum, Organ organFrom, Organ organTo, decimal? coeff)
+    public void AddDecayPath(int lineNum, Organ organFrom, Organ organTo, decimal? coeff)
     {
         var nuclideFrom = organFrom.Nuclide;
         var nuclideTo = organTo.Nuclide;
-        var hasCoeff = coeff is not null;
 
         // 分岐比が不明な壊変経路は定義できない。
         if (!GetProgenies(nuclideFrom).Contains(nuclideTo))
         {
             Errors.AddError(lineNum, $"There is no decay path from {nuclideFrom.Name} to {nuclideTo.Name}.");
-            return null;
+            return;
         }
 
-        // organFrom位置を共有する崩壊系列の1つをtargetChainとして取得する。
-        DecayChain targetChain;
-        if (JointChains.TryGetValue(organFrom, out var chainsFrom))
+        List<DecayChain> GetJointChainsAt(Organ organ)
         {
-            targetChain = chainsFrom[0];
-        }
-        else if (!hasCoeff &&
-            JointChains.TryGetValue(organTo, out chainsFrom) && chainsFrom.Count == 1 &&
-            GetAncestors(nuclideTo).All(ancestor => chainsFrom[0][ancestor].Organ is null))
-        {
-            // nuclideTo位置を通るただ1つの崩壊系列が、nuclideToの祖先核種全てについてコンパートメント未設定の場合に、
-            // これをorganFrom位置も通る崩壊系列として扱い、これに対してorganFromからorganToへの経路を「接ぎ木」する。
-            targetChain = chainsFrom[0];
-            targetChain[nuclideFrom] = (lineNum, organFrom);
-
-            chainsFrom = [targetChain];
-            JointChains.Add(organFrom, chainsFrom);
-        }
-        else
-        {
-            targetChain = new DecayChain(Nuclides.Count);
-            DecayChains.Add(targetChain);
-
-            ref var decayFrom = ref targetChain[nuclideFrom];
-            decayFrom = (lineNum, organFrom);
-
-            chainsFrom = [targetChain];
-            JointChains.Add(organFrom, chainsFrom);
+            if (!JointChains.TryGetValue(organ, out var chains))
+                JointChains.Add(organ, chains = []);
+            return chains;
         }
 
-        // organFromから壊変によって生成された子孫核種を
-        // nuclideTo位置で受けるためのコンパートメントorganDecayを取得する。
-        Organ organDecay;
+        void AddJointChainsAt(int lineNum, Organ organ, DecayChain chain)
         {
-            var decayTo = targetChain[nuclideTo];
-            bool consistentPath;
-            if (hasCoeff)
+            chain[organ.Nuclide] = (lineNum, organ);
+
+            if (!JointChains.TryGetValue(organ, out var chains))
+                JointChains.Add(organ, [chain]);
+            else if (!chains.Contains(chain))
+                chains.Add(chain);
+        }
+
+        // organFrom位置を共有する崩壊系列のリストを取得する。
+        var chainsFrom = GetJointChainsAt(organFrom);
+
+        // 移行速度付きの壊変経路を処理する場合は、organToを
+        // organFromで生成された核種をnuclideTo位置で直接受け止めるための
+        // 暗黙生成されるコンパートメントに置き換える。
+        if (coeff is not null)
+        {
+            // 元々のorganToを、崩壊系列のnuclideTo位置から移行係数coeffで流出する経路の移行先として保存する。
+            var organOutflowTo = organTo;
+
+            // 新しいorganToとして、organFrom位置を共有する崩壊系列において既にnuclideTo位置を占めるものが
+            // 有ればそれを、無ければ新しい壊変コンパートメントを取得する。
+            organTo = chainsFrom.FirstOrDefault()?[nuclideTo].Organ
+                   ?? CreateDecayCompartment(nuclideTo, organFrom.Func);
+
+            if (organTo.IsDecayCompartment == false)
             {
-                organDecay = decayTo.Organ;
+                // 以前に設定されたorganFromからorganToへ速度なし壊変経路が
+                // 今回の設定と衝突するため、これについてエラーを報告する。
+                var prevNum = chainsFrom[0][nuclideTo].LineNum;
+                Errors.AddError(lineNum, $"Conflict of decay path definitions found:");
+                Errors.AddError(prevNum, $"    previous, decay to '{organTo}' without coefficient,");
+                Errors.AddError(lineNum, $"    and here, decay to '{organOutflowTo}' with coefficient {coeff.Value}.");
+                return;
+            }
 
-                if (decayTo.Organ is null)
+            var path2 = (LineNum: lineNum, Outflow: (Coeff: coeff.Value, OrganTo: organOutflowTo));
+            if (!AfterDecayPath.TryGetValue(organTo, out var path1))
+            {
+                AfterDecayPath[organTo] = path2;
+            }
+            else if (path1.Outflow != path2.Outflow)
+            {
+                // 以前に設定されたorganToからnucideToモデル内へ流出する経路が
+                // 今回の設定と衝突するため、これについてエラーを報告する。
+                var prevNum = path1.LineNum;
+                var outflow1 = path1.Outflow;
+                var outflow2 = path2.Outflow;
+                Errors.AddError(lineNum, $"Conflict of decay path definitions found:");
+                Errors.AddError(prevNum, $"    previous, decay to '{outflow1.OrganTo}' with coefficient {outflow1.Coeff},");
+                Errors.AddError(lineNum, $"    and here, decay to '{outflow2.OrganTo}' with coefficient {outflow2.Coeff}.");
+                return;
+            }
+        }
+
+        // organTo位置を共有する崩壊系列のリストを取得する。
+        var chainsTo = GetJointChainsAt(organTo);
+
+        var ancestorsOfTo = GetAncestors(nuclideTo);
+
+        if (chainsFrom.Count != 0)
+        {
+            // chainsFromに含まれる崩壊系列は、nuclideToより子孫の全ての位置について同じ共有状態を持つため
+            // nuclideTo位置の整合性確認にはその1つだけを対象とすればよい。
+            var chainFrom = chainsFrom[0];
+
+            // organFromを共有している崩壊系列は、全てがorganTo位置も暗黙に共有していることになるため
+            // ここでorganTo位置の共有を明示的に設定し、矛盾する場合はエラーを報告する。
+            ref var decay = ref chainFrom[nuclideTo];
+            if (decay.Organ is null)
+            {
+                // chainsToも更新される。
+                foreach (var chain in chainsFrom)
+                    AddJointChainsAt(lineNum, organTo, chain);
+            }
+            else if (decay.Organ != organTo)
+            {
+                ConflictDecayPathsError(decay!, (lineNum, organTo));
+                return;
+            }
+
+            // nuclideFromより子孫の核種位置で合流しorganTo位置へ流入する崩壊系列の集合は、
+            // organFrom位置を通過していないためchainsFromには含まれない、またその中でも
+            // organTo位置をまだ共有していないものはchainsToにも含まれていないため、
+            // ここでこれらを収集し、organTo位置の共有を設定する。
+            foreach (var ancestor in GetProgenies(nuclideFrom).Intersect(ancestorsOfTo))
+            {
+                var organAncestor = chainFrom[ancestor].Organ;
+                if (organAncestor is null)
+                    continue;
+
+                var chainsMore = JointChains[organAncestor].Except(chainsTo).ToList();
+                if (chainsMore.Count == 0)
+                    continue;
+
+                // chainsMoreに含まれる崩壊系列は、ancestorより子孫の全ての位置について同じ共有状態を持つため
+                // nuclideTo位置の整合性確認にはその1つだけを対象とすればよい。
+                var chainMore = chainsMore[0];
+
+                // chainsMoreはancestor位置でchainsFromと既に合流しているため、
+                // もしnuclideTo位置について共有済み(decay.Organ != null)であるならば
+                // すなわちchainsMoreはchainsToに既に含まれているはずであり、
+                // これはchainsMoreの取得条件と矛盾するため、
+                // 従ってnuclideTo位置については必ず未共有(decay.Organ is null)であることが成り立つ。
+                decay = ref chainMore[nuclideTo];
+                Debug.Assert(decay.Organ is null);
+
+                // chainsToも更新されうる。
+                foreach (var chain in chainsMore)
+                    AddJointChainsAt(lineNum, organTo, chain);
+            }
+        }
+
+        // 移行速度がない壊変経路では、organTo位置を共有する崩壊系列は、
+        // 基本的にはnuclideFrom位置を共有せず、nuclideTo位置で合流するだけの
+        // 独立した壊変経路の集合として考える必要がある。
+        // 従ってここでは、nuclideToより祖先の位置全てにまだ共有を持たない崩壊系列群を対象に
+        // organFrom位置の共有を設定する。
+        foreach (var chain in chainsTo.Where(c => ancestorsOfTo.All(n => c[n].Organ is null)))
+        {
+            // chainsFromも更新される。
+            AddJointChainsAt(lineNum, organFrom, chain);
+        }
+
+        if (chainsFrom.Count == 0)
+        {
+            // 今回設定されているorganFromからorganToへの壊変経路の情報を格納する
+            // 既存の崩壊系列が存在しないため、これを行う新しい崩壊系列を作成する。
+            var chain = new DecayChain(Nuclides.Count);
+            DecayChains.Add(chain);
+
+            AddJointChainsAt(lineNum, organFrom, chain);
+            AddJointChainsAt(lineNum, organTo, chain);
+        }
+        else if (chainsTo.Count == 0)
+        {
+            // organFrom位置を共有する全ての崩壊系列は、
+            // nuclideFrom位置より子孫の全ての位置についても既に共有済みであるため
+            // ここではこれ以上何もしなくてよい。
+            return;
+        }
+
+        var chainsMerged = chainsFrom.Concat(chainsTo).Distinct().ToList();
+        if (chainsMerged.Count != 0)
+        {
+            // organToを共有する全ての崩壊系列は、nuclideTo位置より子孫の全ての位置を互いに共有する必要がある。
+            foreach (var progeny in GetProgenies(nuclideTo))
+            {
+                var decay1 = chainsMerged.Select(chain => chain[progeny]).FirstOrDefault(d => d.Organ is not null);
+
+                // progeny位置はchainsMergedのすべての崩壊系列で未設定なので、これ以上は何もしない。
+                if (decay1.Organ is null)
+                    continue;
+                var organProgeny1 = decay1.Organ;
+
+                foreach (var chain in chainsMerged)
                 {
-                    organDecay = CreateDecayCompartment(nuclideTo, organFrom.Func);
-                    AfterDecayPath.Add(organDecay, (organTo, coeff));
-                    consistentPath = true;
-                }
-                else
-                {
-                    // 係数付きの壊変経路は、nuclideTo位置を高々一度だけ占めることができる。
-                    // 言い換えると、以前の経路設定でnuclideTo位置を(係数あり・なしにかかわらず)
-                    // 既に占めている場合はエラーにする。
-                    #region 詳細な説明
+                    ref var decay2 = ref chain[progeny];
+                    if (decay2.Organ is null)
+                    {
+                        AddJointChainsAt(decay1.LineNum, organProgeny1, chain);
+                        continue;
+                    }
+                    if (decay2.Organ == organProgeny1)
+                        continue;
+                    var organProgeny2 = decay2.Organ;
 
-                    // 係数なしの壊変経路の場合は、同じ崩壊系列を辿る場合でもfromが違えば経路設定が可能となっている。
-                    // 具体例を示すと：
-                    //   N1/C1 -> N2/C2 -> N3/C3 の崩壊系列に対して以下の3つの経路設定を行う場合に、
-                    //   - N1/C1 -> N2/C2
-                    //   - N1/C1 -> N3/C3 (経路A)
-                    //   - N2/C2 -> N3/C3 (経路B)
-                    //   これらをどのような順序で設定しても経路Aと経路Bが衝突なく受け付けられる。
-                    //   このとき、設定順序によってはDecayChainが2個作成され得るが、その場合でも設定順序に関係なく
-                    //   2つのDecayChainのN1,N2,N3位置のそれぞれはC1,C2,C3の3つのコンパートメントによって共有され、
-                    //   従って最終的にただ1つの崩壊系列を構成するためである。
-                    //
-                    // しかし係数付きの壊変経路では、organDecayを経路設定時に明示できないため、もしここで禁止している
-                    // 経路設定を受け付けると、設定順序に依存する挙動が生じる。
-                    // 具体例を示すと：
-                    //   N1/C1 -> N2/C2 -> N3/C3 の崩壊系列に対して以下の3つの経路設定を行う場合に、
-                    //   - N1/C1 -> N2/C2
-                    //   - N1/C1 -> N3/C3 + 移行速度 (経路X)
-                    //   - N2/C2 -> N3/C3 + 移行速度 (経路Y)
-                    //
-                    //     設定順序A：
-                    //     (1) N1/C1 -> N2/C2
-                    //     (2) N1/C1 -> N3/C3 + 移行速度 (経路X)
-                    //     (3) N2/C2 -> N3/C3 + 移行速度 (経路Y)
-                    //     …(2)の時点で DecayChain1 { C1, C2, organDecay } だけが作成される
-                    //     …(3)の時点で設定される経路Yは、この1つだけ存在するDecayChain1の一部と判断できるため、
-                    //       経路Yの設定は経路Xと衝突せず受け付けられる。
-                    //     
-                    //     設定順序B：
-                    //     (1) N1/C1 -> N3/C3 + 移行速度 (経路X)
-                    //     (2) N2/C2 -> N3/C3 + 移行速度 (経路Y)
-                    //     (3) N1/C1 -> N2/C2
-                    //     …(1)の時点で DecayChain1 { C1, null, organDecay1 } が作成される。
-                    //     …(2)の時点で DecayChain2 { null, C2, organDecay2 } が作成される。これは経路Yの設定が
-                    //       N3位置についてorganDecay1を明示できず、従ってDecayChain1とこれを共有するかどうかを
-                    //       この時点では判断できないためである。
-                    //       ※ 例えば、もしこの後に N1/C1 -> N4/C41 と N2/C2 -> N4/C42 という2つの経路設定が行われる場合、
-                    //          明らかにDecayChain1とDecayChain2は独立した2つの崩壊系列を構成することになる。
-                    //     …(3)の経路設定によって、DecayChain1とDecayChain2の2つがN1,N2位置についてそれぞれC1,C2を共有する形が作られるが、
-                    //       N3位置についてはorganDecay1とorganDecay2という異なるコンパートメントが設定済みであるため、
-                    //       2つの崩壊系列の分岐が検出されてエラーが報告される。
-                    //
-                    // このように設定順序に依存してエラーの有無が変わることを避けるため、
-                    // 係数付きの壊変経路では、経路Yを設定しようとした時点でエラーを報告する仕様としている。
+                    if (organProgeny1.IsDecayCompartment && organProgeny2.IsDecayCompartment)
+                    {
+                        var outflow1 = AfterDecayPath[organProgeny1].Outflow;
+                        var outflow2 = AfterDecayPath[organProgeny2].Outflow;
+                        if (outflow1 == outflow2)
+                        {
+                            // organProgenyからprogenyの動態モデルに入るための移行先と速度(outflow1)が
+                            // decay.Organ からprogenyの動態モデルに入るためのもの(outflow2)と一致する場合は
+                            // 後者を前者にマージする。
+                            decay2.Organ = organProgeny1;
 
-                    #endregion
-                    consistentPath = false;
+                            JointChains[organProgeny1].AddRange(JointChains[organProgeny2]);
+                            JointChains.Remove(organProgeny2);
+
+                            AfterDecayPath.Remove(organProgeny2);
+                            continue;
+                        }
+                    }
+
+                    ConflictDecayPathsError(decay1!, decay2!);
+                    return;
                 }
+            }
+        }
+
+        void ConflictDecayPathsError((int LineNum, Organ Organ) decay1, (int LineNum, Organ Organ) decay2)
+        {
+            if (decay1.LineNum > decay2.LineNum)
+                (decay1, decay2) = (decay2, decay1);
+
+            var (leading1, leading2) = decay2.LineNum == lineNum
+                ? ("previous,", "and here,")
+                : ("previous, ", "and there,");
+
+            Errors.AddError(lineNum, $"Conflict of decay path definitions found:");
+
+            if (decay1.Organ.IsDecayCompartment)
+            {
+                var outflow1 = AfterDecayPath[decay1.Organ].Outflow;
+                Errors.AddError(decay1.LineNum, $"    {leading1} decay to '{outflow1.OrganTo}' with coefficient {outflow1.Coeff},");
             }
             else
             {
-                organDecay = organTo;
-
-                if (decayTo.Organ is null)
-                {
-                    consistentPath = true;
-                }
-                else
-                {
-                    // 以前に設定された係数なしの壊変経路と、organDecay(== organTo)が整合している。
-                    consistentPath = decayTo.Organ == organDecay;
-                }
+                Errors.AddError(decay1.LineNum, $"    {leading1} decay to '{decay1.Organ}' without coefficient,");
             }
 
-            if (!consistentPath)
+            if (decay2.Organ.IsDecayCompartment)
             {
-                // 今回と前回の矛盾する2つの設定経路について、
-                // nuclideFrom位置からnuclideTo位置までを表示する。
-                var (prevTo, prevCoeff) = AfterDecayPath.GetValueOrDefault(decayTo.Organ, (decayTo.Organ, null));
-                var prev = $"'{prevTo.ToString()}'";
-                if (prevCoeff is decimal v) prev += $" (with coeff. {v})";
-
-                var here = $"'{organTo.ToString()}'";
-                if (hasCoeff) here += $" (with coeff. {coeff.Value})";
-
-                Errors.AddError(lineNum, "Decay paths conflict each other:");
-                Errors.AddError($"    the previous: '{organFrom}' --> {prev} at Line {decayTo.LineNum}");
-                Errors.AddError($"    and here    : '{organFrom}' --> {here}");
-                return null;
+                var outflow2 = AfterDecayPath[decay2.Organ].Outflow;
+                Errors.AddError(decay2.LineNum, $"    {leading2} decay to '{outflow2.OrganTo}' with coefficient {outflow2.Coeff}.");
+            }
+            else
+            {
+                Errors.AddError(decay2.LineNum, $"    {leading2} decay to '{decay2.Organ}' without coefficient.");
             }
         }
-
-        // nuclideTo位置に新たに合流する崩壊系列の集合を取得する。
-        var chainsInflow = CalcChainsInflow(targetChain, nuclideTo);
-
-        // organDecay位置を共有する崩壊系列のリストを取得する。
-        if (!JointChains.TryGetValue(organDecay, out var chainsTo))
-        {
-            chainsTo = chainsInflow;
-
-            // chainsToのnuclideTo位置にorganDecayを設定する。
-            foreach (var chain in chainsTo)
-            {
-                Debug.Assert(chain[nuclideTo].Organ is null);
-                chain[nuclideTo] = (lineNum, organDecay);
-            }
-
-            // organDecay位置を共有する崩壊系列群を設定する。
-            JointChains.Add(organDecay, chainsTo);
-        }
-        else
-        {
-            // chainsToに含まれる、言い換えるとnuclideTo位置を既に
-            // organDecayで占めている崩壊系列をchainsInflowから除外する。
-            // その結果、chainsToへ追加されるべき崩壊系列が0個となる場合は何もしない。
-            chainsInflow.RemoveAll(chain => chainsTo.Contains(chain));
-            if (chainsInflow.Count == 0)
-                goto Lend;
-
-            // ここからの処理で、
-            // organDecay位置を既に占めている崩壊系列群chainsToに
-            // organDecay位置へ新たに合流する崩壊系列群chainsInflowを追加する。
-
-            // chainsInflowのnuclideTo位置にorganDecayを設定する。
-            foreach (var chain in chainsInflow)
-            {
-                Debug.Assert(chain[nuclideTo].Organ is null);
-                chain[nuclideTo] = (lineNum, organDecay);
-            }
-
-            // chainsToとchainsInflowの間に、nuclideToより子孫核種の位置で矛盾がないことを確認する。
-            // 比較処理のために、2つの集合からそれぞれ1つずつ代表となる崩壊系列を取得する。
-            var chainTo = chainsTo[0];
-            var chainInflow = chainsInflow[0];
-            foreach (var progeny in GetProgenies(nuclideTo))
-            {
-                var decayTo = chainTo[progeny];
-                var decayInflow = chainInflow[progeny];
-
-                // 全ての崩壊系列がprogeny位置をまだ共有していない場合は何もしない。
-                if (decayInflow.Organ is null && decayTo.Organ is null)
-                    continue;
-
-                if (decayTo.Organ is null)
-                {
-                    foreach (var chain in chainsTo)
-                        chain[progeny] = decayInflow;
-                }
-                else if (decayInflow.Organ is null)
-                {
-                    foreach (var chain in chainsInflow)
-                        chain[progeny] = decayTo;
-                }
-                else if (decayTo.Organ != decayInflow.Organ)
-                {
-                    // nuclideTo位置より子孫のコンパートメントが全て共有されるべきにもかかわらず
-                    // nuclideToの子孫核種progenyの位置で分岐が生じてしまう2つの壊変経路について、
-                    // nuclideTo位置からprogeny位置までを表示する。
-                    var organStart = chainTo[nuclideTo].Organ;
-
-                    var (prevTo, prevCoeff) = AfterDecayPath.GetValueOrDefault(decayTo.Organ, (decayTo.Organ, null));
-                    var prev = $"'{prevTo.ToString()}'";
-                    if (prevCoeff.HasValue) prev += $" (with coeff. {prevCoeff.Value})";
-
-                    var (hereTo, hereCoeff) = AfterDecayPath.GetValueOrDefault(decayInflow.Organ, (decayInflow.Organ, null));
-                    var here = $"'{hereTo.ToString()}'";
-                    if (hereCoeff.HasValue) here += $" (with coeff. {hereCoeff.Value})";
-
-                    Errors.AddError(lineNum, "Decay paths conflict each other:");
-                    Errors.AddError($"    the previous: '{organStart}' --> {prev} at Line {decayTo.LineNum}");
-                    Errors.AddError($"    and another : '{organStart}' --> {here} at Line {decayInflow.LineNum}");
-                    return null;
-                }
-
-                // progeny位置を共有する崩壊系列にchainsInflowを追加する。
-                var chainsProgeny = JointChains[decayTo.Organ];
-                foreach (var chain in chainsInflow)
-                {
-                    if (!chainsProgeny.Contains(chain))
-                        chainsProgeny.Add(chain);
-                }
-            }
-
-            chainsTo.AddRange(chainsInflow);
-        }
-
-    Lend:
-        // chainsToの全ての崩壊系列は、nuclideTo位置でorganDecayコンパートメントを共有している。
-        Debug.Assert(chainsTo.All(chain => chain[nuclideTo].Organ == organDecay));
-
-        return hasCoeff ? organDecay : null;
-    }
-
-    /// <summary>
-    /// targetChain上でnuclideTo位置に流入している崩壊系列の集合を計算する。
-    /// </summary>
-    /// <param name="targetChain"></param>
-    /// <param name="nuclideTo"></param>
-    /// <returns>結果を新しいリストに格納して返す。結果には少なくともtargetChainが含まれる。</returns>
-    private List<DecayChain> CalcChainsInflow(DecayChain targetChain, NuclideData nuclideTo)
-    {
-        List<DecayChain> results = [targetChain];
-
-        // targetChain上で、nuclideToの祖先核種の位置を確認し、コンパートメントが設定済みの箇所については
-        // それらの位置を共有する崩壊系列を全て取得しそれらの集合を返す。
-        foreach (var nuclide in GetAncestors(nuclideTo))
-        {
-            if (targetChain[nuclide].Organ is not Organ organ)
-                continue;
-            foreach (var chain in JointChains[organ])
-            {
-                if (!results.Contains(chain))
-                    results.Add(chain);
-            }
-        }
-
-        return results;
     }
 
     /// <summary>
@@ -435,7 +402,7 @@ internal class DecaySet
     {
         foreach (var decayChain in DecayChains)
         {
-            var froms = decayChain.Compartments.Select(o => o.Organ).Where(o => o != null).ToList();
+            var froms = decayChain.Compartments.Select(o => o.Organ).OfType<Organ>().ToList();
 
             // デバッグ用
             var decayCompartmentName = $"<decay_from_{froms[0].Nuclide.Name}/{froms[0].Name}>";

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -253,9 +253,15 @@ public class InputDataReader_OIR : InputDataReaderBase
         // 全てのコンパートメントを定義する。
         DefineCompartments(data);
 
+        // コンパートメント定義にエラーがないことを確定する。
+        errors.RaiseIfAny();
+
         // コンパートメント間の移行経路を定義する。
         DefineIntakes(data);
         DefineTransfers(data);
+
+        // 移行経路の定義にエラーがないことを確定する。
+        errors.RaiseIfAny();
 
         // 流入を持たないコンパートメントをマークする。
         MarkZeroInflows(data);
@@ -1078,9 +1084,6 @@ public class InputDataReader_OIR : InputDataReaderBase
 
             nuclide.OtherSourceRegions = otherSourceRegions;
         }
-
-        // コンパートメント定義にエラーがないことを確定する。
-        errors.RaiseIfAny();
     }
 
     /// <summary>
@@ -1187,11 +1190,11 @@ public class InputDataReader_OIR : InputDataReaderBase
 
             organTo.Inflows.Add(new Inflow
             {
-                ID = organFrom.ID,
-                Rate = inflowRate,
-
                 // 流入経路から流入元臓器の情報を直接引くための参照を設定する。
+                ID = organFrom.ID,
                 Organ = organFrom,
+
+                Rate = inflowRate,
             });
         }
     }
@@ -1369,8 +1372,13 @@ public class InputDataReader_OIR : InputDataReaderBase
     /// <param name="data"></param>
     private void DefineTransfers(InputData data)
     {
+        var olderrorsN = errors.Count;
+
         var decaySet = new DecaySet(data.Nuclides, errors);
         var parser = new TransferParser(inputNuclides, data.Organs, inputEvaluators, errors);
+
+        // 有効な移行経路の定義を収集する
+        var correctTransfers = new List<(int lineNum, Organ from, Organ to, decimal coeff)>();
 
         foreach (var nuclide in inputNuclides)
         {
@@ -1381,15 +1389,8 @@ public class InputDataReader_OIR : InputDataReaderBase
             if (!inputTransfers.TryGetValue(nuc, out var transfers))
                 continue;
 
-            var olderrorsN = errors.Count;
-            var sectionLineNum = transferSectionLocs[nuc];
-
             var evaluator = inputEvaluators[nuclide];
 
-            // 移行経路の定義が正しいことの確認と、
-            // 各コンパートメントから流出する移行係数の総計を求める。
-            var transfersCorrect = new List<(int lineNum, Organ from, Organ to, decimal coeff)>();
-            var sumOfOutflowCoeff = new Dictionary<Organ, decimal>();
             foreach (var transfer in transfers)
             {
                 if (!parser.TryParse(nuclide, transfer, out var result))
@@ -1411,40 +1412,50 @@ public class InputDataReader_OIR : InputDataReaderBase
                     // あるいはインプットで定義済みのコンパートメントを直接使用することで、
                     // 以下のような経路に構成し直す。
                     //   Parent/organFrom
-                    //      ↓
+                    //   ↓
                     //   Progeny_1/organDecay
-                    //   ： ：
-                    //   ↓ ↓
-                    //   ↓ Progeny_i/organDecay --(coeff)--> Progeny_i/organTo  ①移行速度あり
-                    //   ↓ Progeny_i/organDecay == organTo                      ②移行速度なし
-                    //   ↓ ：
-                    //   ↓ ↓
-                    //   Progeny_N/organDecay
+                    //   ：
+                    //   ↓
+                    //   Progeny_i/organDecay --(coeff)--> Progeny_i/organTo  ①移行速度あり
+                    //   Progeny_i/organDecay == organTo                      ②移行速度なし
 
-                    var organDecay = decaySet.AddDecayPath(lineNum, organFrom, organTo, coeff);
-                    if (organDecay is null)
-                        continue;
-
-                    // 以降の処理を核種が同じコンパートメント間organDecay -> organToの経路設定にすり替える。
-                    organFrom = organDecay;
+                    decaySet.AddDecayPath(lineNum, organFrom, organTo, coeff);
                 }
-
-                if (coeff is decimal coeff_v)
+                else
                 {
-                    if (!sumOfOutflowCoeff.TryGetValue(organFrom, out var sum))
-                        sum = 0;
-                    sumOfOutflowCoeff[organFrom] = sum + coeff_v;
+                    // パース処理によって、同じ核種での移行経路では必ず移行係数が存在する。
+                    Debug.Assert(coeff is not null);
+
+                    correctTransfers.Add((lineNum, organFrom, organTo, coeff.Value));
                 }
-
-                transfersCorrect.Add((lineNum, organFrom, organTo, coeff ?? 0));
             }
+        }
 
-            // 核種nuclideの動態モデルに入る移行経路にエラーがないことを確定する。
-            if (errors.IfAny(olderrorsN))
+        // 移行速度付き壊変経路によって核種のモデルへ流入する経路を追加する。
+        foreach (var (organDecay, (lineNum, (coeff, organTo))) in decaySet.AfterDecayPath)
+        {
+            correctTransfers.Add((lineNum, organDecay, organTo, coeff));
+        }
+
+        // 全ての核種について陽に設定された移行経路と係数にエラーがないことを確定する。
+        if (errors.IfAny(olderrorsN))
+            return;
+
+        // 各コンパートメントから流出する移行係数の総計を処理する。
+        var sumOfOutflowCoeff = new Dictionary<Organ, decimal>();
+        foreach (var (_, organFrom, organTo, coeff) in correctTransfers)
+        {
+            if (!sumOfOutflowCoeff.TryGetValue(organFrom, out var sum))
+                sum = 0;
+            sumOfOutflowCoeff[organFrom] = sum + coeff;
+        }
+        foreach (var nuclide in inputNuclides)
+        {
+            if (!CalcProgeny && nuclide.IsProgeny)
                 continue;
 
-            // あるコンパートメントから同じ核種のまま流出する全ての移行経路について処理する。
-            var outflowGroups = transfersCorrect.GroupBy(t => t.from);
+            // あるコンパートメントから同じ核種のまま流出する全ての移行経路について取り扱う。
+            var outflowGroups = correctTransfers.GroupBy(t => t.from);
             foreach (var outflows in outflowGroups)
             {
                 if (!outflows.Any())
@@ -1452,13 +1463,13 @@ public class InputDataReader_OIR : InputDataReaderBase
                 var organFrom = outflows.Key;
                 var nameFrom = organFrom.Name;
 
-                if (organFrom.IsInstantOutflow)
+                if (organFrom.Func == OrganFunc.mix)
                 {
                     // 流出路毎の移行割合を合計したものが1.0 == 100%かどうかを確認する。
                     var sum = sumOfOutflowCoeff[organFrom];
                     if (sum != 1)
                     {
-                        var ts = transfersCorrect.Where(t => t.from == organFrom).OrderBy(t => t.lineNum).ToArray();
+                        var ts = correctTransfers.Where(t => t.from == organFrom).OrderBy(t => t.lineNum).ToArray();
                         for (int i = 0; i < ts.Length; i++)
                         {
                             var (lineNum, _, _, coeff) = ts[i];
@@ -1474,50 +1485,35 @@ public class InputDataReader_OIR : InputDataReaderBase
                     if (organFrom.Func == OrganFunc.acc)
                         organFrom.BioDecay = (double)sumOfOutflowCoeff[organFrom];
                 }
-
-                // GetDecayChain(organFrom);
-            }
-
-            // 核種nuclideの動態モデルに入る移行経路と係数にエラーがないことを確定する。
-            if (errors.IfAny(olderrorsN))
-                continue;
-
-            // 核種が同じコンパートメントへの流入経路と、移行割合を設定する。
-            foreach (var (_, organFrom, organTo, coeff) in transfersCorrect)
-            {
-                double inflowRate;
-                if (organFrom.IsInstantOutflow)
-                {
-                    // fromからtoへの移行割合 = 移行割合[%]
-                    inflowRate = (double)coeff;
-                }
-                else
-                {
-                    var sum = sumOfOutflowCoeff[organFrom];
-
-                    // fromからtoへの移行割合 = 移行速度[/d]
-                    inflowRate = (double)coeff;
-                }
-
-                organTo.Inflows.Add(new Inflow
-                {
-                    ID = organFrom.ID,
-                    Rate = inflowRate,
-
-                    // 流入経路から流入元臓器の情報を直接引くための参照を設定する。
-                    Organ = organFrom,
-                });
             }
         }
 
-        // 全ての核種について陽に設定された移行経路と係数にエラーがないことを確定する。
-        errors.RaiseIfAny();
+        // 核種nuclideの動態モデルに入る移行経路と係数にエラーがないことを確定する。
+        if (errors.IfAny(olderrorsN))
+            return;
+
+        // 核種が同じコンパートメントへの流入経路と、移行割合を設定する。
+        foreach (var (_, organFrom, organTo, coeff) in correctTransfers)
+        {
+            // fromからtoへの移行割合 = 移行速度[/d] or 移行割合[%]
+            var inflowRate = (double)coeff;
+
+            organTo.Inflows.Add(new Inflow
+            {
+                // 流入経路から流入元臓器の情報を直接引くための参照を設定する。
+                ID = organFrom.ID,
+                Organ = organFrom,
+
+                Rate = inflowRate,
+            });
+        }
 
         // 核種が異なるコンパートメントへの流入経路と、移行割合を設定する。
         decaySet.DefineDecayTransfers(data.Organs);
 
         // 移行経路の定義にエラーがないことを確定する。
-        errors.RaiseIfAny();
+        if (errors.IfAny(olderrorsN))
+            return;
 
         // 壊変経路の充足を確認する。
         VerifyDecayPaths(data);


### PR DESCRIPTION
崩壊経路が`N1` -> `N2`  -> `N3`とあり、それぞれのコンパートメントが`N1/C1`, `N2/C2`, `N3/C3`と定義されている場合に、以下のような移行経路定義を行うと、(3)の箇所でエラーが発生していた。

```
[N2:transfer]
  N1/C1  C2     ---       # 壊変経路定義(1)
[N3:transfer]
  N1/C1  C3     1.23    # 壊変経路定義(2)
  N2/C2  C3     1.23    # 壊変経路定義(3)
```

これは同じ壊変コンパートメント位置を通過する複数の経路定義が見つかった場合に、この重複を適切に処理できないという（半ば意図的な）従来処理の制約に起因していたが、今回、同じ位置に重複する壊変コンパートメントのマージ処理を導入することによってこの制約を解除し、意図する経路定義を実施できるように改良した。

合わせて、壊変経路の処理クラス`DecaySet`に対する単体テストを刷新・拡充も行った。