### PR TITLE
OIRインプットのうち、崩壊系列上の核種を全て作成できていないもののタイトル先頭に「(Incomplete)」を付加する

### DIFF
--- a/resources/inp/OIR/88-Ra/Ra-223/Ra-223_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-223/Ra-223_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-223 Ingestion
+(Incomplete) Ra-223 Ingestion
 
 [nuclide]
   Ra-223

--- a/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-223 Inhalation, Aerosols Type F
+(Incomplete) Ra-223 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-223

--- a/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-223 Inhalation, Aerosols Type M
+(Incomplete) Ra-223 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-223

--- a/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-223 Inhalation, Aerosols Type S
+(Incomplete) Ra-223 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-223

--- a/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-223/Ra-223_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-223 Injection
+(Incomplete) Ra-223 Injection
 
 [nuclide]
   Ra-223

--- a/resources/inp/OIR/88-Ra/Ra-224/Ra-224_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-224/Ra-224_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-224 Ingestion
+(Incomplete) Ra-224 Ingestion
 
 [nuclide]
   Ra-224

--- a/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-224 Inhalation, Aerosols Type F
+(Incomplete) Ra-224 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-224

--- a/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-224 Inhalation, Aerosols Type M
+(Incomplete) Ra-224 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-224

--- a/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-224 Inhalation, Aerosols Type S
+(Incomplete) Ra-224 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-224

--- a/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-224/Ra-224_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-224 Injection
+(Incomplete) Ra-224 Injection
 
 [nuclide]
   Ra-224

--- a/resources/inp/OIR/88-Ra/Ra-225/Ra-225_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-225/Ra-225_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-225 Ingestion
+(Incomplete) Ra-225 Ingestion
 
 [nuclide]
   Ra-225

--- a/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-225 Inhalation, Aerosols Type F
+(Incomplete) Ra-225 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-225

--- a/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-225 Inhalation, Aerosols Type M
+(Incomplete) Ra-225 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-225

--- a/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-225 Inhalation, Aerosols Type S
+(Incomplete) Ra-225 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-225

--- a/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-225/Ra-225_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-225 Injection
+(Incomplete) Ra-225 Injection
 
 [nuclide]
   Ra-225

--- a/resources/inp/OIR/88-Ra/Ra-226/Ra-226_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-226/Ra-226_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-226 Ingestion
+(Incomplete) Ra-226 Ingestion
 
 [nuclide]
   Ra-226

--- a/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-226 Inhalation, Aerosols Type F
+(Incomplete) Ra-226 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-226

--- a/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-226 Inhalation, Aerosols Type M
+(Incomplete) Ra-226 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-226

--- a/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-226 Inhalation, Aerosols Type S
+(Incomplete) Ra-226 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-226

--- a/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-226/Ra-226_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-226 Injection
+(Incomplete) Ra-226 Injection
 
 [nuclide]
   Ra-226

--- a/resources/inp/OIR/88-Ra/Ra-227/Ra-227_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-227/Ra-227_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-227 Ingestion
+(Incomplete) Ra-227 Ingestion
 
 [nuclide]
   Ra-227

--- a/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-227 Inhalation, Aerosols Type F
+(Incomplete) Ra-227 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-227

--- a/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-227 Inhalation, Aerosols Type M
+(Incomplete) Ra-227 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-227

--- a/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-227 Inhalation, Aerosols Type S
+(Incomplete) Ra-227 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-227

--- a/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-227/Ra-227_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-227 Injection
+(Incomplete) Ra-227 Injection
 
 [nuclide]
   Ra-227

--- a/resources/inp/OIR/88-Ra/Ra-228/Ra-228_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-228/Ra-228_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-228 Ingestion
+(Incomplete) Ra-228 Ingestion
 
 [nuclide]
   Ra-228  Ac-228

--- a/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-228 Inhalation, Aerosols Type F
+(Incomplete) Ra-228 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-228  Ac-228

--- a/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-228 Inhalation, Aerosols Type M
+(Incomplete) Ra-228 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-228  Ac-228

