### PR TITLE
`[parameter]`, `[compartment]`, `[transfer]`セクションについて複数の定義を受け付ける 

### DIFF
--- a/FlexID.Core.Tests/InputErrorTests.cs
+++ b/FlexID.Core.Tests/InputErrorTests.cs
@@ -17,17 +17,17 @@ public class InputErrorTests
             [title]
             dummy2
 
-            [parameter]
-              OutputDose = true
-
-            [parameter]
-              OutputDose = true
-
             [nuclide]
               Sr-90  6.596156E-05
 
             [nuclide]
               Y-90   2.595247E-01
+
+            [parameter]
+              OutputDose = true
+
+            [parameter]
+              OutputRetention = true
 
             [intake]
               ST0    100%
@@ -52,11 +52,8 @@ public class InputErrorTests
         e.ErrorLines.ShouldBe(
         [
             "(4): Duplicated [title] section.",
-            "(10): Duplicated [parameter] section.",
-            "(16): Duplicated [nuclide] section.",
+            "(10): Duplicated [nuclide] section.",
             "(22): Duplicated [intake] section.",
-            "(28): Duplicated [Sr-90:compartment] section.",
-            "(34): Duplicated [Sr-90:transfer] section.",
         ]);
     }
 

--- a/FlexID.Core/InputDataReader_OIR.cs
+++ b/FlexID.Core/InputDataReader_OIR.cs
@@ -85,7 +85,6 @@ public class InputDataReader_OIR : IDisposable
     private bool inputNuclidesRead;
     private readonly List<NuclideData> inputNuclides = [];
 
-    private bool inputParametersRead;
     private readonly List<InputParameter> inputParameters = [];
 
     private readonly Dictionary<string, List<InputOrgan>> inputOrgans = [];
@@ -734,13 +733,6 @@ public class InputDataReader_OIR : IDisposable
     /// <returns>セクションの次行。</returns>
     private string? GetParameters()
     {
-        if (inputParametersRead)
-        {
-            errors.AddError(Loc, "Duplicated [parameter] section.");
-            return SkipUntilNextSection();
-        }
-        inputParametersRead = true;
-
         string? line;
         while (true)
         {
@@ -792,12 +784,8 @@ public class InputDataReader_OIR : IDisposable
     /// <returns>セクションの次行。</returns>
     private string? GetCompartments(string nuc)
     {
-        if (inputOrgans.TryGetValue(nuc, out var organs))
-        {
-            errors.AddError(Loc, $"Duplicated [{nuc}:compartment] section.");
-            return SkipUntilNextSection();
-        }
-        inputOrgans.Add(nuc, organs = []);
+        if (!inputOrgans.TryGetValue(nuc, out var organs))
+            inputOrgans.Add(nuc, organs = []);
 
         var olderrors = errors.Count;
         var sectionLineNum = Loc;
@@ -899,12 +887,8 @@ public class InputDataReader_OIR : IDisposable
     /// <param name="line"></param>
     private string? GetTransfers(string nuc)
     {
-        if (inputTransfers.TryGetValue(nuc, out var transfers))
-        {
-            errors.AddError(Loc, $"Duplicated [{nuc}:transfer] section.");
-            return SkipUntilNextSection();
-        }
-        inputTransfers.Add(nuc, transfers = []);
+        if (!inputTransfers.TryGetValue(nuc, out var transfers))
+            inputTransfers.Add(nuc, transfers = []);
 
         var olderrors = errors.Count;
         var sectionLineNum = Loc;


### PR DESCRIPTION
#302 に関する追加変更

これらのセクションを`[include]`セクションを通して2回以上定義し、それらを合成した結果を最終的なインプットとして構成することに実用性が見つかったことからこれを許可する方向に変更する。具体的な実例は以下の通り：
- `[parameter]`セクションについては、摂取形態に応じた親核種の`fr`,`sr`,`ss`,`fA`などの定義と、子孫元素において共通の`fA_MaxValueOfing`の定義を分けて組み合わせる
- `[compartment]`と`[transfer]`セクションについては、HATM+UBとHRTMを分け、前者のみをincludeすることで経口摂取に、両者を同時にincludeすることで吸入摂取に対応する
