### PR TITLE
Windows App SDK 2.3.1へ更新

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,20 +9,20 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.251219" />
-    <PackageVersion Include="EPPlus" Version="8.5.4" />
+    <PackageVersion Include="EPPlus" Version="8.6.3" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
-    <PackageVersion Include="MSTest" Version="4.2.3" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="MSTest" Version="4.3.3" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="ObservableCollections.R3" Version="3.3.4" />
-    <PackageVersion Include="R3" Version="1.3.0" />
-    <PackageVersion Include="R3Extensions.WinUI3" Version="1.3.0" />
-    <PackageVersion Include="ScottPlot.WinUI" Version="5.1.58" />
+    <PackageVersion Include="R3" Version="1.3.1" />
+    <PackageVersion Include="R3Extensions.WinUI3" Version="1.3.1" />
+    <PackageVersion Include="ScottPlot.WinUI" Version="5.1.59" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Sprache" Version="2.3.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
-    <PackageVersion Include="WinUIEx" Version="2.9.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
+    <PackageVersion Include="WinUIEx" Version="2.9.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="EPPlus" Version="8.5.4" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
     <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="ObservableCollections.R3" Version="3.3.4" />

--- a/FlexID.Core/FlexID.Core.csproj
+++ b/FlexID.Core/FlexID.Core.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <None Visible="false" Include="$(IntermediateOutputPath)ResourceFiles" CopyToOutputDirectory="Always" CopyToPublishDirectory="Never" />
 
+    <None Visible="false" Include="$(SolutionDir)resources/ICRP-PERMISSION.TXT"     LinkBase="licenses" CopyToPublishDirectory="PreserveNewest" />
     <None Visible="false" Include="$(SolutionDir)resources/License_DECDATA.TXT"     LinkBase="licenses" CopyToPublishDirectory="PreserveNewest" />
     <None Visible="false" Include="$(SolutionDir)resources/LICENSE_OIR_DViewer.TXT" LinkBase="licenses" CopyToPublishDirectory="PreserveNewest" />
 

--- a/FlexID.Core/FlexID.Core.csproj
+++ b/FlexID.Core/FlexID.Core.csproj
@@ -40,6 +40,7 @@
     <None Visible="false" Include="$(SolutionDir)resources/lib/torgans_????-??-??.NDX"  LinkBase="lib" CopyToPublishDirectory="PreserveNewest" />
 
     <None Visible="false" Include="$(SolutionDir)resources/inp/OIR/**/*.inp"   LinkBase="inp/OIR"      CopyToPublishDirectory="PreserveNewest" />
+    <None Visible="false" Include="$(SolutionDir)resources/inp/OIR/**/*.inc"   LinkBase="inp/OIR"      CopyToPublishDirectory="PreserveNewest" />
     <None Visible="false" Include="$(SolutionDir)resources/lib/OIR/wT.txt"     LinkBase="lib/OIR"      CopyToPublishDirectory="PreserveNewest" />
 
     <None Visible="false" Include="$(SolutionDir)resources/inp/EIR/**/*.inp"   LinkBase="inp/EIR"      CopyToPublishDirectory="PreserveNewest" />


### PR DESCRIPTION
Publish結果に幾つかのファイルが含まれていなかった問題も合わせて修正。