--- a/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-228 Inhalation, Aerosols Type S
+(Incomplete) Ra-228 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-228  Ac-228

--- a/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-228/Ra-228_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-228 Injection
+(Incomplete) Ra-228 Injection
 
 [nuclide]
   Ra-228  Ac-228

--- a/resources/inp/OIR/88-Ra/Ra-230/Ra-230_ing.inp
+++ b/resources/inp/OIR/88-Ra/Ra-230/Ra-230_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-230 Ingestion
+(Incomplete) Ra-230 Ingestion
 
 [nuclide]
   Ra-230

--- a/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-230 Inhalation, Aerosols Type F
+(Incomplete) Ra-230 Inhalation, Aerosols Type F
 
 [nuclide]
   Ra-230

--- a/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-230 Inhalation, Aerosols Type M
+(Incomplete) Ra-230 Inhalation, Aerosols Type M
 
 [nuclide]
   Ra-230

--- a/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-230 Inhalation, Aerosols Type S
+(Incomplete) Ra-230 Inhalation, Aerosols Type S
 
 [nuclide]
   Ra-230

--- a/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inj.inp
+++ b/resources/inp/OIR/88-Ra/Ra-230/Ra-230_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ra-230 Injection
+(Incomplete) Ra-230 Injection
 
 [nuclide]
   Ra-230

--- a/resources/inp/OIR/89-Ac/Ac-224/Ac-224_ing.inp
+++ b/resources/inp/OIR/89-Ac/Ac-224/Ac-224_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-224 Ingestion
+(Incomplete) Ac-224 Ingestion
 
 [nuclide]
   Ac-224

--- a/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-224 Inhalation, Aerosols Type F
+(Incomplete) Ac-224 Inhalation, Aerosols Type F
 
 [nuclide]
   Ac-224

--- a/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-224 Inhalation, Aerosols Type M
+(Incomplete) Ac-224 Inhalation, Aerosols Type M
 
 [nuclide]
   Ac-224

--- a/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-224 Inhalation, Aerosols Type S
+(Incomplete) Ac-224 Inhalation, Aerosols Type S
 
 [nuclide]
   Ac-224

--- a/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inj.inp
+++ b/resources/inp/OIR/89-Ac/Ac-224/Ac-224_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-224 Injection
+(Incomplete) Ac-224 Injection
 
 [nuclide]
   Ac-224

--- a/resources/inp/OIR/89-Ac/Ac-225/Ac-225_ing.inp
+++ b/resources/inp/OIR/89-Ac/Ac-225/Ac-225_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-225 Ingestion
+(Incomplete) Ac-225 Ingestion
 
 [nuclide]
   Ac-225

--- a/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-225 Inhalation, Aerosols Type F
+(Incomplete) Ac-225 Inhalation, Aerosols Type F
 
 [nuclide]
   Ac-225

--- a/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-225 Inhalation, Aerosols Type M
+(Incomplete) Ac-225 Inhalation, Aerosols Type M
 
 [nuclide]
   Ac-225

--- a/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-225 Inhalation, Aerosols Type S
+(Incomplete) Ac-225 Inhalation, Aerosols Type S
 
 [nuclide]
   Ac-225

--- a/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inj.inp
+++ b/resources/inp/OIR/89-Ac/Ac-225/Ac-225_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-225 Injection
+(Incomplete) Ac-225 Injection
 
 [nuclide]
   Ac-225

--- a/resources/inp/OIR/89-Ac/Ac-226/Ac-226_ing.inp
+++ b/resources/inp/OIR/89-Ac/Ac-226/Ac-226_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-226 Ingestion
+(Incomplete) Ac-226 Ingestion
 
 [nuclide]
   Ac-226

--- a/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-226 Inhalation, Aerosols Type F
+(Incomplete) Ac-226 Inhalation, Aerosols Type F
 
 [nuclide]
   Ac-226

--- a/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-226 Inhalation, Aerosols Type M
+(Incomplete) Ac-226 Inhalation, Aerosols Type M
 
 [nuclide]
   Ac-226

--- a/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-226 Inhalation, Aerosols Type S
+(Incomplete) Ac-226 Inhalation, Aerosols Type S
 
 [nuclide]
   Ac-226

