### PR TITLE
インプット定義に核種パターンを導入する

### DIFF
--- a/FlexID.Core.Tests/InputErrorTests.cs
+++ b/FlexID.Core.Tests/InputErrorTests.cs
@@ -86,33 +86,6 @@ public class InputErrorTests
     }
 
     [TestMethod]
-    public void MissingSectionErrors2()
-    {
-        var reader = CreateReader("""
-            [title]
-            dummy
-
-            [nuclide]
-              Sr-90  6.596156E-05
-
-            [intake]
-              ST0    100%
-
-            # [Sr-90:compartment]
-            #   acc    ST0       ---
-
-            # [Sr-90:transfer]
-            """);
-
-        var e = new Action(() => reader.Read()).ShouldThrow<InputErrorsException>();
-        e.ErrorLines.ShouldBe(
-        [
-            "Line 14: Missing [Sr-90:compartment] section.",
-            "Line 14: Missing [Sr-90:transfer] section.",
-        ]);
-    }
-
-    [TestMethod]
     public void EmptySectionErrors1()
     {
         var reader = CreateReader("""

--- a/FlexID.Core.Tests/InputEvaluatorTests.cs
+++ b/FlexID.Core.Tests/InputEvaluatorTests.cs
@@ -33,6 +33,17 @@ public class InputEvaluatorTests
         return lines;
     }
 
+    private IReadOnlyList<string> TestReadCompartment(int lineNum, string input, out string result)
+    {
+        result = input;
+        if (evaluator.TryReadCompartment(lineNum, ref result))
+            return [];
+
+        var lines = new Action(() => errors.RaiseIfAny()).ShouldThrow<InputErrorsException>().ErrorLines.ToArray();
+        errors.Clear();
+        return lines;
+    }
+
     [TestMethod]
     public void DefineVariable()
     {
@@ -134,5 +145,25 @@ public class InputEvaluatorTests
         var actualToET2S = result.value;
         expectToET2S.ShouldBe((1m - 0.01m) * (1.0m - 0.002m) * 0.2582m);
         expectToET2S.ShouldBe(actualToET2S);
+    }
+
+    [TestMethod]
+    public void CalcCompartment()
+    {
+        string result;
+
+        TestReadCompartment(LineNum, "abc", out result).ShouldBeEmpty();
+        result.ShouldBe("abc");
+
+        TestReadCompartment(LineNum, """$('abc' + 'def')""", out result).ShouldBeEmpty();
+        result.ShouldBe("abcdef");
+
+        TestReadCompartment(LineNum, """$('a\'bc' + "d\"ef")""", out result).ShouldBeEmpty();
+        result.ShouldBe("a'bcd\"ef");
+
+        TestReadCompartment(LineNum, "abc def", out result).ShouldBe(new[]
+        {
+            "Expected a compartment name, not 'abc def'.",
+        });
     }
 }

--- a/FlexID.Core.Tests/InputOtherCalcTests.cs
+++ b/FlexID.Core.Tests/InputOtherCalcTests.cs
@@ -322,7 +322,11 @@ public class InputOtherCalcTests
         var e = new Action(() => reader.Read()).ShouldThrow<InputErrorsException>();
         e.ErrorLines.ShouldBe(
         [
-            "Line 10: Both of C/T-marrow and R/Y-marrow source region pairs are used.",
+            "Line 12: Both of C/T-marrow and R/Y-marrow source region pairs are used for nuclide 'Th-232'.",
+            "Line 12:     acc  C-marrow  C-marrow",
+            "Line 13:     acc  T-marrow  T-marrow",
+            "Line 14:     acc  R-marrow  R-marrow",
+            "Line 15:     acc  Y-marrow  Y-marrow",
         ]);
     }
 }

--- a/FlexID.Core.Tests/InputParserTests.cs
+++ b/FlexID.Core.Tests/InputParserTests.cs
@@ -9,6 +9,7 @@ class StringifyVisitor : Visitor<string>
 {
     public string Var(string ident) => ident;
     public string Number(string value, string unit) => $"{value}{unit}";
+    public string String(string value) => $"'{value.Replace("'", "\\'")}'";
     public string Pos(string expr) => $"+{expr}";
     public string Neg(string expr) => $"-{expr}";
     public string Add(string left, string right) => $"({left} + {right})";
@@ -68,6 +69,24 @@ public class InputParserTests
     }
 
     [TestMethod]
+    public void ParseString()
+    {
+        var (Success, Failure) = MakeTesters(parser.StringExpr);
+
+        Success(@"''");
+        Success(@"'abc'");
+        Success(@"""abc""");
+        Success(@"'a\nc'");
+        Success(@"'a\\c'");
+
+        Failure(@"abc");
+        Failure(@"'abc");
+        Failure(@"""abc");
+        Failure(@"'abc""");
+        Failure(@"""abc'");
+    }
+
+    [TestMethod]
     public void ParseUnaryExpr()
     {
         var (Success, Failure) = MakeTesters(parser.Expr);
@@ -110,10 +129,12 @@ public class InputParserTests
         Success("ident")    /**/.ShouldBe("ident");
         Success("1234")     /**/.ShouldBe("1234");
         Success("3.1415")   /**/.ShouldBe("3.1415");
+        Success("'abc'")    /**/.ShouldBe("'abc'");
 
         Success("(ident)")  /**/.ShouldBe("ident");
         Success("(1234)")   /**/.ShouldBe("1234");
         Success("(3.1415)") /**/.ShouldBe("3.1415");
+        Success("('abc')")  /**/.ShouldBe("'abc'");
 
         Success("-(1.2 + +(a * b) - (-c / +d))");
 

--- a/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Pb-210.inp
+++ b/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Pb-210.inp
@@ -11,36 +11,8 @@ Pb-210 DecayCalc
 [intake]
   C   100.0%
 
-
-[Pb-210:compartment]
+[{*}:compartment]
   acc   C   ---
 
-[Pb-210:transfer]
-
-
-[Bi-210:compartment]
-  acc   C   ---
-
-[Bi-210:transfer]
-  Pb-210/C  Bi-210/C    ---
-
-
-[Po-210:compartment]
-  acc   C   ---
-
-[Po-210:transfer]
-  Pb-210/C  Po-210/C    ---
-
-
-[Hg-206:compartment]
-  acc   C   ---
-
-[Hg-206:transfer]
-  Pb-210/C  Hg-206/C    ---
-
-
-[Tl-206:compartment]
-  acc   C   ---
-
-[Tl-206:transfer]
-  Pb-210/C  Tl-206/C    ---
+[{*}:transfer]
+  {*}/C     C    ---

--- a/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Pb-212.inp
+++ b/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Pb-212.inp
@@ -11,29 +11,8 @@ Pb-212 DecayCalc
 [intake]
   C   100.0%
 
-
-[Pb-212:compartment]
+[{*}:compartment]
   acc   C   ---
 
-[Pb-212:transfer]
-
-
-[Bi-212:compartment]
-  acc   C   ---
-
-[Bi-212:transfer]
-  Pb-212/C  Bi-212/C    ---
-
-
-[Po-212:compartment]
-  acc   C   ---
-
-[Po-212:transfer]
-  Pb-212/C  Po-212/C    ---
-
-
-[Tl-208:compartment]
-  acc   C   ---
-
-[Tl-208:transfer]
-  Pb-212/C  Tl-208/C    ---
+[{*}:transfer]
+  {*}/C     C    ---

--- a/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Ra-224.inp
+++ b/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Ra-224.inp
@@ -11,50 +11,8 @@ Ra-224 DecayCalc
 [intake]
   C   100.0%
 
-
-[Ra-224:compartment]
+[{*}:compartment]
   acc   C   ---
 
-[Ra-224:transfer]
-
-
-[Rn-220:compartment]
-  acc   C   ---
-
-[Rn-220:transfer]
-  Ra-224/C  Rn-220/C    ---
-
-
-[Po-216:compartment]
-  acc   C   ---
-
-[Po-216:transfer]
-  Ra-224/C  Po-216/C    ---
-
-
-[Pb-212:compartment]
-  acc   C   ---
-
-[Pb-212:transfer]
-  Ra-224/C  Pb-212/C    ---
-
-
-[Bi-212:compartment]
-  acc   C   ---
-
-[Bi-212:transfer]
-  Ra-224/C  Bi-212/C    ---
-
-
-[Po-212:compartment]
-  acc   C   ---
-
-[Po-212:transfer]
-  Ra-224/C  Po-212/C    ---
-
-
-[Tl-208:compartment]
-  acc   C   ---
-
-[Tl-208:transfer]
-  Ra-224/C  Tl-208/C    ---
+[{*}:transfer]
+  {*}/C     C    ---

--- a/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Th-232.inp
+++ b/FlexID.Core.Tests/TestFiles/TestCalc/DecayActivityTest_Th-232.inp
@@ -12,78 +12,8 @@ Th-232 DecayCalc
 [intake]
   C   100.0%
 
-
-[Th-232:compartment]
+[{*}:compartment]
   acc   C   ---
 
-[Th-232:transfer]
-
-
-[Ra-228:compartment]
-  acc   C   ---
-
-[Ra-228:transfer]
-  Th-232/C  Ra-228/C    ---
-
-
-[Ac-228:compartment]
-  acc   C   ---
-
-[Ac-228:transfer]
-  Th-232/C  Ac-228/C    ---
-
-
-[Th-228:compartment]
-  acc   C   ---
-
-[Th-228:transfer]
-  Th-232/C  Th-228/C    ---
-
-
-[Ra-224:compartment]
-  acc   C   ---
-
-[Ra-224:transfer]
-  Th-232/C  Ra-224/C    ---
-
-
-[Rn-220:compartment]
-  acc   C   ---
-
-[Rn-220:transfer]
-  Th-232/C  Rn-220/C    ---
-
-
-[Po-216:compartment]
-  acc   C   ---
-
-[Po-216:transfer]
-  Th-232/C  Po-216/C    ---
-
-
-[Pb-212:compartment]
-  acc   C   ---
-
-[Pb-212:transfer]
-  Th-232/C  Pb-212/C    ---
-
-
-[Bi-212:compartment]
-  acc   C   ---
-
-[Bi-212:transfer]
-  Th-232/C  Bi-212/C    ---
-
-
-[Po-212:compartment]
-  acc   C   ---
-
-[Po-212:transfer]
-  Th-232/C  Po-212/C    ---
-
-
-[Tl-208:compartment]
-  acc   C   ---
-
-[Tl-208:transfer]
-  Th-232/C  Tl-208/C    ---
+[{*}:transfer]
+  {*}/C     C    ---

--- a/FlexID.Core/DecaySet.cs
+++ b/FlexID.Core/DecaySet.cs
@@ -101,9 +101,9 @@ public class DecaySet
 
     private readonly IReadOnlyList<NuclideData>[] nuclideProgenies;
 
-    private IReadOnlyList<NuclideData> GetAncestors(NuclideData nuclide) => nuclideAncestors[nuclide.Index];
+    public IReadOnlyList<NuclideData> GetAncestors(NuclideData nuclide) => nuclideAncestors[nuclide.Index];
 
-    private IReadOnlyList<NuclideData> GetProgenies(NuclideData nuclide) => nuclideProgenies[nuclide.Index];
+    public IReadOnlyList<NuclideData> GetProgenies(NuclideData nuclide) => nuclideProgenies[nuclide.Index];
 
     /// <summary>
     /// 対象コンパートメントの核種から始まる崩壊系列の情報を保持する。

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -937,8 +937,8 @@ public class InputDataReader_OIR : InputDataReaderBase
 
             var otherSourceRegions = new List<string>(otherSourceRegionsBase);
             var otherCompartments = new List<Organ>();
-            var anyCTmarrow = false;
-            var anyRYmarrow = false;
+            List<(int LineNum, Organ Organ)> organsCTmarrow = [];
+            List<(int LineNum, Organ Organ)> organsRYmarrow = [];
             bool? otherContainsMineralBone;
 
             // Otherから無機質骨の体積組織(C-bone-VとT-bone-V)への分配について制御する。
@@ -1007,9 +1007,9 @@ public class InputDataReader_OIR : InputDataReaderBase
                     otherSourceRegions.Remove(sourceRegion);
 
                     if (sourceRegion == "C-marrow" || sourceRegion == "T-marrow")
-                        anyCTmarrow = true;
+                        organsCTmarrow.Add((lineNum, organ));
                     if (sourceRegion == "R-marrow" || sourceRegion == "Y-marrow")
-                        anyRYmarrow = true;
+                        organsRYmarrow.Add((lineNum, organ));
 
                     if (sourceRegion == "Other")
                         otherCompartments.Add(organ);
@@ -1048,7 +1048,7 @@ public class InputDataReader_OIR : InputDataReaderBase
                 otherSourceRegions.Remove("T-bone-V");
             }
 
-            if (anyCTmarrow)
+            if (organsCTmarrow.Any())
             {
                 // C/T-marrowがコンパートメントとして明示されている場合は、
                 // OtherからR/Y-marrowへの分配を行わないようにする。
@@ -1056,8 +1056,15 @@ public class InputDataReader_OIR : InputDataReaderBase
                 otherSourceRegions.Remove("Y-marrow");
 
                 // C/T-marrowとR/Y-marrowの組み合わせが両方同時に使用されている場合はエラーとする。
-                if (anyRYmarrow)
-                    errors.AddError(sectionLineNum, "Both of C/T-marrow and R/Y-marrow source region pairs are used.");
+                if (organsRYmarrow.Any())
+                {
+                    var marrowOrgans = organsCTmarrow.Concat(organsRYmarrow).OrderBy(o => o.LineNum).ToArray();
+                    var firstLineNum = marrowOrgans.First().LineNum;
+                    var maxOrganNameLength = marrowOrgans.Max(o => o.Organ.Name.Length);
+                    errors.AddError(firstLineNum, $"Both of C/T-marrow and R/Y-marrow source region pairs are used for nuclide '{nuclide.Name}'.");
+                    foreach (var (lineNum, organ) in marrowOrgans)
+                        errors.AddError(lineNum, $"    {organ.Func}  {organ.Name.PadRight(maxOrganNameLength)}  {organ.SourceRegion}");
+                }
             }
 
             nuclide.OtherSourceRegions = otherSourceRegions;

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -236,7 +236,7 @@ public class InputDataReader_OIR : InputDataReaderBase
 
         // コンパートメント間の移行経路を定義する。
         DefineIntakes(data);
-        DefineTransfers(data);
+        DefineTransfers(data, expander);
 
         // 移行経路の定義にエラーがないことを確定する。
         errors.RaiseIfAny();
@@ -300,7 +300,7 @@ public class InputDataReader_OIR : InputDataReaderBase
             }
             else if (header.EndsWith(":transfer", StringComparison.OrdinalIgnoreCase))
             {
-                conditionDirectiveState = ConditionDirectiveState.Disabled;
+                conditionDirectiveState = ConditionDirectiveState.OutsideBlock;
                 var i = header.IndexOf(':');
                 var nuc = header.Slice(0, i).ToString();
                 line = GetTransfers(nuc);
@@ -807,11 +807,13 @@ public class InputDataReader_OIR : InputDataReaderBase
                 continue;
             }
 
+            var parentOnly = IsParentOnly;
+
             var orgamFrom = values[0];
             var organTo = values[1];
             var coeff = values[2];      // 移行係数、[/d] or [%]
 
-            transfers.Add(new InputTransfer(LineNum, orgamFrom, organTo, IsBar(coeff) ? null : coeff));
+            transfers.Add(new InputTransfer(LineNum, parentOnly, orgamFrom, organTo, IsBar(coeff) ? null : coeff));
         }
         if (errors.IfAny(olderrors))
             return line;
@@ -1222,16 +1224,43 @@ public class InputDataReader_OIR : InputDataReaderBase
     /// インプットから読み取った移行経路定義の情報を保持する。
     /// </summary>
     /// <param name="LineNum">行番号。</param>
+    /// <param name="ParentOnly"></param>
     /// <param name="From">移行元コンパートメント。</param>
     /// <param name="To">移行先コンパートメント。</param>
     /// <param name="Coeff">移行係数。</param>
-    private record class InputTransfer(int LineNum, string From, string To, string? Coeff);
+    private record class InputTransfer(int LineNum, bool? ParentOnly, string From, string To, string? Coeff);
 
     private static bool IsDecayPath(Organ from, Organ to) => from.Nuclide != to.Nuclide;
 
+    private Dictionary<NuclideData, List<InputTransfer>> ExpandTransfers(InputNuclideExpander expander)
+    {
+        var resultTransfers = new Dictionary<NuclideData, List<InputTransfer>>();
+
+        foreach (var (nuc, inputs) in inputTransfers)
+        {
+            var lineNum = transferSectionLocs[nuc];
+
+            var olderrors = errors.Count;
+            var nuclides = expander.ExpandNuclides(lineNum, nuc);
+            if (errors.IfAny(olderrors))
+                continue;
+
+            foreach (var nuclide in nuclides)
+            {
+                if (!resultTransfers.TryGetValue(nuclide, out var results))
+                    resultTransfers.Add(nuclide, results = []);
+
+                results.AddRange(inputs);
+            }
+        }
+
+        return resultTransfers;
+    }
+
     private class TransferParser(
-        IReadOnlyList<NuclideData> nuclides,
         IReadOnlyList<Organ> organs,
+        DecaySet decaySet,
+        InputNuclideExpander expander,
         Dictionary<NuclideData, InputEvaluator> evaluators,
         InputErrors errors)
     {
@@ -1239,25 +1268,33 @@ public class InputDataReader_OIR : InputDataReaderBase
 
         public bool TryParse(
             NuclideData nuclide, InputTransfer transfer,
-            out (Organ OrganFrom, Organ OrganTo, decimal? Coeff) result)
+            out (IReadOnlyList<Organ> OrgansFrom, Organ OrganTo, decimal? Coeff) result)
         {
-            var evaluator = evaluators[nuclide];
-            var lineNum = transfer.LineNum;
-
             result = default;
 
             var olderrorsT = errors.Count;
+            var lineNum = transfer.LineNum;
 
             // 移行元コンパートメントを読み取る。
-            var nuclideFrom = nuclide;
+            IReadOnlyList<NuclideData> nuclidesFrom;
             var nameFrom = transfer.From;
+            var isFromPattern = false;
             if (nameFrom.IndexOf('/') is int i && i != -1)
             {
                 var nucFrom = nameFrom[..i];
                 nameFrom = nameFrom[(i + 1)..];
-                nuclideFrom = nuclides.FirstOrDefault(n => n.Name == nucFrom);
-                if (nuclideFrom is null)
-                    errors.AddError(lineNum, $"Undefined nuclide '{nucFrom}'.");
+
+                isFromPattern = nucFrom.StartsWith('{');
+                nuclidesFrom = expander.ExpandNuclides(lineNum, nucFrom);
+
+                // 移行元の核種がパターン指定されている場合は、nuclideの祖先核種に集合を狭める。
+                if (isFromPattern)
+                    nuclidesFrom = [.. nuclidesFrom.Intersect(decaySet.GetAncestors(nuclide))];
+            }
+            else
+            {
+                // 移行元と移行先が同じ核種の場合。
+                nuclidesFrom = [nuclide];
             }
 
             // 移行先コンパートメントを読み取る。
@@ -1267,7 +1304,7 @@ public class InputDataReader_OIR : InputDataReaderBase
             {
                 var nucTo = nameTo[..j];
                 nameTo = nameTo[(j + 1)..];
-                nuclideTo = nuclides.FirstOrDefault(n => n.Name == nucTo);
+                nuclideTo = decaySet.Nuclides.FirstOrDefault(n => n.Name == nucTo);
                 if (nuclideTo is null)
                 {
                     errors.AddError(lineNum, $"Undefined nuclide '{nucTo}'.");
@@ -1279,38 +1316,71 @@ public class InputDataReader_OIR : InputDataReaderBase
                 }
             }
 
-            // 以降の処理でnuclideFromとnuclideToの両方が存在していることを確定する。
+            // 以降の処理でnuclidesFromとnuclideToの両方が存在していることを確定する。
             if (errors.IfAny(olderrorsT))
                 return false;
-            Debug.Assert(nuclideFrom is not null);
             Debug.Assert(nuclideTo is not null);
 
-            var organFrom = organs.FirstOrDefault(o => o.Name == nameFrom && o.Nuclide == nuclideFrom);
-            var organTo = organs.FirstOrDefault(o => o.Name == nameTo && o.Nuclide == nuclideTo);
+            var evaluatorTo = evaluators[nuclideTo];
 
-            // 移行元と移行先のそれぞれがcompartmentセクションで定義済みかを確認する。
-            if (organFrom is null || organTo is null)
+            var organsFrom = GetOrgansFrom();
+            var organTo = GetOrganTo();
+
+            IReadOnlyList<Organ> GetOrgansFrom()
             {
-                if (organFrom is null)
-                    errors.AddError(lineNum, $"Undefined compartment '{nuclideFrom.Name}/{nameFrom}'.");
+                List<Organ> organsFrom = [];
+                foreach (var nuclideFrom in nuclidesFrom)
+                {
+                    var organFrom = organs.FirstOrDefault(o => o.Name == nameFrom && o.Nuclide == nuclideFrom);
+
+                    // 移行元がcompartmentセクションで定義済みかを確認する。
+                    if (organFrom is null)
+                    {
+                        // 壊変経路の親核種側がパターン指定されている場合は、移行元コンパートメントが見つからない状態を
+                        // エラーにはせず、経路定義が有効な経路を設定できないだけであるように扱う。
+                        if (!isFromPattern)
+                            errors.AddError(lineNum, $"Undefined compartment '{nuclideFrom.Name}/{nameFrom}'.");
+                        continue;
+                    }
+
+                    organsFrom.Add(organFrom);
+                }
+                return organsFrom;
+            }
+
+            Organ? GetOrganTo()
+            {
+                var organTo = organs.FirstOrDefault(o => o.Name == nameTo && o.Nuclide == nuclideTo);
+
+                // 移行先がcompartmentセクションで定義済みかを確認する。
                 if (organTo is null)
+                {
                     errors.AddError(lineNum, $"Undefined compartment '{nuclideTo.Name}/{nameTo}'.");
-            }
-            else if (organTo == organFrom)
-            {
-                // 自分自身への移行経路は定義できない。
-                errors.AddError(lineNum, "Cannot set transfer path to itself.");
-            }
-            else if (!definedTransfers.Add((organFrom, organTo)))
-            {
+                    return null;
+                }
+
+                // 自分自身への移行経路を定義していないことを確認する。
+                if (organsFrom.Contains(organTo))
+                {
+                    errors.AddError(lineNum, "Cannot set transfer path to itself.");
+                    return null;
+                }
+
                 // 同じ移行経路が複数回定義されていないことを確認する。
-                errors.AddError(lineNum, $"Duplicated transfer path from '{organFrom}' to '{organTo}'.");
+                foreach (var organFrom in organsFrom)
+                {
+                    if (!definedTransfers.Add((organFrom, organTo)))
+                        errors.AddError(lineNum, $"Duplicated transfer path from '{organFrom}' to '{organTo}'.");
+                }
+
+                return organTo!;
             }
 
-            // 以降の処理でorganFromとorganToの両方が存在していることを確定する。
+            // 以降の処理でorgansFromとorganToの両方が存在していることを確定する。
             if (errors.IfAny(olderrorsT))
                 return false;
-            Debug.Assert(organFrom is not null);
+            if (organsFrom is [])
+                return false;
             Debug.Assert(organTo is not null);
 
             var coeff = default(decimal?);
@@ -1318,7 +1388,7 @@ public class InputDataReader_OIR : InputDataReaderBase
             var hasCoeff = false;
             if (transfer.Coeff is not null)
             {
-                if (!evaluator.TryReadCoefficient(lineNum, transfer.Coeff, out var res))
+                if (!evaluatorTo.TryReadCoefficient(lineNum, transfer.Coeff, out var res))
                     return false;
                 (coeff, isFrac) = res;
                 hasCoeff = true;
@@ -1328,58 +1398,61 @@ public class InputDataReader_OIR : InputDataReaderBase
                     errors.AddError(lineNum, "Transfer coefficient should be positive.");
             }
 
-            // 設定された移行経路が有効かどうかを確認する。
-            var funcFrom = organFrom.Func;
-            var funcTo = organTo.Func;
-            if (IsDecayPath(organFrom, organTo))
+            foreach (var organFrom in organsFrom)
             {
-                if (funcFrom == OrganFunc.acc)
+                // 設定された移行経路が有効かどうかを確認する。
+                var funcFrom = organFrom.Func;
+                var funcTo = organTo.Func;
+                if (IsDecayPath(organFrom, organTo))
                 {
-                    // accからの壊変経路では、係数なし、または移行速度の設定を要求する。
-                    // パーセント値(移行割合)の設定はエラーとする。
-                    if (isFrac)
-                        errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{organFrom}'.");
+                    if (funcFrom == OrganFunc.acc)
+                    {
+                        // accからの壊変経路では、係数なし、または移行速度の設定を要求する。
+                        // パーセント値(移行割合)の設定はエラーとする。
+                        if (isFrac)
+                            errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{organFrom}'.");
 
-                    // accからの壊変経路はaccにしか移行できない。
-                    // ただし、excへの係数付きの壊変経路は、実際には途中に壊変コンパートメントとしてのaccが生成されるため許可する。
-                    if (funcTo != OrganFunc.acc && !(funcTo == OrganFunc.exc && hasCoeff))
-                        errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}' to non-acc '{organTo.Name}'.");
+                        // accからの壊変経路はaccにしか移行できない。
+                        // ただし、excへの係数付きの壊変経路は、実際には途中に壊変コンパートメントとしてのaccが生成されるため許可する。
+                        if (funcTo != OrganFunc.acc && !(funcTo == OrganFunc.exc && hasCoeff))
+                            errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}' to non-acc '{organTo.Name}'.");
+                    }
+
+                    // excからの壊変経路では、子孫核種のexcへの移行のみ許可する。
+                    if (funcFrom == OrganFunc.exc && funcTo != OrganFunc.exc)
+                        errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}' to non-exc '{organTo.Name}'.");
+
+                    // mixからの壊変経路は定義できない。
+                    if (funcFrom == OrganFunc.mix)
+                        errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}'.");
                 }
+                else
+                {
+                    // accからの流出経路では、移行速度の入力を要求する。
+                    // 係数なし、またはパーセント値(移行割合)の設定はエラーとする。
+                    if (funcFrom == OrganFunc.acc && (!hasCoeff || isFrac))
+                        errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{organFrom.Name}'.");
 
-                // excからの壊変経路では、子孫核種のexcへの移行のみ許可する。
-                if (funcFrom == OrganFunc.exc && funcTo != OrganFunc.exc)
-                    errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}' to non-exc '{organTo.Name}'.");
+                    // excからの流出は定義できない。
+                    if (funcFrom == OrganFunc.exc)
+                        errors.AddError(lineNum, $"Cannot set output path from exc '{organFrom.Name}'.");
 
-                // mixからの壊変経路は定義できない。
-                if (funcFrom == OrganFunc.mix)
-                    errors.AddError(lineNum, $"Cannot set decay path from {funcFrom} '{organFrom}'.");
-            }
-            else
-            {
-                // accからの流出経路では、移行速度の入力を要求する。
-                // 係数なし、またはパーセント値(移行割合)の設定はエラーとする。
-                if (funcFrom == OrganFunc.acc && (!hasCoeff || isFrac))
-                    errors.AddError(lineNum, $"Require transfer rate [/d] from {funcFrom} '{organFrom.Name}'.");
+                    // TODO: mixからmixへの経路は定義できない。
+                    //if (funcFrom == OrganFunc.mix && funcTo == OrganFunc.mix)
+                    //    errors.AddError(lineNum, "Cannot set transfer path from 'mix' to 'mix'.");
 
-                // excからの流出は定義できない。
-                if (funcFrom == OrganFunc.exc)
-                    errors.AddError(lineNum, $"Cannot set output path from exc '{organFrom.Name}'.");
-
-                // TODO: mixからmixへの経路は定義できない。
-                //if (funcFrom == OrganFunc.mix && funcTo == OrganFunc.mix)
-                //    errors.AddError(lineNum, "Cannot set transfer path from 'mix' to 'mix'.");
-
-                // mixからの同核種での移行経路では、移行割合の入力を要求する。
-                // なお、ここでは割合値(0.15など)とパーセント値(10.5%など)の両方を受け付ける。
-                if (funcFrom == OrganFunc.mix && !hasCoeff)
-                    errors.AddError(lineNum, $"Require fraction of output activity [%] from {funcFrom} '{organFrom.Name}'.");
+                    // mixからの同核種での移行経路では、移行割合の入力を要求する。
+                    // なお、ここでは割合値(0.15など)とパーセント値(10.5%など)の両方を受け付ける。
+                    if (funcFrom == OrganFunc.mix && !hasCoeff)
+                        errors.AddError(lineNum, $"Require fraction of output activity [%] from {funcFrom} '{organFrom.Name}'.");
+                }
             }
 
             // 以降の処理で移行経路の設定位置が有効であることを確定する。
             if (errors.IfAny(olderrorsT))
                 return false;
 
-            result = (organFrom, organTo, coeff);
+            result = (organsFrom, organTo, coeff);
 
             return true;
         }
@@ -1389,12 +1462,16 @@ public class InputDataReader_OIR : InputDataReaderBase
     /// 全ての移行経路を定義する。
     /// </summary>
     /// <param name="data"></param>
-    private void DefineTransfers(InputData data)
+    /// <param name="expander"></param>
+    private void DefineTransfers(InputData data, InputNuclideExpander expander)
     {
         var olderrorsN = errors.Count;
 
         var decaySet = new DecaySet(data.Nuclides, errors);
-        var parser = new TransferParser(inputNuclides, data.Organs, inputEvaluators, errors);
+        var parser = new TransferParser(data.Organs, decaySet, expander, inputEvaluators, errors);
+
+        // 核種パターンを展開したものを作成する。
+        var expandTransfers = ExpandTransfers(expander);
 
         // 有効な移行経路の定義を収集する
         var correctTransfers = new List<(int lineNum, Organ from, Organ to, decimal coeff)>();
@@ -1403,49 +1480,52 @@ public class InputDataReader_OIR : InputDataReaderBase
         {
             if (!CalcProgeny && nuclide.IsProgeny)
                 continue;
-
-            var nuc = nuclide.Name;
-            if (!inputTransfers.TryGetValue(nuc, out var transfers))
+            if (!expandTransfers.TryGetValue(nuclide, out var transfers))
                 continue;
 
             var evaluator = inputEvaluators[nuclide];
 
             foreach (var transfer in transfers)
             {
+                if (nuclide.IsProgeny == transfer.ParentOnly)
+                    continue;
                 if (!parser.TryParse(nuclide, transfer, out var result))
                     continue;
 
                 var lineNum = transfer.LineNum;
-                var organFrom = result.OrganFrom;
+                var organsFrom = result.OrgansFrom;
                 var organTo = result.OrganTo;
                 var coeff = result.Coeff;
 
-                if (IsDecayPath(organFrom, organTo))
+                foreach (var organFrom in organsFrom)
                 {
-                    // 次のような壊変経路を、
-                    //   Parent/organFrom --(coeff)--> Progeny_i/organTo  ①移行速度あり
-                    //   Parent/organFrom -----------> Progeny_i/organTo  ②移行速度なし
-                    //
-                    // 親核種ParentがコンパートメントorganFromから移動しないまま壊変することで生成された
-                    // 子孫核種Progeny_1～Nのそれぞれを受けるorganDecayを、自動的に追加定義する、
-                    // あるいはインプットで定義済みのコンパートメントを直接使用することで、
-                    // 以下のような経路に構成し直す。
-                    //   Parent/organFrom
-                    //   ↓
-                    //   Progeny_1/organDecay
-                    //   ：
-                    //   ↓
-                    //   Progeny_i/organDecay --(coeff)--> Progeny_i/organTo  ①移行速度あり
-                    //   Progeny_i/organDecay == organTo                      ②移行速度なし
+                    if (IsDecayPath(organFrom, organTo))
+                    {
+                        // 次のような壊変経路を、
+                        //   Parent/organFrom --(coeff)--> Progeny_i/organTo  ①移行速度あり
+                        //   Parent/organFrom -----------> Progeny_i/organTo  ②移行速度なし
+                        //
+                        // 親核種ParentがコンパートメントorganFromから移動しないまま壊変することで生成された
+                        // 子孫核種Progeny_1～Nのそれぞれを受けるorganDecayを、自動的に追加定義する、
+                        // あるいはインプットで定義済みのコンパートメントを直接使用することで、
+                        // 以下のような経路に構成し直す。
+                        //   Parent/organFrom
+                        //   ↓
+                        //   Progeny_1/organDecay
+                        //   ：
+                        //   ↓
+                        //   Progeny_i/organDecay --(coeff)--> Progeny_i/organTo  ①移行速度あり
+                        //   Progeny_i/organDecay == organTo                      ②移行速度なし
 
-                    decaySet.AddDecayPath(lineNum, organFrom, organTo, coeff);
-                }
-                else
-                {
-                    // パース処理によって、同じ核種での移行経路では必ず移行係数が存在する。
-                    Debug.Assert(coeff is not null);
+                        decaySet.AddDecayPath(lineNum, organFrom, organTo, coeff);
+                    }
+                    else
+                    {
+                        // パース処理によって、同じ核種での移行経路では必ず移行係数が存在する。
+                        Debug.Assert(coeff is not null);
 
-                    correctTransfers.Add((lineNum, organFrom, organTo, coeff.Value));
+                        correctTransfers.Add((lineNum, organFrom, organTo, coeff.Value));
+                    }
                 }
             }
         }

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -229,7 +229,7 @@ public class InputDataReader_OIR : InputDataReaderBase
         DefineParameters(data, expander);
 
         // 全てのコンパートメントを定義する。
-        DefineCompartments(data);
+        DefineCompartments(data, expander);
 
         // コンパートメント定義にエラーがないことを確定する。
         errors.RaiseIfAny();
@@ -288,7 +288,7 @@ public class InputDataReader_OIR : InputDataReaderBase
             }
             else if (header.EndsWith(":compartment", StringComparison.OrdinalIgnoreCase))
             {
-                conditionDirectiveState = ConditionDirectiveState.Disabled;
+                conditionDirectiveState = ConditionDirectiveState.OutsideBlock;
                 var i = header.IndexOf(':');
                 var nuc = header.Slice(0, i).ToString();
                 line = GetCompartments(nuc);
@@ -637,9 +637,10 @@ public class InputDataReader_OIR : InputDataReaderBase
                 continue;
             }
 
+            var parentOnly = IsParentOnly;
+
             var name = values[0].Trim();
             var value = values[1].Trim();
-            var parentOnly = IsParentOnly;
 
             var isVarDecl = name.StartsWith('$');
             if (isVarDecl)
@@ -699,6 +700,8 @@ public class InputDataReader_OIR : InputDataReaderBase
                 continue;
             }
 
+            var parentOnly = IsParentOnly;
+
             var organFn = values[0];        // コンパートメント機能
             var organName = values[1];      // コンパートメント名
             var sourceRegion = values[2];   // コンパートメントに対応する線源領域の名称
@@ -714,7 +717,7 @@ public class InputDataReader_OIR : InputDataReaderBase
                     continue;
             }
 
-            organs.Add(new InputOrgan(LineNum, organFunc, organName, IsBar(sourceRegion) ? null : sourceRegion));
+            organs.Add(new InputOrgan(LineNum, parentOnly, organFunc, organName, IsBar(sourceRegion) ? null : sourceRegion));
         }
         if (errors.IfAny(olderrors))
             return line;
@@ -904,16 +907,43 @@ public class InputDataReader_OIR : InputDataReaderBase
     /// インプットから読み取ったコンパートメント定義の情報を保持する。
     /// </summary>
     /// <param name="LineNum">行番号。</param>
+    /// <param name="ParentOnly"></param>
     /// <param name="Func">コンパートメント機能。</param>
     /// <param name="Name">コンパートメント名。</param>
     /// <param name="SourceRegion">線源領域。</param>
-    private record class InputOrgan(int LineNum, OrganFunc Func, string Name, string? SourceRegion);
+    private record class InputOrgan(int LineNum, bool? ParentOnly, OrganFunc Func, string Name, string? SourceRegion);
+
+    private Dictionary<NuclideData, List<InputOrgan>> ExpandCompartments(InputNuclideExpander expander)
+    {
+        var resultOrgans = new Dictionary<NuclideData, List<InputOrgan>>();
+
+        foreach (var (nuc, inputs) in inputOrgans)
+        {
+            var lineNum = compartmentSectionLocs[nuc];
+
+            var olderrors = errors.Count;
+            var nuclides = expander.ExpandNuclides(lineNum, nuc);
+            if (errors.IfAny(olderrors))
+                continue;
+
+            foreach (var nuclide in nuclides)
+            {
+                if (!resultOrgans.TryGetValue(nuclide, out var results))
+                    resultOrgans.Add(nuclide, results = []);
+
+                results.AddRange(inputs);
+            }
+        }
+
+        return resultOrgans;
+    }
 
     /// <summary>
     /// 全てのコンパートメントを定義する。
     /// </summary>
     /// <param name="data"></param>
-    private void DefineCompartments(InputData data)
+    /// <param name="expander"></param>
+    private void DefineCompartments(InputData data, InputNuclideExpander expander)
     {
         // 'Other'は、線源領域「その他の組織」に関連付ける際の名称。
         var validSourceRegions = data.SourceRegions
@@ -923,15 +953,16 @@ public class InputDataReader_OIR : InputDataReaderBase
             .Where(s => s.MaleID != 0 || s.FemaleID != 0)
             .Select(s => s.Name).ToList();
 
+        // 核種パターンを展開したものを作成する。
+        var expandOrgans = ExpandCompartments(expander);
+
         foreach (var nuclide in inputNuclides)
         {
             if (!CalcProgeny && nuclide.IsProgeny)
                 continue;
 
-            var nuc = nuclide.Name;
-            if (!inputOrgans.TryGetValue(nuc, out var organs))
+            if (!expandOrgans.TryGetValue(nuclide, out var organs))
                 continue;
-            var sectionLineNum = compartmentSectionLocs[nuc];
 
             data.Nuclides.Add(nuclide);
 
@@ -969,8 +1000,11 @@ public class InputDataReader_OIR : InputDataReaderBase
                 data.Organs.Add(input);
             }
 
-            foreach (var (lineNum, organFunc, organName, sourceRegion) in organs)
+            foreach (var (lineNum, parentOnly, organFunc, organName, sourceRegion) in organs)
             {
+                if (nuclide.IsProgeny == parentOnly)
+                    continue;
+
                 var organ = new Organ
                 {
                     Nuclide  /**/= nuclide,

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -203,28 +203,6 @@ public class InputDataReader_OIR : InputDataReaderBase
         if (!inputIntakesRead)
             errors.AddError(LineNum, "Missing [intake] section.");
 
-        foreach (var (lineNum, nuc) in inputOrgans.Keys.Except(inputNuclides.Select(n => n.Name) ?? [])
-            .Select(nuc => (LineNum: compartmentSectionLocs[nuc], nuc)).OrderBy(t => t.LineNum))
-        {
-            errors.AddError(lineNum, $"Undefined nuclide '{nuc}' is used to define compartments.");
-        }
-
-        foreach (var (lineNum, nuc) in inputTransfers.Keys.Except(inputNuclides.Select(n => n.Name) ?? [])
-            .Select(nuc => (LineNum: transferSectionLocs[nuc], nuc)).OrderBy(t => t.LineNum))
-        {
-            errors.AddError(lineNum, $"Undefined nuclide '{nuc}' is used to define transfers.");
-        }
-
-        {
-            var nuclideNames = inputNuclides.Select(n => n.Name).ToArray();
-
-            foreach (var nuc in nuclideNames.Where(nuc => !inputOrgans.ContainsKey(nuc)))
-                errors.AddError(LineNum, $"Missing [{nuc}:compartment] section.");
-
-            foreach (var nuc in nuclideNames.Where(nuc => !inputTransfers.ContainsKey(nuc)))
-                errors.AddError(LineNum, $"Missing [{nuc}:transfer] section.");
-        }
-
         // 核種定義に対して[compartment]と[transfer]セクションに過不足がないことを確定する。
         errors.RaiseIfAny();
 

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -1141,6 +1141,8 @@ public class InputDataReader_OIR : InputDataReaderBase
             var lineNum = intake.LineNum;
 
             var nameTo = intake.To;
+            if (!evaluatorTo.TryReadCompartment(lineNum, ref nameTo))
+                continue;
             var organTo = data.Organs.FirstOrDefault(o => o.Name == nameTo && o.Nuclide == nuclideTo);
 
             // 移行先がcompartmentセクションで定義済みかを確認する。
@@ -1331,6 +1333,11 @@ public class InputDataReader_OIR : InputDataReaderBase
                 List<Organ> organsFrom = [];
                 foreach (var nuclideFrom in nuclidesFrom)
                 {
+                    var evaluatorFrom = evaluators[nuclideFrom];
+
+                    // 移行元がcompartmentセクションで定義済みかを確認する。
+                    if (!evaluatorFrom.TryReadCompartment(lineNum, ref nameFrom))
+                        continue;
                     var organFrom = organs.FirstOrDefault(o => o.Name == nameFrom && o.Nuclide == nuclideFrom);
 
                     // 移行元がcompartmentセクションで定義済みかを確認する。
@@ -1350,6 +1357,8 @@ public class InputDataReader_OIR : InputDataReaderBase
 
             Organ? GetOrganTo()
             {
+                if (!evaluatorTo.TryReadCompartment(lineNum, ref nameTo))
+                    return null;
                 var organTo = organs.FirstOrDefault(o => o.Name == nameTo && o.Nuclide == nuclideTo);
 
                 // 移行先がcompartmentセクションで定義済みかを確認する。

--- a/FlexID.Core/InputParser.cs
+++ b/FlexID.Core/InputParser.cs
@@ -16,11 +16,15 @@ public class InputParser<T>
 
     public Parser<T> NumberExpr { get; }
 
+    public Parser<T> StringExpr { get; }
+
     public Parser<T> Expr { get; }
 
     public Parser<(string ident, T expr)> VarDecl { get; }
 
     public Parser<T> Coefficient { get; }
+
+    public Parser<T> Compartment { get; }
 
     public InputParser(Visitor<T> visitor)
     {
@@ -48,9 +52,15 @@ public class InputParser<T>
             from unit in OrEmpty(Char('%'))
             select visitor.Number($"{num}{exponent}", unit);
 
+        StringExpr =
+            from quote in Chars("\'\"")
+            from content in CharExcept(['\\', quote]).Or(Char('\\').Then(_ => AnyChar)).Many().Text()
+            from _end in Char(quote)
+            select visitor.String(content);
+
         var Parenthesis = Ref(() => Expr).Contained(Char('('), Char(')'));
 
-        var Primary = VarExpr.Or(NumberExpr).Or(Parenthesis);
+        var Primary = VarExpr.Or(NumberExpr).Or(StringExpr).Or(Parenthesis);
 
         var Prefix =
             from sign in OrEmpty(Chars("+-"))
@@ -82,7 +92,15 @@ public class InputParser<T>
                     sign == "-" ? visitor.Neg(expr) : expr);
 
         Coefficient =
-            from expr in SignedNumerExpr.Or(Char('$').Then(_ => VarExpr.Or(Parenthesis)))
+            from expr in Char('$').Then(_ => VarExpr.Or(Parenthesis)).Or(SignedNumerExpr)
+            select expr;
+
+        var compartmentName =
+            from name in CharExcept(' ').AtLeastOnce().Text()
+            select visitor.String(name);
+
+        Compartment =
+            from expr in Char('$').Then(_ => VarExpr.Or(Parenthesis)).Or(compartmentName)
             select expr;
     }
 }
@@ -95,6 +113,7 @@ public interface Visitor<T>
 {
     T Var(string ident);
     T Number(string value, string unit);
+    T String(string value);
     T Pos(T expr);
     T Neg(T expr);
     T Add(T left, T right);
@@ -127,18 +146,24 @@ public class ExpressionVisitor : Visitor<Expr>
 }
 #endif
 
+public record class AbstractValue { }
+
+public record class NumberValue(decimal Value, bool IsFrac) : AbstractValue;
+
+public record class StringValue(string Content) : AbstractValue;
+
 /// <summary>
 /// インプット上の変数定義や部分式の評価を行う。
 /// </summary>
-public class InputEvaluator : Visitor<(decimal v, bool r)>
+public class InputEvaluator : Visitor<AbstractValue>
 {
     private readonly string nuc;
 
     private readonly InputErrors errors;
 
-    private readonly InputParser<(decimal v, bool r)> parser;
+    private readonly InputParser<AbstractValue> parser;
 
-    private readonly Dictionary<string, (decimal, bool)> variables = [];
+    private readonly Dictionary<string, AbstractValue> variables = [];
 
     private int lineNum;
 
@@ -149,7 +174,7 @@ public class InputEvaluator : Visitor<(decimal v, bool r)>
     {
         this.nuc = nuc;
         this.errors = errors;
-        this.parser = new InputParser<(decimal, bool)>(this);
+        this.parser = new InputParser<AbstractValue>(this);
     }
 
     /// <summary>
@@ -188,7 +213,7 @@ public class InputEvaluator : Visitor<(decimal v, bool r)>
         this.lineNum = lineNum;
         result = default;
 
-        IResult<(decimal v, bool r)> r;
+        IResult<AbstractValue> r;
         try
         {
             r = parser.Coefficient.Token().End().TryParse(input);
@@ -203,19 +228,41 @@ public class InputEvaluator : Visitor<(decimal v, bool r)>
             errors.AddError(lineNum, $"Transfer coefficient evaluation failed: {ex.Message}.");
             return false;
         }
-        if (!r.WasSuccessful)
+        if (!r.WasSuccessful || r.Value is not NumberValue n)
         {
             errors.AddError(lineNum, $"Transfer coefficient should be evaluated to a number, not '{input}'.");
             return false;
         }
 
-        var (expr, isFrac) = r.Value;
-        //Debug.WriteLine($"Line {lineNum} '{input}' ==> {expr * (isFrac ? 100 : 1)}{(isFrac ? "%" : "")}");
-        result = r.Value;
+        //Debug.WriteLine($"Line {lineNum} '{input}' ==> {n.Value * (n.IsFrac ? 100 : 1)}{(n.IsFrac ? "%" : "")}");
+        result = (n.Value, n.IsFrac);
         return true;
     }
 
-    public (decimal v, bool r) Var(string ident)
+    public bool TryReadCompartment(int lineNum, ref string target)
+    {
+        this.lineNum = lineNum;
+
+        IResult<AbstractValue> r;
+        try
+        {
+            r = parser.Compartment.Token().End().TryParse(target);
+        }
+        catch (InputErrorsException ex)
+        {
+            errors.AddErrors(ex);
+            return false;
+        }
+        if (!r.WasSuccessful || r.Value is not StringValue s)
+        {
+            errors.AddError(lineNum, $"Expected a compartment name, not '{target}'.");
+            return false;
+        }
+        target = s.Content;
+        return true;
+    }
+
+    public AbstractValue Var(string ident)
     {
         // 定義されていない変数の使用に対してエラーを報告する。
         if (!variables.TryGetValue(ident, out var v))
@@ -223,45 +270,78 @@ public class InputEvaluator : Visitor<(decimal v, bool r)>
         return v;
     }
 
-    public (decimal v, bool r) Number(string input, string unit)
+    public AbstractValue Number(string input, string unit)
     {
         var value = decimal.Parse(input, NumberStyles.Float);
         var isFrac = (unit == "%");
         if (isFrac)
             value = value / 100;
-        return (value, isFrac);
+        return new NumberValue(value, isFrac);
     }
 
-    public (decimal v, bool r) Pos((decimal v, bool r) oper) => (+oper.v, oper.r);
-
-    public (decimal v, bool r) Neg((decimal v, bool r) oper) => (-oper.v, oper.r);
-
-    public (decimal v, bool r) Add((decimal v, bool r) left, (decimal v, bool r) right)
+    public AbstractValue String(string value)
     {
-        if (left.r != right.r)
-            throw new InputErrorsException(lineNum, "Addition with inconsistent value units");
-        return (left.v + right.v, left.r);
+        return new StringValue(value);
     }
 
-    public (decimal v, bool r) Sub((decimal v, bool r) left, (decimal v, bool r) right)
+    public AbstractValue Pos(AbstractValue oper) => oper switch
     {
-        if (left.r != right.r)
-            throw new InputErrorsException(lineNum, "Subtraction with inconsistent value units");
-        return (left.v - right.v, left.r);
-    }
+        NumberValue n => n,
+        _ => throw new InputErrorsException(lineNum, "Unexpected operands"),
+    };
 
-    public (decimal v, bool r) Mul((decimal v, bool r) left, (decimal v, bool r) right) => (left.v * right.v, left.r && right.r);
-
-    public (decimal v, bool r) Div((decimal v, bool r) left, (decimal v, bool r) right)
+    public AbstractValue Neg(AbstractValue oper) => oper switch
     {
-        try
+        NumberValue n => new NumberValue(-n.Value, n.IsFrac),
+        _ => throw new InputErrorsException(lineNum, "Unexpected operands"),
+    };
+
+    public AbstractValue Add(AbstractValue left, AbstractValue right)
+    {
+        return (left, right) switch
         {
-            var result = checked(left.v / right.v);
-            return (result, left.r && right.r);
+            (NumberValue a, NumberValue b) =>
+                a.IsFrac == b.IsFrac ? new NumberValue(a.Value + b.Value, a.IsFrac)
+                                     : throw new InputErrorsException(lineNum, "Addition with inconsistent value units"),
+            (StringValue a, StringValue b) => new StringValue(a.Content + b.Content),
+            _ => throw new InputErrorsException(lineNum, "Unexpected operands"),
+        };
+    }
+
+    public AbstractValue Sub(AbstractValue left, AbstractValue right)
+    {
+        return (left, right) switch
+        {
+            (NumberValue a, NumberValue b) =>
+                a.IsFrac == b.IsFrac ? new NumberValue(a.Value - b.Value, a.IsFrac)
+                                     : throw new InputErrorsException(lineNum, "Subtraction with inconsistent value units"),
+            _ => throw new InputErrorsException(lineNum, "Unexpected operands"),
+        };
+    }
+
+    public AbstractValue Mul(AbstractValue left, AbstractValue right) => (left, right) switch
+    {
+        (NumberValue a, NumberValue b) => new NumberValue(a.Value * b.Value, a.IsFrac && b.IsFrac),
+        _ => throw new InputErrorsException(lineNum, "Unexpected operands"),
+    };
+
+    public AbstractValue Div(AbstractValue left, AbstractValue right)
+    {
+        if ((left, right) is (NumberValue a, NumberValue b))
+        {
+            try
+            {
+                var result = checked(a.Value / b.Value);
+                return new NumberValue(result, a.IsFrac && b.IsFrac);
+            }
+            catch (DivideByZeroException)
+            {
+                throw new InputErrorsException(lineNum, "Transfer coefficient evaluation failed: divide by zero.");
+            }
         }
-        catch (DivideByZeroException)
+        else
         {
-            throw new InputErrorsException(lineNum, "Transfer coefficient evaluation failed: divide by zero.");
+            throw new InputErrorsException(lineNum, "Unexpected operands");
         }
     }
 }


### PR DESCRIPTION
Close #286, #287, #293

`[compartment]`セクションと`[transfer]`セクションに対する核種パターンの導入と、移行経路の両端について変数名を使用可能とすることで、長大な崩壊系列を持つ核種のインプット作成をより容易にする。