--- a/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inj.inp
+++ b/resources/inp/OIR/89-Ac/Ac-226/Ac-226_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-226 Injection
+(Incomplete) Ac-226 Injection
 
 [nuclide]
   Ac-226

--- a/resources/inp/OIR/89-Ac/Ac-227/Ac-227_ing.inp
+++ b/resources/inp/OIR/89-Ac/Ac-227/Ac-227_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-227 Ingestion
+(Incomplete) Ac-227 Ingestion
 
 [nuclide]
   Ac-227

--- a/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-227 Inhalation, Aerosols Type F
+(Incomplete) Ac-227 Inhalation, Aerosols Type F
 
 [nuclide]
   Ac-227

--- a/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-227 Inhalation, Aerosols Type M
+(Incomplete) Ac-227 Inhalation, Aerosols Type M
 
 [nuclide]
   Ac-227

--- a/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-227 Inhalation, Aerosols Type S
+(Incomplete) Ac-227 Inhalation, Aerosols Type S
 
 [nuclide]
   Ac-227

--- a/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inj.inp
+++ b/resources/inp/OIR/89-Ac/Ac-227/Ac-227_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-227 Injection
+(Incomplete) Ac-227 Injection
 
 [nuclide]
   Ac-227

--- a/resources/inp/OIR/89-Ac/Ac-228/Ac-228_ing.inp
+++ b/resources/inp/OIR/89-Ac/Ac-228/Ac-228_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-228 Ingestion
+(Incomplete) Ac-228 Ingestion
 
 [nuclide]
   Ac-228

--- a/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-228 Inhalation, Aerosols Type F
+(Incomplete) Ac-228 Inhalation, Aerosols Type F
 
 [nuclide]
   Ac-228

--- a/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-228 Inhalation, Aerosols Type M
+(Incomplete) Ac-228 Inhalation, Aerosols Type M
 
 [nuclide]
   Ac-228

--- a/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-228 Inhalation, Aerosols Type S
+(Incomplete) Ac-228 Inhalation, Aerosols Type S
 
 [nuclide]
   Ac-228

--- a/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inj.inp
+++ b/resources/inp/OIR/89-Ac/Ac-228/Ac-228_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Ac-228 Injection
+(Incomplete) Ac-228 Injection
 
 [nuclide]
   Ac-228

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_ing_Insoluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_ing_Insoluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Ingestion, Insoluble
+(Incomplete) Pu-238 Ingestion, Insoluble
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_ing_Soluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_ing_Soluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Ingestion, Soluble
+(Incomplete) Pu-238 Ingestion, Soluble
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Inhalation, Aerosols Type F
+(Incomplete) Pu-238 Inhalation, Aerosols Type F
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Inhalation, Aerosols Type M
+(Incomplete) Pu-238 Inhalation, Aerosols Type M
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Inhalation, Aerosols Type S
+(Incomplete) Pu-238 Inhalation, Aerosols Type S
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inj.inp
+++ b/resources/inp/OIR/94-Pu/Pu-238/Pu-238_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-238 Injection
+(Incomplete) Pu-238 Injection
 
 [nuclide]
   Pu-238

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_ing_Insoluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_ing_Insoluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Ingestion, Insoluble
+(Incomplete) Pu-239 Ingestion, Insoluble
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_ing_Soluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_ing_Soluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Ingestion, Soluble
+(Incomplete) Pu-239 Ingestion, Soluble
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Inhalation, Aerosols Type F
+(Incomplete) Pu-239 Inhalation, Aerosols Type F
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Inhalation, Aerosols Type M
+(Incomplete) Pu-239 Inhalation, Aerosols Type M
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Inhalation, Aerosols Type S
+(Incomplete) Pu-239 Inhalation, Aerosols Type S
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inj.inp
+++ b/resources/inp/OIR/94-Pu/Pu-239/Pu-239_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-239 Injection
+(Incomplete) Pu-239 Injection
 
 [nuclide]
   Pu-239

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_ing_Insoluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_ing_Insoluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Ingestion, Insoluble
+(Incomplete) Pu-240 Ingestion, Insoluble
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_ing_Soluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_ing_Soluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Ingestion, Soluble
+(Incomplete) Pu-240 Ingestion, Soluble
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Inhalation, Aerosols Type F
+(Incomplete) Pu-240 Inhalation, Aerosols Type F
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Inhalation, Aerosols Type M
+(Incomplete) Pu-240 Inhalation, Aerosols Type M
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Inhalation, Aerosols Type S
+(Incomplete) Pu-240 Inhalation, Aerosols Type S
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inj.inp
+++ b/resources/inp/OIR/94-Pu/Pu-240/Pu-240_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-240 Injection
+(Incomplete) Pu-240 Injection
 
 [nuclide]
   Pu-240

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_ing_Insoluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_ing_Insoluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Ingestion, Insoluble
+(Incomplete) Pu-241 Ingestion, Insoluble
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_ing_Soluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_ing_Soluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Ingestion, Soluble
+(Incomplete) Pu-241 Ingestion, Soluble
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Inhalation, Aerosols Type F
+(Incomplete) Pu-241 Inhalation, Aerosols Type F
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Inhalation, Aerosols Type M
+(Incomplete) Pu-241 Inhalation, Aerosols Type M
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Inhalation, Aerosols Type S
+(Incomplete) Pu-241 Inhalation, Aerosols Type S
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inj.inp
+++ b/resources/inp/OIR/94-Pu/Pu-241/Pu-241_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-241 Injection
+(Incomplete) Pu-241 Injection
 
 [nuclide]
   Pu-241

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_ing_Insoluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_ing_Insoluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Ingestion, Insoluble
+(Incomplete) Pu-242 Ingestion, Insoluble
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_ing_Soluble.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_ing_Soluble.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Ingestion, Soluble
+(Incomplete) Pu-242 Ingestion, Soluble
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Inhalation, Aerosols Type F
+(Incomplete) Pu-242 Inhalation, Aerosols Type F
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Inhalation, Aerosols Type M
+(Incomplete) Pu-242 Inhalation, Aerosols Type M
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Inhalation, Aerosols Type S
+(Incomplete) Pu-242 Inhalation, Aerosols Type S
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inj.inp
+++ b/resources/inp/OIR/94-Pu/Pu-242/Pu-242_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Pu-242 Injection
+(Incomplete) Pu-242 Injection
 
 [nuclide]
   Pu-242

--- a/resources/inp/OIR/98-Cf/Cf-252/Cf-252_ing.inp
+++ b/resources/inp/OIR/98-Cf/Cf-252/Cf-252_ing.inp
@@ -1,5 +1,5 @@
 [title]
-Cf-252 Ingestion
+(Incomplete) Cf-252 Ingestion
 
 [nuclide]
   Cf-252

--- a/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeF.inp
+++ b/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeF.inp
@@ -1,5 +1,5 @@
 [title]
-Cf-252 Inhalation, Aerosols Type F
+(Incomplete) Cf-252 Inhalation, Aerosols Type F
 
 [nuclide]
   Cf-252

--- a/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeM.inp
+++ b/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeM.inp
@@ -1,5 +1,5 @@
 [title]
-Cf-252 Inhalation, Aerosols Type M
+(Incomplete) Cf-252 Inhalation, Aerosols Type M
 
 [nuclide]
   Cf-252

--- a/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeS.inp
+++ b/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inh_Aerosols-TypeS.inp
@@ -1,5 +1,5 @@
 [title]
-Cf-252 Inhalation, Aerosols Type S
+(Incomplete) Cf-252 Inhalation, Aerosols Type S
 
 [nuclide]
   Cf-252

--- a/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inj.inp
+++ b/resources/inp/OIR/98-Cf/Cf-252/Cf-252_inj.inp
@@ -1,5 +1,5 @@
 [title]
-Cf-252 Injection
+(Incomplete) Cf-252 Injection
 
 [nuclide]
   Cf-252


### PR DESCRIPTION
FlexUI上でこのようなインプットを区別できるようにするため。